### PR TITLE
wrap connection error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add driver version and name to TDS login packets
 * Add `pipe` connection string parameter for named pipe dialer
+* Expose network errors that occur during connection establishment. Now they are
+wrapped, and can be detected by using errors.As/Is practise. This connection
+errors can, and could even before, happen anytime the sql.DB doesn't have free
+connection for executed query.
 
 ### Bug fixes
 

--- a/protocol.go
+++ b/protocol.go
@@ -104,8 +104,8 @@ func (t tcpDialer) DialSqlConnection(ctx context.Context, c *Connector, p *msdsn
 	}
 	// Can't do the usual err != nil check, as it is possible to have gotten an error before a successful connection
 	if conn == nil {
-		f := "unable to open tcp connection with host '%v:%v': %v"
-		return nil, fmt.Errorf(f, p.Host, resolveServerPort(p.Port), err.Error())
+		f := "unable to open tcp connection with host '%v:%v': %w"
+		return nil, fmt.Errorf(f, p.Host, resolveServerPort(p.Port), err)
 	}
 	if p.ServerSPN == "" {
 		p.ServerSPN = generateSpn(p.Host, instanceOrPort(p.Instance, p.Port))

--- a/protocol.go
+++ b/protocol.go
@@ -104,8 +104,7 @@ func (t tcpDialer) DialSqlConnection(ctx context.Context, c *Connector, p *msdsn
 	}
 	// Can't do the usual err != nil check, as it is possible to have gotten an error before a successful connection
 	if conn == nil {
-		f := "unable to open tcp connection with host '%v:%v': %w"
-		return nil, fmt.Errorf(f, p.Host, resolveServerPort(p.Port), err)
+		return nil, wrapConnErr(p, err)
 	}
 	if p.ServerSPN == "" {
 		p.ServerSPN = generateSpn(p.Host, instanceOrPort(p.Instance, p.Port))

--- a/protocol_go113.go
+++ b/protocol_go113.go
@@ -1,0 +1,15 @@
+//go:build go1.13
+// +build go1.13
+
+package mssql
+
+import (
+	"fmt"
+
+	"github.com/microsoft/go-mssqldb/msdsn"
+)
+
+func wrapConnErr(p *msdsn.Config, err error) error {
+	f := "unable to open tcp connection with host '%v:%v': %w"
+	return fmt.Errorf(f, p.Host, resolveServerPort(p.Port), err)
+}

--- a/protocol_go113pre.go
+++ b/protocol_go113pre.go
@@ -3,6 +3,12 @@
 
 package mssql
 
+import (
+	"fmt"
+
+	"github.com/microsoft/go-mssqldb/msdsn"
+)
+
 func wrapConnErr(p *msdsn.Config, err error) error {
 	f := "unable to open tcp connection with host '%v:%v': %v"
 	return fmt.Errorf(f, p.Host, resolveServerPort(p.Port), err)

--- a/protocol_go113pre.go
+++ b/protocol_go113pre.go
@@ -1,0 +1,9 @@
+//go:build !go1.13
+// +build !go1.13
+
+package mssql
+
+func wrapConnErr(p *msdsn.Config, err error) error {
+	f := "unable to open tcp connection with host '%v:%v': %v"
+	return fmt.Errorf(f, p.Host, resolveServerPort(p.Port), err)
+}

--- a/tds_go113_test.go
+++ b/tds_go113_test.go
@@ -51,6 +51,8 @@ func TestConnectError(t *testing.T) {
 		// port where nothing listens on. Port 666 is reserved for Doom multiplayer
 		// server, hopefully no-one runs one in CI or in development environment.
 		params.Port = 666
+		// clear instance name, so we don't tease SQL Server Browser.
+		params.Instance = ""
 
 		connErr := connAndPing(t, params)
 

--- a/tds_go113_test.go
+++ b/tds_go113_test.go
@@ -1,0 +1,93 @@
+//go:build go1.13
+// +build go1.13
+
+package mssql
+
+import (
+	"database/sql"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/microsoft/go-mssqldb/msdsn"
+)
+
+// TestConnectError tests wrapped errors from connection establishing. It uses
+// error handling introduced in Go 1.13, that's the reason for conditional test.
+func TestConnectError(t *testing.T) {
+	loadConnParams := func(t *testing.T) msdsn.Config {
+		params := testConnParams(t)
+		if params.Encryption == msdsn.EncryptionRequired {
+			t.Skip("Unable to test connection to IP for servers that expect encryption")
+		}
+
+		if params.Host == "." {
+			params.Host = "127.0.0.1"
+		} else {
+			ips, err := net.LookupIP(params.Host)
+			if err != nil {
+				t.Fatal("Unable to lookup IP", err)
+			}
+			params.Host = ips[0].String()
+		}
+		return params
+	}
+	connAndPing := func(t *testing.T, params msdsn.Config) error {
+		connStr := params.URL().String()
+		conn, err := sql.Open("mssql", connStr)
+		if err != nil {
+			t.Fatal("Open connection failed:", err.Error())
+			return nil
+		}
+		pingErr := conn.Ping()
+		if pingErr == nil {
+			t.Fatal("Error required")
+			return nil
+		}
+		return pingErr
+	}
+	t.Run("bad port - refused connection", func(t *testing.T) {
+		params := loadConnParams(t)
+		// port where nothing listens on. Port 666 is reserved for Doom multiplayer
+		// server, hopefully no-one runs one in CI or in development environment.
+		params.Port = 666
+
+		connErr := connAndPing(t, params)
+
+		var ne *net.OpError
+		if !errors.As(connErr, &ne) {
+			t.Fatalf("Expected *net.OpError, got: %[1]T: %[1]v", connErr)
+			return
+		}
+		if ne.Op != "dial" {
+			t.Fatalf("Expected net dial error: %v", connErr)
+			return
+		}
+		if ne.Timeout() {
+			t.Fatalf("Expected not timeout error: %v", connErr)
+			return
+		}
+	})
+	t.Run("bad addr - host will keep us hanging", func(t *testing.T) {
+		params := loadConnParams(t)
+		// Change host to server that won't talk to us and will keep the connection
+		// hanging.
+		params.Host = "8.8.8.8"
+
+		connErr := connAndPing(t, params)
+
+		var ne *net.OpError
+		if !errors.As(connErr, &ne) {
+			t.Fatalf("Expected *net.OpError, got: %[1]T: %[1]v", connErr)
+			return
+		}
+		if ne.Op != "dial" {
+			t.Fatalf("Expected net dial error: %v", connErr)
+			return
+		}
+		if !ne.Timeout() {
+			t.Fatalf("Expected timeout error: %v", connErr)
+			return
+		}
+	})
+}

--- a/tds_go113_test.go
+++ b/tds_go113_test.go
@@ -20,6 +20,8 @@ func TestConnectError(t *testing.T) {
 		if params.Encryption == msdsn.EncryptionRequired {
 			t.Skip("Unable to test connection to IP for servers that expect encryption")
 		}
+		// clear instance name, so we don't tease SQL Server Browser.
+		params.Instance = ""
 
 		if params.Host == "." {
 			params.Host = "127.0.0.1"
@@ -51,8 +53,6 @@ func TestConnectError(t *testing.T) {
 		// port where nothing listens on. Port 666 is reserved for Doom multiplayer
 		// server, hopefully no-one runs one in CI or in development environment.
 		params.Port = 666
-		// clear instance name, so we don't tease SQL Server Browser.
-		params.Instance = ""
 
 		connErr := connAndPing(t, params)
 

--- a/tds_test.go
+++ b/tds_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -262,7 +263,7 @@ func GetConnParams() (*msdsn.Config, error) {
 		if err != io.EOF && err != nil {
 			return nil, err
 		}
-		params, err := msdsn.Parse(dsn)
+		params, err := msdsn.Parse(strings.TrimSuffix(dsn, "\n"))
 		if err != nil {
 			return nil, err
 		}
@@ -887,6 +888,85 @@ func TestReadBVarByte(t *testing.T) {
 	if err == nil {
 		t.Error("readUsVarByte should fail on short buffer, but it didn't")
 	}
+}
+
+func TestConnectError(t *testing.T) {
+	loadConnParams := func(t *testing.T) msdsn.Config {
+		params := testConnParams(t)
+		if params.Encryption == msdsn.EncryptionRequired {
+			t.Skip("Unable to test connection to IP for servers that expect encryption")
+		}
+
+		if params.Host == "." {
+			params.Host = "127.0.0.1"
+		} else {
+			ips, err := net.LookupIP(params.Host)
+			if err != nil {
+				t.Fatal("Unable to lookup IP", err)
+			}
+			params.Host = ips[0].String()
+		}
+		return params
+	}
+	connAndPing := func(t *testing.T, params msdsn.Config) error {
+		connStr := params.URL().String()
+		conn, err := sql.Open("mssql", connStr)
+		if err != nil {
+			t.Fatal("Open connection failed:", err.Error())
+			return nil
+		}
+		pingErr := conn.Ping()
+		if pingErr == nil {
+			t.Fatal("Error required")
+			return nil
+		}
+		return pingErr
+	}
+	t.Run("bad port - refused connection", func(t *testing.T) {
+		params := loadConnParams(t)
+		// port where nothing listens on. Port 666 is reserved for Doom multiplayer
+		// server, hopefully no-one runs one in CI or in development environment.
+		params.Port = 666
+
+		connErr := connAndPing(t, params)
+
+		var ne *net.OpError
+		if !errors.As(connErr, &ne) {
+			t.Fatalf("Expected *net.OpError, got: %[1]T: %[1]v", connErr)
+			return
+		}
+		if ne.Op != "dial" {
+			t.Fatalf("Expected net dial error: %v", connErr)
+			return
+		}
+		if ne.Timeout() {
+			t.Fatalf("Expected not timeout error: %v", connErr)
+			return
+		}
+	})
+	t.Run("bad addr - host will keep us hanging", func(t *testing.T) {
+		params := loadConnParams(t)
+		// Change host to server that won't talk to us and will keep the connection
+		// hanging.
+		params.Host = "8.8.8.8"
+
+		connErr := connAndPing(t, params)
+
+		var ne *net.OpError
+		if !errors.As(connErr, &ne) {
+			t.Fatalf("Expected *net.OpError, got: %[1]T: %[1]v", connErr)
+			return
+		}
+		if ne.Op != "dial" {
+			t.Fatalf("Expected net dial error: %v", connErr)
+			return
+		}
+		if !ne.Timeout() {
+			t.Fatalf("Expected timeout error: %v", connErr)
+			return
+		}
+		t.Logf("%#v", ne.Err)
+	})
 }
 
 func BenchmarkPacketSize(b *testing.B) {

--- a/tds_test.go
+++ b/tds_test.go
@@ -965,7 +965,6 @@ func TestConnectError(t *testing.T) {
 			t.Fatalf("Expected timeout error: %v", connErr)
 			return
 		}
-		t.Logf("%#v", ne.Err)
 	})
 }
 

--- a/tds_test.go
+++ b/tds_test.go
@@ -7,7 +7,6 @@ import (
 	"database/sql"
 	"encoding/binary"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -889,84 +888,6 @@ func TestReadBVarByte(t *testing.T) {
 	if err == nil {
 		t.Error("readUsVarByte should fail on short buffer, but it didn't")
 	}
-}
-
-func TestConnectError(t *testing.T) {
-	loadConnParams := func(t *testing.T) msdsn.Config {
-		params := testConnParams(t)
-		if params.Encryption == msdsn.EncryptionRequired {
-			t.Skip("Unable to test connection to IP for servers that expect encryption")
-		}
-
-		if params.Host == "." {
-			params.Host = "127.0.0.1"
-		} else {
-			ips, err := net.LookupIP(params.Host)
-			if err != nil {
-				t.Fatal("Unable to lookup IP", err)
-			}
-			params.Host = ips[0].String()
-		}
-		return params
-	}
-	connAndPing := func(t *testing.T, params msdsn.Config) error {
-		connStr := params.URL().String()
-		conn, err := sql.Open("mssql", connStr)
-		if err != nil {
-			t.Fatal("Open connection failed:", err.Error())
-			return nil
-		}
-		pingErr := conn.Ping()
-		if pingErr == nil {
-			t.Fatal("Error required")
-			return nil
-		}
-		return pingErr
-	}
-	t.Run("bad port - refused connection", func(t *testing.T) {
-		params := loadConnParams(t)
-		// port where nothing listens on. Port 666 is reserved for Doom multiplayer
-		// server, hopefully no-one runs one in CI or in development environment.
-		params.Port = 666
-
-		connErr := connAndPing(t, params)
-
-		var ne *net.OpError
-		if !errors.As(connErr, &ne) {
-			t.Fatalf("Expected *net.OpError, got: %[1]T: %[1]v", connErr)
-			return
-		}
-		if ne.Op != "dial" {
-			t.Fatalf("Expected net dial error: %v", connErr)
-			return
-		}
-		if ne.Timeout() {
-			t.Fatalf("Expected not timeout error: %v", connErr)
-			return
-		}
-	})
-	t.Run("bad addr - host will keep us hanging", func(t *testing.T) {
-		params := loadConnParams(t)
-		// Change host to server that won't talk to us and will keep the connection
-		// hanging.
-		params.Host = "8.8.8.8"
-
-		connErr := connAndPing(t, params)
-
-		var ne *net.OpError
-		if !errors.As(connErr, &ne) {
-			t.Fatalf("Expected *net.OpError, got: %[1]T: %[1]v", connErr)
-			return
-		}
-		if ne.Op != "dial" {
-			t.Fatalf("Expected net dial error: %v", connErr)
-			return
-		}
-		if !ne.Timeout() {
-			t.Fatalf("Expected timeout error: %v", connErr)
-			return
-		}
-	})
 }
 
 func BenchmarkPacketSize(b *testing.B) {

--- a/tds_test.go
+++ b/tds_test.go
@@ -263,6 +263,7 @@ func GetConnParams() (*msdsn.Config, error) {
 		if err != io.EOF && err != nil {
 			return nil, err
 		}
+		// If file follows POSIX and file ends with LF, it's necessary to strip it out.
 		params, err := msdsn.Parse(strings.TrimSuffix(dsn, "\n"))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Then it's possible to assign error by errors.As to *net.OpError.
It allows us to determine if connection timeouted or was refused.