### PR TITLE
Fix bug where SQL Server Browser is required if using named instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Other supported formats are listed below.
 ### Connection parameters for ODBC and ADO style connection strings
 
 * `server` - host or host\instance (default localhost)
-* `port` - used only when there is no instance in server (default 1433)
+* `port` - specifies the host\instance port (default 1433). If instance name is provided but no port, the driver will use SQL Server Browser to discover the port.
 
 ### Less common parameters
 


### PR DESCRIPTION
Hi from the HashiCorp Vault team 👋!

We ran into an issue where named instances are used on a non-standard port, with SQL Server Browser disabled, which caused connection failures. The driver attempts to discover the instance by connecting via UDP to <hostname>:1433.

This PR lifts the requirement of SQL Server Browser if named instances are used in the connection URL, and honors any configured non-standard ports.

Fixes https://github.com/denisenkom/go-mssqldb/issues/714.