### PR TITLE
ColumnType methods should not panic if column type is unimplemented

### DIFF
--- a/types.go
+++ b/types.go
@@ -1069,6 +1069,8 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 			return reflect.TypeOf([]byte{})
 		case 8:
 			return reflect.TypeOf([]byte{})
+		default:
+			return reflect.TypeOf(new(interface{})).Elem()
 		}
 	case typeDateTim4:
 		return reflect.TypeOf(time.Time{})
@@ -1080,6 +1082,8 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 			return reflect.TypeOf(time.Time{})
 		case 8:
 			return reflect.TypeOf(time.Time{})
+		default:
+			return reflect.TypeOf(new(interface{})).Elem()
 		}
 	case typeDateTime2N:
 		return reflect.TypeOf(time.Time{})
@@ -1379,7 +1383,7 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 		case 8:
 			return 0, false
 		default:
-			panic("invalid size of INTNTYPE")
+			return 0, false
 		}
 	case typeFlt8:
 		return 0, false
@@ -1390,7 +1394,7 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 		case 8:
 			return 0, false
 		default:
-			panic("invalid size of FLNNTYPE")
+			return 0, false
 		}
 	case typeBit, typeBitN:
 		return 0, false
@@ -1403,7 +1407,7 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 		case 8:
 			return 0, false
 		default:
-			panic("invalid size of MONEYN")
+			return 0, false
 		}
 	case typeDateTim4, typeDateTime:
 		return 0, false
@@ -1414,7 +1418,7 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 		case 8:
 			return 0, false
 		default:
-			panic("invalid size of DATETIMEN")
+			return 0, false
 		}
 	case typeDateTime2N:
 		return 0, false
@@ -1463,7 +1467,8 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 	case typeBigBinary:
 		return int64(ti.Size), true
 	default:
-		panic(fmt.Sprintf("not implemented makeGoLangTypeLength for type %d", ti.TypeId))
+		// not implemented makeGoLangTypeLength for type
+		return 0, false
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -1040,7 +1040,7 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 		case 8:
 			return reflect.TypeOf(int64(0))
 		default:
-			panic("invalid size of INTNTYPE")
+			return reflect.TypeOf(new(interface{})).Elem()
 		}
 	case typeFlt8:
 		return reflect.TypeOf(float64(0))
@@ -1051,7 +1051,7 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 		case 8:
 			return reflect.TypeOf(float64(0))
 		default:
-			panic("invalid size of FLNNTYPE")
+			return reflect.TypeOf(new(interface{})).Elem()
 		}
 	case typeBigVarBin:
 		return reflect.TypeOf([]byte{})
@@ -1069,8 +1069,6 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 			return reflect.TypeOf([]byte{})
 		case 8:
 			return reflect.TypeOf([]byte{})
-		default:
-			panic("invalid size of MONEYN")
 		}
 	case typeDateTim4:
 		return reflect.TypeOf(time.Time{})
@@ -1082,8 +1080,6 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 			return reflect.TypeOf(time.Time{})
 		case 8:
 			return reflect.TypeOf(time.Time{})
-		default:
-			panic("invalid size of DATETIMEN")
 		}
 	case typeDateTime2N:
 		return reflect.TypeOf(time.Time{})
@@ -1114,7 +1110,7 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 	case typeVariant:
 		return reflect.TypeOf(nil)
 	default:
-		panic(fmt.Sprintf("not implemented makeGoLangScanType for type %d", ti.TypeId))
+		return reflect.TypeOf(new(interface{})).Elem()
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -1507,7 +1507,7 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 		case 8:
 			return 0, 0, false
 		default:
-			panic("invalid size of INTNTYPE")
+			return 0, 0, false
 		}
 	case typeFlt8:
 		return 0, 0, false
@@ -1518,7 +1518,7 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 		case 8:
 			return 0, 0, false
 		default:
-			panic("invalid size of FLNNTYPE")
+			return 0, 0, false
 		}
 	case typeBit, typeBitN:
 		return 0, 0, false
@@ -1531,7 +1531,7 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 		case 8:
 			return 0, 0, false
 		default:
-			panic("invalid size of MONEYN")
+			return 0, 0, false
 		}
 	case typeDateTim4, typeDateTime:
 		return 0, 0, false
@@ -1542,7 +1542,7 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 		case 8:
 			return 0, 0, false
 		default:
-			panic("invalid size of DATETIMEN")
+			return 0, 0, false
 		}
 	case typeDateTime2N:
 		return int64(ti.Prec), int64(ti.Scale), true
@@ -1579,6 +1579,6 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 	case typeBigBinary:
 		return 0, 0, false
 	default:
