### PR TITLE
Deprecation of go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Requires Go 1.8 or above.
 
-Install with `go get github.com/microsoft/go-mssqldb` .
+Install with `go install github.com/microsoft/go-mssqldb@latest`.
 
 ## Connection Parameters and DSN
 


### PR DESCRIPTION
`go get` is deprecated by go 1.7, and this project needs go 1.8

    ❯ go get github.com/microsoft/go-mssqldb
    go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.