### PR TITLE
ignore spurious row counts

### DIFF
--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -1236,7 +1236,8 @@ select getdate()
 PRINT N'This is a message'
 select 199
 RAISERROR (N'Testing!' , 11, 1)
-select 300
+declare @d int = 300
+select @d
 `
 
 func testMixedQuery(conn *sql.DB, b testing.TB) (msgs, errs, results, rowcounts int) {

--- a/token.go
+++ b/token.go
@@ -49,6 +49,20 @@ const (
 	doneSrvError = 0x100
 )
 
+// CurCmd values in done
+const (
+	cmdSelect     = 0xc1
+	cmdInsert     = 0xc3
+	cmdDelete     = 0xc4
+	cmdUpdate     = 0xc5
+	cmdAbort      = 0xd2
+	cmdBeginXaxt  = 0xd4
+	cmdEndXact    = 0xd5
+	cmdBulkInsert = 0xf0
+	cmdOpenCursor = 0x20
+	cmdMerge      = 0x117
+)
+
 // ENVCHANGE types
 // http://msdn.microsoft.com/en-us/library/dd303449.aspx
 const (
@@ -654,7 +668,7 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 		}
 		close(ch)
 	}()
-
+	colsReceived := false
 	packet_type, err := sess.buf.BeginRead()
 	if err != nil {
 		if sess.logFlags&logErrors != 0 {
@@ -696,10 +710,12 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 			done := parseDoneInProc(sess.buf)
 
 			ch <- done
-			if sess.logFlags&logRows != 0 && done.Status&doneCount != 0 {
-				sess.logger.Log(ctx, msdsn.LogRows, fmt.Sprintf("(%d rows affected)", done.RowCount))
+			if done.Status&doneCount != 0 {
+				if sess.logFlags&logRows != 0 {
+					sess.logger.Log(ctx, msdsn.LogRows, fmt.Sprintf("(%d rows affected)", done.RowCount))
+				}
 
-				if outs.msgq != nil {
+				if (colsReceived || done.CurCmd != cmdSelect) && outs.msgq != nil {
 					_ = sqlexp.ReturnMessageEnqueue(ctx, outs.msgq, sqlexp.MsgRowsAffected{Count: int64(done.RowCount)})
 				}
 			}
@@ -709,6 +725,7 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 				// to set Rows.Err correctly when ctx expires already
 				_ = sqlexp.ReturnMessageEnqueue(ctx, outs.msgq, sqlexp.MsgNextResultSet{})
 			}
+			colsReceived = false
 			if done.Status&doneMore == 0 {
 				// Rows marks the request as done when seeing this done token. We queue another result set message
 				// so the app calls NextResultSet again which will return false.
@@ -733,15 +750,19 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 				}
 				return
 			}
-			if sess.logFlags&logRows != 0 && done.Status&doneCount != 0 {
-				sess.logger.Log(ctx, msdsn.LogRows, fmt.Sprintf("(%d row(s) affected)", done.RowCount))
-			}
 			ch <- done
 			if done.Status&doneCount != 0 {
-				if outs.msgq != nil {
-					_ = sqlexp.ReturnMessageEnqueue(ctx, outs.msgq, sqlexp.MsgRowsAffected{Count: int64(done.RowCount)})
+				if sess.logFlags&logRows != 0 && done.Status&doneCount != 0 {
+					sess.logger.Log(ctx, msdsn.LogRows, fmt.Sprintf("(%d row(s) affected)", done.RowCount))
+				}
+
+				if done.Status&doneCount != 0 {
+					if (colsReceived || done.CurCmd != cmdSelect) && outs.msgq != nil {
+						_ = sqlexp.ReturnMessageEnqueue(ctx, outs.msgq, sqlexp.MsgRowsAffected{Count: int64(done.RowCount)})
+					}
 				}
 			}
+			colsReceived = false
 			if outs.msgq != nil {
 				_ = sqlexp.ReturnMessageEnqueue(ctx, outs.msgq, sqlexp.MsgNextResultSet{})
 			}
@@ -756,7 +777,7 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 		case tokenColMetadata:
 			columns = parseColMetadata72(sess.buf)
 			ch <- columns
-
+			colsReceived = true
 			if outs.msgq != nil {
 				_ = sqlexp.ReturnMessageEnqueue(ctx, outs.msgq, sqlexp.MsgNext{})
 			}

--- a/token.go
+++ b/token.go
@@ -752,15 +752,14 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 			}
 			ch <- done
 			if done.Status&doneCount != 0 {
-				if sess.logFlags&logRows != 0 && done.Status&doneCount != 0 {
+				if sess.logFlags&logRows != 0 {
 					sess.logger.Log(ctx, msdsn.LogRows, fmt.Sprintf("(%d row(s) affected)", done.RowCount))
 				}
 
-				if done.Status&doneCount != 0 {
-					if (colsReceived || done.CurCmd != cmdSelect) && outs.msgq != nil {
-						_ = sqlexp.ReturnMessageEnqueue(ctx, outs.msgq, sqlexp.MsgRowsAffected{Count: int64(done.RowCount)})
-					}
+				if (colsReceived || done.CurCmd != cmdSelect) && outs.msgq != nil {
+					_ = sqlexp.ReturnMessageEnqueue(ctx, outs.msgq, sqlexp.MsgRowsAffected{Count: int64(done.RowCount)})
 				}
+
 			}
 			colsReceived = false
 			if outs.msgq != nil {

--- a/token.go
+++ b/token.go
@@ -49,18 +49,18 @@ const (
 	doneSrvError = 0x100
 )
 
-// CurCmd values in done
+// CurCmd values in done (undocumented)
 const (
-	cmdSelect     = 0xc1
-	cmdInsert     = 0xc3
-	cmdDelete     = 0xc4
-	cmdUpdate     = 0xc5
-	cmdAbort      = 0xd2
-	cmdBeginXaxt  = 0xd4
-	cmdEndXact    = 0xd5
-	cmdBulkInsert = 0xf0
-	cmdOpenCursor = 0x20
-	cmdMerge      = 0x117
+	cmdSelect = 0xc1
+	// cmdInsert     = 0xc3
+	// cmdDelete     = 0xc4
+	// cmdUpdate     = 0xc5
+	// cmdAbort      = 0xd2
+	// cmdBeginXaxt  = 0xd4
+	// cmdEndXact    = 0xd5
+	// cmdBulkInsert = 0xf0
+	// cmdOpenCursor = 0x20
+	// cmdMerge      = 0x117
 )
 
 // ENVCHANGE types


### PR DESCRIPTION
SQL Server sends row count values in the `done` struct for non-select statements like `declare @d1 int = 1`. We will ignore those row counts for the rows affected messages.
Fixes [sqlcmd](https://github.com/microsoft/go-sqlcmd/issues/81)