### PR TITLE
Use appropriate integer sizes for query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,9 @@ are supported:
 * "github.com/golang-sql/civil".Time -> time
 * mssql.TVP -> Table Value Parameter (TDS version dependent)
 
+Using an `int` parameter will send a 4 byte value (int) from a 32bit app and an 8 byte value (bigint) from a 64bit app. 
+To make sure your integer parameter matches the size of the SQL parameter, use the appropriate sized type like `int32` or `int8`.
+
 ```go
 // If this is passed directly as a parameter, 
 // the SQL parameter generated would be nvarchar

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,6 @@ environment:
   DATABASE: test
   GOVERSION: 113
   matrix:
-    - GOVERSION: 18
-      SQLINSTANCE: SQL2017
     - GOVERSION: 19
       SQLINSTANCE: SQL2017
     - GOVERSION: 110
@@ -50,7 +48,7 @@ install:
   - go env
   - go get -u github.com/golang-sql/civil
   - go get -u github.com/golang-sql/sqlexp
-
+  
 build_script:
   - go build
 

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -381,6 +381,14 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 			res.buffer = str2ucs2(val)
 		case int64:
 			res.buffer = []byte(strconv.FormatInt(val, 10))
+		case int:
+			res.buffer = []byte(strconv.FormatInt(int64(val), 10))
+		case int8:
+			res.buffer = []byte(strconv.FormatInt(int64(val), 10))
+		case int32:
+			res.buffer = []byte(strconv.FormatInt(int64(val), 10))
+		case int16:
+			res.buffer = []byte(strconv.FormatInt(int64(val), 10))
 		case []byte:
 			res.buffer = val
 		default:
@@ -397,6 +405,14 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 			res.buffer = val
 		case int64:
 			res.buffer = []byte(strconv.FormatInt(val, 10))
+		case int:
+			res.buffer = []byte(strconv.FormatInt(int64(val), 10))
+		case int8:
+			res.buffer = []byte(strconv.FormatInt(int64(val), 10))
+		case int32:
+			res.buffer = []byte(strconv.FormatInt(int64(val), 10))
+		case int16:
+			res.buffer = []byte(strconv.FormatInt(int64(val), 10))
 		default:
 			err = fmt.Errorf("mssql: invalid type for varchar column: %T %s", val, val)
 			return

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -403,16 +403,16 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 			res.buffer = []byte(val)
 		case []byte:
 			res.buffer = val
-		case int64:
-			res.buffer = []byte(strconv.FormatInt(val, 10))
 		case int:
 			res.buffer = []byte(strconv.FormatInt(int64(val), 10))
 		case int8:
 			res.buffer = []byte(strconv.FormatInt(int64(val), 10))
-		case int32:
-			res.buffer = []byte(strconv.FormatInt(int64(val), 10))
 		case int16:
 			res.buffer = []byte(strconv.FormatInt(int64(val), 10))
+		case int32:
+			res.buffer = []byte(strconv.FormatInt(int64(val), 10))
+		case int64:
+			res.buffer = []byte(strconv.FormatInt(val, 10))
 		default:
 			err = fmt.Errorf("mssql: invalid type for varchar column: %T %s", val, val)
 			return

--- a/bulkcopy_test.go
+++ b/bulkcopy_test.go
@@ -1,3 +1,4 @@
+//go:build go1.9
 // +build go1.9
 
 package mssql
@@ -81,6 +82,10 @@ func TestBulkcopy(t *testing.T) {
 		{"test_binary", []byte("1"), nil},
 		{"test_binary_16", bin, nil},
 		{"test_intvarchar", 1234, "1234"},
+		{"test_int64nvarchar", int64(123456), "123456"},
+		{"test_int32nvarchar", int32(12345), "12345"},
+		{"test_int16nvarchar", int16(1234), "1234"},
+		{"test_int8nvarchar", int8(12), "12"},
 		{"test_intnvarchar", 1234, "1234"},
 	}
 
@@ -278,6 +283,10 @@ func setupTable(ctx context.Context, t *testing.T, conn *sql.Conn, tableName str
 	[test_binary] BINARY NOT NULL,
 	[test_binary_16] BINARY(16) NOT NULL,
 	[test_intvarchar] [varchar](4) NULL,
+	[test_int64nvarchar] [varchar](6) NULL,
+	[test_int32nvarchar] [varchar](5) NULL,
+	[test_int16nvarchar] [varchar](4) NULL,
+	[test_int8nvarchar] [varchar](3) NULL,
 	[test_intnvarchar] [varchar](4) NULL,
  CONSTRAINT [PK_` + tableName + `_id] PRIMARY KEY CLUSTERED
 (

--- a/mssql.go
+++ b/mssql.go
@@ -917,7 +917,6 @@ func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 			res.ti.Size = 4
 			binary.LittleEndian.PutUint32(res.buffer, uint32(val))
 		} else {
-			res.ti.TypeId = typeIntN
 			res.buffer = make([]byte, 8)
 			res.ti.Size = 8
 			binary.LittleEndian.PutUint64(res.buffer, uint64(val))

--- a/mssql.go
+++ b/mssql.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/bits"
 	"net"
 	"reflect"
 	"strings"
@@ -906,6 +907,33 @@ func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 		return
 	}
 	switch val := val.(type) {
+	case int:
+		res.ti.TypeId = typeIntN
+		// if the value fits in a 32bit int, use 4 bytes
+		if bits.UintSize == 32 || int64(val) <= int64(0x7fffffff) {
+			res.buffer = make([]byte, 4)
+			res.ti.Size = 4
+			binary.LittleEndian.PutUint32(res.buffer, uint32(val))
+		} else {
+			res.ti.TypeId = typeIntN
+			res.buffer = make([]byte, 8)
+			res.ti.Size = 8
+			binary.LittleEndian.PutUint64(res.buffer, uint64(val))
+		}
+	case int8:
+		res.ti.TypeId = typeIntN
+		res.buffer = []byte{byte(val)}
+		res.ti.Size = 1
+	case int16:
+		res.ti.TypeId = typeIntN
+		res.buffer = make([]byte, 2)
+		res.ti.Size = 2
+		binary.LittleEndian.PutUint16(res.buffer, uint16(val))
+	case int32:
+		res.ti.TypeId = typeIntN
+		res.buffer = make([]byte, 4)
+		res.ti.Size = 4
+		binary.LittleEndian.PutUint32(res.buffer, uint32(val))
 	case int64:
 		res.ti.TypeId = typeIntN
 		res.buffer = make([]byte, 8)

--- a/mssql.go
+++ b/mssql.go
@@ -909,8 +909,10 @@ func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 	switch val := val.(type) {
 	case int:
 		res.ti.TypeId = typeIntN
-		// if the value fits in a 32bit int, use 4 bytes
-		if bits.UintSize == 32 || int64(val) <= int64(0x7fffffff) {
+		// Rather than guess if the caller intends to pass a 32bit int from a 64bit app based on the
+		// value of the int, we'll just match the runtime size of int.
+		// Apps that want a 32bit int should use int32
+		if bits.UintSize == 32 {
 			res.buffer = make([]byte, 4)
 			res.ti.Size = 4
 			binary.LittleEndian.PutUint32(res.buffer, uint32(val))

--- a/mssql_go110_perf_test.go
+++ b/mssql_go110_perf_test.go
@@ -1,3 +1,6 @@
+//go:build go1.10
+// +build go1.10
+
 package mssql
 
 import (

--- a/mssql_go110_perf_test.go
+++ b/mssql_go110_perf_test.go
@@ -24,6 +24,9 @@ func BenchmarkSelectWithTypeMismatch(b *testing.B) {
 		b.Fatal("Unable to query")
 	}
 	rows.Close()
+	if rows.Err() != nil {
+		b.Fatal("Rows error:", rows.Err())
+	}
 	b.Run("PromoteToBigInt", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			rows, err := conn.Query(`SELECT Count(*) from sys.all_objects where object_id > @obid`, sql.Named("obid", int64(-605853368)))

--- a/mssql_go110_perf_test.go
+++ b/mssql_go110_perf_test.go
@@ -1,0 +1,56 @@
+package mssql
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// The default value converter promotes every int type to bigint.
+// This benchmark forces that mismatch for comparing the query performance with the
+// fixed version of the driver that doesn't perform such promotion.
+// It may not show much of a time difference. Look for the actual query via plan or xevents
+// while the benchmark runs to make sure it's passing the correct int type.
+func BenchmarkSelectWithTypeMismatch(b *testing.B) {
+	connector, err := NewConnector(makeConnStr(b).String())
+	if err != nil {
+		b.Fatal("Open connection failed:", err.Error())
+	}
+	conn := sql.OpenDB(connector)
+	defer conn.Close()
+	conn.SetMaxOpenConns(1)
+	conn.SetMaxIdleConns(1)
+	rows, err := conn.Query("select 'prime the pump'")
+	if err != nil {
+		b.Fatal("Unable to query")
+	}
+	rows.Close()
+	b.Run("PromoteToBigInt", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			rows, err := conn.Query(`SELECT Count(*) from sys.all_objects where object_id > @obid`, sql.Named("obid", int64(-605853368)))
+			if err != nil {
+				b.Fatal("Query failed:", err.Error())
+			}
+			defer rows.Close()
+			for rows.Next() {
+			}
+			if rows.Err() != nil {
+				b.Fatal("Rows error:", rows.Err())
+			}
+		}
+	})
+	b.Run("NoIntPromotion", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			rows, err := conn.Query(`SELECT Count(*) from sys.all_objects where object_id > @obid`, sql.Named("obid", int32(-605853368)))
+			if err != nil {
+				b.Fatal("Query failed:", err.Error())
+			}
+			defer rows.Close()
+			for rows.Next() {
+			}
+			if rows.Err() != nil {
+				b.Fatal("Rows error:", rows.Err())
+			}
+		}
+	})
+
+}

--- a/mssql_go19.go
+++ b/mssql_go19.go
@@ -1,3 +1,4 @@
+//go:build go1.9
 // +build go1.9
 
 package mssql
@@ -42,6 +43,8 @@ type DateTimeOffset time.Time
 
 func convertInputParameter(val interface{}) (interface{}, error) {
 	switch v := val.(type) {
+	case int, int16, int32, int64, int8:
+		return val, nil
 	case VarChar:
 		return val, nil
 	case NVarCharMax:

--- a/mssql_perf_test.go
+++ b/mssql_perf_test.go
@@ -3,7 +3,6 @@ package mssql
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"database/sql/driver"
 	"encoding/base64"
 	"encoding/binary"
@@ -213,49 +212,4 @@ func BenchmarkSelectParser(b *testing.B) {
 		}
 		processSingleResponse(context.Background(), sess, ch, outputs{})
 	}
-}
-
-// The default value converter promotes every int type to bigint.
-// This benchmark forces that mismatch for comparing the query performance with the
-// fixed version of the driver that doesn't perform such promotion.
-// It may not show much of a time difference. Look for the actual query via plan or xevents
-// while the benchmark runs to make sure it's passing the correct int type.
-func BenchmarkSelectWithTypeMismatch(b *testing.B) {
-	connector, err := NewConnector(makeConnStr(b).String())
-	if err != nil {
-		b.Fatal("Open connection failed:", err.Error())
-	}
-	conn := sql.OpenDB(connector)
-	defer conn.Close()
-	conn.SetMaxOpenConns(1)
-	conn.SetMaxIdleConns(1)
-	b.Run("PromoteToBigInt", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			rows, err := conn.Query(`SELECT Count(*) from sys.all_objects where object_id > @obid`, sql.Named("obid", int64(-605853368)))
-			if err != nil {
-				b.Fatal("Query failed:", err.Error())
-			}
-			defer rows.Close()
-			for rows.Next() {
-			}
-			if rows.Err() != nil {
-				b.Fatal("Rows error:", rows.Err())
-			}
-		}
-	})
-	b.Run("NoIntPromotion", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			rows, err := conn.Query(`SELECT Count(*) from sys.all_objects where object_id > @obid`, sql.Named("obid", int32(-605853368)))
-			if err != nil {
-				b.Fatal("Query failed:", err.Error())
-			}
-			defer rows.Close()
-			for rows.Next() {
-			}
-			if rows.Err() != nil {
-				b.Fatal("Rows error:", rows.Err())
-			}
-		}
-	})
-
 }

--- a/mssql_perf_test.go
+++ b/mssql_perf_test.go
@@ -235,6 +235,7 @@ func BenchmarkSelectWithTypeMismatch(b *testing.B) {
 			if err != nil {
 				b.Fatal("Query failed:", err.Error())
 			}
+			defer rows.Close()
 			for rows.Next() {
 			}
 			if rows.Err() != nil {
@@ -248,6 +249,7 @@ func BenchmarkSelectWithTypeMismatch(b *testing.B) {
 			if err != nil {
 				b.Fatal("Query failed:", err.Error())
 			}
+			defer rows.Close()
 			for rows.Next() {
 			}
 			if rows.Err() != nil {

--- a/mssql_perf_test.go
+++ b/mssql_perf_test.go
@@ -218,6 +218,8 @@ func BenchmarkSelectParser(b *testing.B) {
 // The default value converter promotes every int type to bigint.
 // This benchmark forces that mismatch for comparing the query performance with the
 // fixed version of the driver that doesn't perform such promotion.
+// It may not show much of a time difference. Look for the actual query via plan or xevents
+// while the benchmark runs to make sure it's passing the correct int type.
 func BenchmarkSelectWithTypeMismatch(b *testing.B) {
 	connector, err := NewConnector(makeConnStr(b).String())
 	if err != nil {

--- a/mssql_perf_test.go
+++ b/mssql_perf_test.go
@@ -235,8 +235,10 @@ func BenchmarkSelectWithTypeMismatch(b *testing.B) {
 			if err != nil {
 				b.Fatal("Query failed:", err.Error())
 			}
-			defer rows.Close()
 			for rows.Next() {
+			}
+			if rows.Err() != nil {
+				b.Fatal("Rows error:", rows.Err())
 			}
 		}
 	})
@@ -246,8 +248,10 @@ func BenchmarkSelectWithTypeMismatch(b *testing.B) {
 			if err != nil {
 				b.Fatal("Query failed:", err.Error())
 			}
-			defer rows.Close()
 			for rows.Next() {
+			}
+			if rows.Err() != nil {
+				b.Fatal("Rows error:", rows.Err())
 			}
 		}
 	})

--- a/queries_test.go
+++ b/queries_test.go
@@ -488,6 +488,9 @@ func TestParams(t *testing.T) {
 	}
 	values := []interface{}{
 		int64(5),
+		int32(10),
+		int16(20),
+		int8(40),
 		"hello",
 		"",
 		[]byte{1, 2, 3},
@@ -525,6 +528,17 @@ func TestParams(t *testing.T) {
 				}
 			case time.Time:
 				same = decodedval.UTC() == val
+			case int64:
+				switch intVal := val.(type) {
+				case int16:
+					same = decodedval == int64(intVal)
+				case int32:
+					same = decodedval == int64(intVal)
+				case int8:
+					same = decodedval == int64(intVal)
+				default:
+					same = retval == val
+				}
 			default:
 				same = retval == val
 			}

--- a/queries_test.go
+++ b/queries_test.go
@@ -491,6 +491,7 @@ func TestParams(t *testing.T) {
 		int32(10),
 		int16(20),
 		int8(40),
+		int(10000),
 		"hello",
 		"",
 		[]byte{1, 2, 3},
@@ -535,6 +536,8 @@ func TestParams(t *testing.T) {
 				case int32:
 					same = decodedval == int64(intVal)
 				case int8:
+					same = decodedval == int64(intVal)
+				case int:
 					same = decodedval == int64(intVal)
 				default:
 					same = retval == val


### PR DESCRIPTION
Fixes #16 
I'd like community input on #21. Changing the scan-to-interface{} behavior is fairly easy to do but it may have undesired side effects if apps are expecting `int64` in that scenario and could fail otherwise.