-		panic(fmt.Sprintf("not implemented makeGoLangTypePrecisionScale for type %d", ti.TypeId))
+		return 0, 0, false
 	}
 }

--- a/types.go
+++ b/types.go
@@ -1269,7 +1269,7 @@ func makeGoLangTypeName(ti typeInfo) string {
 		case 8:
 			return "BIGINT"
 		default:
-			panic("invalid size of INTNTYPE")
+			return ""
 		}
 	case typeFlt8:
 		return "FLOAT"
@@ -1280,7 +1280,7 @@ func makeGoLangTypeName(ti typeInfo) string {
 		case 8:
 			return "FLOAT"
 		default:
-			panic("invalid size of FLNNTYPE")
+			return ""
 		}
 	case typeBigVarBin:
 		return "VARBINARY"
@@ -1299,7 +1299,7 @@ func makeGoLangTypeName(ti typeInfo) string {
 		case 8:
 			return "MONEY"
 		default:
-			panic("invalid size of MONEYN")
+			return ""
 		}
 	case typeDateTim4:
 		return "SMALLDATETIME"
@@ -1312,7 +1312,7 @@ func makeGoLangTypeName(ti typeInfo) string {
 		case 8:
 			return "DATETIME"
 		default:
-			panic("invalid size of DATETIMEN")
+			return ""
 		}
 	case typeDateTime2N:
 		return "DATETIME2"
@@ -1343,7 +1343,8 @@ func makeGoLangTypeName(ti typeInfo) string {
 	case typeBigBinary:
 		return "BINARY"
 	default:
-		panic(fmt.Sprintf("not implemented makeGoLangTypeName for type %d", ti.TypeId))
+		// unsupported type
+		return ""
 	}
 }
 

--- a/types_test.go
+++ b/types_test.go
@@ -43,8 +43,6 @@ func TestMakeGoLangScanType(t *testing.T) {
 }
 
 func TestMakeGoLangTypeName(t *testing.T) {
-	defer handlePanic(t)
-
 	tests := []struct {
 		typeName   string
 		typeString string

--- a/types_test.go
+++ b/types_test.go
@@ -52,6 +52,8 @@ func TestMakeGoLangTypeName(t *testing.T) {
 		{"typeDateTim4", "SMALLDATETIME", typeDateTim4},
 		{"typeBigBinary", "BINARY", typeBigBinary},
 		//TODO: Add other supported types
+
+		{"unimplemented type", "", typeUdt},
 	}
 
 	for _, tt := range tests {
@@ -62,8 +64,6 @@ func TestMakeGoLangTypeName(t *testing.T) {
 }
 
 func TestMakeGoLangTypeLength(t *testing.T) {
-	defer handlePanic(t)
-
 	tests := []struct {
 		typeName   string
 		typeVarLen bool
@@ -77,6 +77,8 @@ func TestMakeGoLangTypeLength(t *testing.T) {
 		{"typeBigVarChar", true, 10, typeBigVarChar, 10},
 		{"typeBigBinary", true, 30, typeBigBinary, 30},
 		//TODO: Add other supported types
+
+		{"unimplemented type", false, 0, typeUdt, 0},
 	}
 
 	for _, tt := range tests {
@@ -104,6 +106,8 @@ func TestMakeGoLangTypePrecisionScale(t *testing.T) {
 		{"typeDateTim4", typeDateTim4, false, 0, 0},
 		{"typeBigBinary", typeBigBinary, false, 0, 0},
 		//TODO: Add other supported types
+
+		{"unimplemented type", typeUdt, false, 0, 0},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
For issue: https://github.com/microsoft/go-mssqldb/issues/31

ColumnType methods should return nil values instead of panicking when column types are unimplemented. Current behavior, which panics, means calling `ColumnTypes()` or related methods in the `database/sql` lib panics if I'm doing something like `select * ` on a table with an unsupported column (or trying to use the driver for generic queries). Matching the spec would let clients handle the cases.

This matches the documentation in the database/sql package for drivers:
- makeGoLangTypeName -> used in [DatabaseTypeName](https://pkg.go.dev/database/sql#ColumnType.DatabaseTypeName): "If an empty string is returned, then the driver type name is not supported. "
- makeGoLangScanType -> used in [ScanType](https://pkg.go.dev/database/sql#ColumnType.ScanType): "If a driver does not support this property ScanType will return the type of an empty interface."
-  makeGoLangTypeLength -> [Length](https://pkg.go.dev/database/sql#ColumnType.Length): " if not supported by the driver ok is false."
- makeGoLangTypePrecisionScale  -> [precision](https://pkg.go.dev/database/sql#ColumnType.DecimalSize) " If not applicable or if not supported ok is false."