### PR TITLE
Implement shared memory dialer

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,8 @@ db.QueryContext(ctx, `select * from t2 where user_name = @p1;`, mssql.VarChar(na
 * Supports query notifications
 * Supports Kerberos Authentication
 * Pluggable Dialer implementations through `msdsn.ProtocolParsers` and `msdsn.ProtocolDialers`
-* A `namedpipe` package to support connections using named pipes on Windows
+* A `namedpipe` package to support connections using named pipes (np:) on Windows
+* A `sharedmemory` package to support connections using shared memory (lpc:) on Windows
 
 ## Tests
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,7 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GOVERSION: 118
       SQLINSTANCE: SQL2017
+      # Cover 32bit and named pipes protocol
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GOVERSION: 118-x86
       SQLINSTANCE: SQL2017
@@ -53,11 +54,14 @@ environment:
       RACE:
       PROTOCOL: np
       TAGS: -tags np
+      # Cover SSPI and lpc protocol
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GOVERSION: 118
       SQLINSTANCE: SQL2019
       PROTOCOL: lpc
       TAGS: -tags sm
+      SQLUSER:
+      SQLPASSWORD:
 install:
   - set GOROOT=c:\go%GOVERSION%
   - set PATH=%GOPATH%\bin;%GOROOT%\bin;%PATH%
@@ -84,6 +88,11 @@ before_test:
       $Np = $wmi.GetSmoObject($uri)
       $Np.IsEnabled = $true
       $Np.Alter()
+      # Enable shared memory
+      $uri = "ManagedComputer[@Name='$serverName']/ServerInstance[@Name='$instanceName']/ServerProtocol[@Name='lpc']"
+      $lpc = $wmi.GetSmoObject($uri)
+      $lpc.IsEnabled = $true
+      $lpc.Alter()
       Start-Service "SQLBrowser"
       Start-Service "MSSQL`$$instanceName"
       Start-Sleep -Seconds 10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,11 +88,6 @@ before_test:
       $Np = $wmi.GetSmoObject($uri)
       $Np.IsEnabled = $true
       $Np.Alter()
-      # Enable shared memory
-      $uri = "ManagedComputer[@Name='$serverName']/ServerInstance[@Name='$instanceName']/ServerProtocol[@Name='lpc']"
-      $lpc = $wmi.GetSmoObject($uri)
-      $lpc.IsEnabled = $true
-      $lpc.Alter()
       Start-Service "SQLBrowser"
       Start-Service "MSSQL`$$instanceName"
       Start-Sleep -Seconds 10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,6 +53,11 @@ environment:
       RACE:
       PROTOCOL: np
       TAGS: -tags np
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GOVERSION: 118
+      SQLINSTANCE: SQL2019
+      PROTOCOL: lpc
+      TAGS: -tags sm
 install:
   - set GOROOT=c:\go%GOVERSION%
   - set PATH=%GOPATH%\bin;%GOROOT%\bin;%PATH%

--- a/examples/azuread-service-principal-authtoken/service_principal_authtoken.go
+++ b/examples/azuread-service-principal-authtoken/service_principal_authtoken.go
@@ -1,3 +1,6 @@
+//go:build go1.18
+// +build go1.18
+
 package main
 
 import (

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -276,10 +276,7 @@ func Parse(dsn string) (Config, error) {
 	serverSPN, ok := params["serverspn"]
 	if ok {
 		p.ServerSPN = serverSPN
-	} else {
-		// allow connections to sql server instances
-		p.ServerSPN = generateSpn(p.Host, instanceOrPort(p.Instance, p.Port))
-	}
+	} // If not set by the app, ServerSPN will be set by the successful dialer.
 
 	workstation, ok := params["workstation id"]
 	if ok {
@@ -649,16 +646,6 @@ func normalizeOdbcKey(s string) string {
 	return strings.ToLower(strings.TrimRightFunc(s, unicode.IsSpace))
 }
 
-func instanceOrPort(instance string, port uint64) string {
-	if len(instance) > 0 {
-		return instance
-	}
-
-	port = resolveServerPort(port)
-
-	return strconv.FormatInt(int64(port), 10)
-}
-
 const defaultServerPort = 1433
 
 func resolveServerPort(port uint64) uint64 {
@@ -667,10 +654,6 @@ func resolveServerPort(port uint64) uint64 {
 	}
 
 	return port
-}
-
-func generateSpn(host string, port string) string {
-	return fmt.Sprintf("MSSQLSvc/%s:%s", host, port)
 }
 
 // ProtocolParser can populate Config with parameters to dial using its protocol

--- a/msdsn/extensions.go
+++ b/msdsn/extensions.go
@@ -11,8 +11,8 @@ type BrowserData map[string]map[string]string
 type ProtocolDialer interface {
 	// Translates data from SQL Browser to parameters in the config
 	ParseBrowserData(data BrowserData, p *Config) error
-	// DialConnection eturns a Dialer to make the connection
-	DialConnection(ctx context.Context, p Config) (conn net.Conn, err error)
+	// DialConnection eturns a Dialer to make the connection. On success, also set Config.ServerSPN if it is unset.
+	DialConnection(ctx context.Context, p *Config) (conn net.Conn, err error)
 	// Returns true if information is needed from the SQL Browser service to make a connection
 	CallBrowser(p *Config) bool
 }

--- a/namedpipe/stub.go
+++ b/namedpipe/stub.go
@@ -23,7 +23,7 @@ func (n namedPipeDialer) ParseBrowserData(data msdsn.BrowserData, p *msdsn.Confi
 	return fmt.Errorf("Named pipe connections are not supported on this operating system")
 }
 
-func (n namedPipeDialer) DialConnection(ctx context.Context, p msdsn.Config) (conn net.Conn, err error) {
+func (n namedPipeDialer) DialConnection(ctx context.Context, p *msdsn.Config) (conn net.Conn, err error) {
 
 	return nil, fmt.Errorf("Named pipe connections are not supported on this operating system")
 }

--- a/namedpipe_test.go
+++ b/namedpipe_test.go
@@ -4,13 +4,33 @@
 package mssql
 
 import (
+	"testing"
+
 	"github.com/microsoft/go-mssqldb/msdsn"
 	_ "github.com/microsoft/go-mssqldb/namedpipe"
-	"testing"
 )
 
 func TestNamedPipeProtocolInstalled(t *testing.T) {
-	if len(msdsn.ProtocolParsers) != 2 {
-		t.Fatal("np protocol not registered")
+	for _, p := range msdsn.ProtocolParsers {
+		if p.Protocol() == "np" {
+			return
+		}
+	}
+	t.Fatalf("ProtocolParsers is missing np %v", msdsn.ProtocolParsers)
+}
+
+func TestNamedPipeConnection(t *testing.T) {
+	params := testConnParams(t)
+	protocol, ok := params.Parameters["protocol"]
+	if ok && protocol != "np" {
+		t.Skip("Test is not running with named pipe protocol set")
+	}
+	conn, _ := open(t)
+	row := conn.QueryRow(`SELECT net_transport FROM sys.dm_exec_connections WHERE session_id = @@SPID`)
+	if err := row.Scan(&protocol); err != nil {
+		t.Fatalf("Unable to query connection protocol %s", err.Error())
+	}
+	if protocol != "Named pipe" {
+		t.Fatalf("Named pips connection not made. Protocol: %s", protocol)
 	}
 }

--- a/net_go116_test.go
+++ b/net_go116_test.go
@@ -70,7 +70,7 @@ func TestTLSHandshakeConn(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
-	toconn, err := dialConnection(ctx, connector, connector.params, nil)
+	toconn, err := dialConnection(ctx, connector, &connector.params, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -130,7 +130,7 @@ func TestPassthroughConn(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
-	toconn, err := dialConnection(ctx, connector, connector.params, nil)
+	toconn, err := dialConnection(ctx, connector, &connector.params, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/queries_test.go
+++ b/queries_test.go
@@ -2093,12 +2093,12 @@ func getLatency(t *testing.T) time.Duration {
 		dialer := msdsn.ProtocolDialers[protocol]
 		sqlDialer, ok := dialer.(MssqlProtocolDialer)
 		if !ok {
-			conn, err := dialer.DialConnection(context.Background(), params)
+			conn, err := dialer.DialConnection(context.Background(), &params)
 			if err == nil {
 				conn.Close()
 			}
 		} else {
-			conn, err := sqlDialer.DialSqlConnection(context.Background(), c, params)
+			conn, err := sqlDialer.DialSqlConnection(context.Background(), c, &params)
 			if err == nil {
 				conn.Close()
 			}

--- a/sharedmemory/sharedmemory.go
+++ b/sharedmemory/sharedmemory.go
@@ -1,0 +1,18 @@
+package sharedmemory
+
+import (
+	"runtime"
+
+	"github.com/microsoft/go-mssqldb/msdsn"
+)
+
+type sharedMemoryDialer struct{}
+
+var dialer sharedMemoryDialer = sharedMemoryDialer{}
+
+func init() {
+	if runtime.GOOS == "windows" {
+		msdsn.ProtocolParsers = append(msdsn.ProtocolParsers, dialer)
+		msdsn.ProtocolDialers["lpc"] = dialer
+	}
+}

--- a/sharedmemory/sharedmemory_windows.go
+++ b/sharedmemory/sharedmemory_windows.go
@@ -1,0 +1,64 @@
+package sharedmemory
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/microsoft/go-mssqldb/msdsn"
+	"gopkg.in/natefinch/npipe.v2"
+)
+
+func (n sharedMemoryDialer) ParseServer(server string, p *msdsn.Config) error {
+	if p.Port > 0 {
+		return fmt.Errorf("Shared memory disallowed due to port being specified")
+	} else if p.Host == "" { // if the string specifies np:host\instance, tcpParser won't have filled in p.Host
+		parts := strings.SplitN(server, `\`, 2)
+		p.Host = parts[0]
+		if p.Host == "." || strings.ToUpper(p.Host) == "(LOCAL)" {
+			p.Host = "localhost"
+		}
+		if len(parts) > 1 {
+			p.Instance = parts[1]
+		}
+	}
+	hostName, err := os.Hostname()
+	if err != nil {
+		// Don't know when HostName would return an error, but if it does only support shared memory for localhost or .
+		hostName = "localhost"
+	}
+	if !strings.EqualFold(p.Host, hostName) && !strings.EqualFold("localhost", p.Host) {
+		return fmt.Errorf("Cannot open a Shared Memory connection to a remote SQL server")
+	}
+	return nil
+}
+
+func (n sharedMemoryDialer) Protocol() string {
+	return "lpc"
+}
+
+func (n sharedMemoryDialer) ParseBrowserData(data msdsn.BrowserData, p *msdsn.Config) error {
+	return nil
+}
+
+func (n sharedMemoryDialer) DialConnection(ctx context.Context, p msdsn.Config) (net.Conn, error) {
+	pipename := `\\.\pipe\SQLLocal\`
+	if p.Instance != "" {
+		pipename = pipename + p.Instance
+	} else {
+		pipename = pipename + "MSSQLSERVER"
+	}
+	dl, ok := ctx.Deadline()
+	if ok {
+		duration := dl.Sub(time.Now())
+		return npipe.DialTimeout(pipename, duration)
+	}
+	return npipe.Dial(pipename)
+}
+
+func (n sharedMemoryDialer) CallBrowser(p *msdsn.Config) bool {
+	return false
+}

--- a/sharedmemory/stub.go
+++ b/sharedmemory/stub.go
@@ -23,7 +23,7 @@ func (n sharedMemoryDialer) ParseBrowserData(data msdsn.BrowserData, p *msdsn.Co
 	return fmt.Errorf("Shared memory connections are not supported on this operating system")
 }
 
-func (n sharedMemoryDialer) DialConnection(ctx context.Context, p msdsn.Config) (conn net.Conn, err error) {
+func (n sharedMemoryDialer) DialConnection(ctx context.Context, p *msdsn.Config) (conn net.Conn, err error) {
 
 	return nil, fmt.Errorf("Shared memory connections are not supported on this operating system")
 }

--- a/sharedmemory/stub.go
+++ b/sharedmemory/stub.go
@@ -1,0 +1,33 @@
+//go:build !windows
+// +build !windows
+
+package sharedmemory
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/microsoft/go-mssqldb/msdsn"
+)
+
+func (n sharedMemoryDialer) ParseServer(server string, p *msdsn.Config) error {
+	return fmt.Errorf("Shared memory connections are not supported on this operating system")
+}
+
+func (n sharedMemoryDialer) Protocol() string {
+	return "np"
+}
+
+func (n sharedMemoryDialer) ParseBrowserData(data msdsn.BrowserData, p *msdsn.Config) error {
+	return fmt.Errorf("Shared memory connections are not supported on this operating system")
+}
+
+func (n sharedMemoryDialer) DialConnection(ctx context.Context, p msdsn.Config) (conn net.Conn, err error) {
+
+	return nil, fmt.Errorf("Shared memory connections are not supported on this operating system")
+}
+
+func (n sharedMemoryDialer) CallBrowser(p *msdsn.Config) bool {
+	return false
+}

--- a/sharedmemory_test.go
+++ b/sharedmemory_test.go
@@ -1,0 +1,36 @@
+//go:build sm
+// +build sm
+
+package mssql
+
+import (
+	"testing"
+
+	"github.com/microsoft/go-mssqldb/msdsn"
+	_ "github.com/microsoft/go-mssqldb/sharedmemory"
+)
+
+func TestSharedMemoryProtocolInstalled(t *testing.T) {
+	for _, p := range msdsn.ProtocolParsers {
+		if p.Protocol() == "lpc" {
+			return
+		}
+	}
+	t.Fatalf("ProtocolParsers is missing lpc %v", msdsn.ProtocolParsers)
+}
+
+func TestSharedMemoryConnection(t *testing.T) {
+	params := testConnParams(t)
+	protocol, ok := params.Parameters["protocol"]
+	if !ok || protocol != "lpc" {
+		t.Skip("Test is not running with named pipe protocol set")
+	}
+	conn, _ := open(t)
+	row := conn.QueryRow("SELECT net_transport FROM sys.dm_exec_connections WHERE session_id = @@SPID")
+	if err := row.Scan(&protocol); err != nil {
+		t.Fatalf("Unable to query connection protocol %s", err.Error())
+	}
+	if protocol != "Shared memory" {
+		t.Fatalf("Shared memory connection not made. Protocol: %s", protocol)
+	}
+}

--- a/tds.go
+++ b/tds.go
@@ -837,7 +837,7 @@ func sendAttention(buf *tdsBuffer) error {
 }
 
 // Makes an attempt to connect with each available protocol, in order, until one succeeds or the timeout elapses
-func dialConnection(ctx context.Context, c *Connector, p msdsn.Config, logger ContextLogger) (conn net.Conn, err error) {
+func dialConnection(ctx context.Context, c *Connector, p *msdsn.Config, logger ContextLogger) (conn net.Conn, err error) {
 	for _, protocol := range p.Protocols {
 		dialer := msdsn.ProtocolDialers[protocol]
 		sqlDialer, ok := dialer.(MssqlProtocolDialer)
@@ -1077,7 +1077,7 @@ func connect(ctx context.Context, c *Connector, logger ContextLogger, p msdsn.Co
 	}
 
 initiate_connection:
-	conn, err := dialConnection(dialCtx, c, p, logger)
+	conn, err := dialConnection(dialCtx, c, &p, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/tds.go
+++ b/tds.go
@@ -841,7 +841,7 @@ func dialConnection(ctx context.Context, c *Connector, p msdsn.Config, logger Co
 	for _, protocol := range p.Protocols {
 		dialer := msdsn.ProtocolDialers[protocol]
 		sqlDialer, ok := dialer.(MssqlProtocolDialer)
-		if logger != nil {
+		if logger != nil && uint64(p.LogFlags)&logDebug != 0 {
 			logger.Log(ctx, msdsn.LogDebug, "Dialing with protocol "+protocol)
 		}
 		if !ok {
@@ -849,11 +849,11 @@ func dialConnection(ctx context.Context, c *Connector, p msdsn.Config, logger Co
 		} else {
 			conn, err = sqlDialer.DialSqlConnection(ctx, c, p)
 		}
-		if err != nil && logger != nil {
+		if err != nil && logger != nil && uint64(p.LogFlags)&logErrors != 0 {
 			logger.Log(ctx, msdsn.LogErrors, "Unable to connect with protocol "+protocol+":"+err.Error())
 		}
 		if conn != nil {
-			if logger != nil {
+			if logger != nil && uint64(p.LogFlags)&logDebug != 0 {
 				logger.Log(ctx, msdsn.LogDebug, "Returning connection from protocol "+protocol)
 			}
 			return
@@ -1009,7 +1009,7 @@ func queryBrowser(ctx context.Context, dialCtx context.Context, c *Connector, lo
 			pErr := pd.ParseBrowserData(instances, p)
 			if pErr != nil {
 				pErrors[protocol] = pErr
-				if logger != nil {
+				if logger != nil && uint64(p.LogFlags)&logErrors != 0 {
 					logger.Log(ctx, msdsn.Log(logErrors), "Removing protocol "+protocol+" from dialers. Error:"+pErr.Error())
 				}
 			}

--- a/tds_test.go
+++ b/tds_test.go
@@ -218,9 +218,9 @@ func testConnParams(t testing.TB) msdsn.Config {
 // TestConnParams returns a connection configuration based on environment variables or the contents of a text file
 // Set environment variable SQLSERVER_DSN to provide an entire connection string
 // Set environment variables HOST and DATABASE from which a minimal config will be created.
-//  If HOST and DATABASE are set, you can optionally set INSTANCE, SQLUSER, and SQLPASSWORD as well
+// If HOST and DATABASE are set, you can optionally set INSTANCE, SQLUSER, and SQLPASSWORD as well
 // If environment variables are not set, it will look in the working directory for a file named .connstr
-//   If the file exists it will use the first line of the file as the file as the DSN
+// If the file exists it will use the first line of the file as the file as the DSN
 func GetConnParams() (*msdsn.Config, error) {
 	dsn := os.Getenv("SQLSERVER_DSN")
 	const logFlags = 127
@@ -366,7 +366,6 @@ func TestConnectViaIp(t *testing.T) {
 	if params.Encryption == msdsn.EncryptionRequired {
 		t.Skip("Unable to test connection to IP for servers that expect encryption")
 	}
-	skipIfNamedPipesEnabled(t)
 
 	if params.Host == "." {
 		params.Host = "127.0.0.1"
@@ -782,7 +781,7 @@ func TestUcs22str(t *testing.T) {
 
 var sideeffect_varchar string
 
-//ucs22str benchmarks
+// ucs22str benchmarks
 func BenchmarkUcs22strAscii(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		s, _ := ucs22str(encoded123Bytes)

--- a/tds_test.go
+++ b/tds_test.go
@@ -600,6 +600,7 @@ func TestSqlBrowserNotUsedIfPortSpecified(t *testing.T) {
 
 	// Connect to an instance on a host that doesn't exist (so connection will always expectedly fail)
 	params := testConnParams(t)
+	delete(params.Parameters, "protocol")
 	params.Host = "badhost"
 	params.Instance = "foobar"
 	protocols := params.Protocols
@@ -611,7 +612,7 @@ func TestSqlBrowserNotUsedIfPortSpecified(t *testing.T) {
 	err := testConnectionBad(t, params.URL().String())
 
 	if !strings.Contains(err.Error(), errorSubstrStringToCheckFor) {
-		t.Fatal("Connection should have tried to use SQL Browser")
+		t.Fatalf("Connection should have tried to use SQL Browser. Error:%s", err.Error())
 	}
 
 	// Specify port, ensure error does not indicate SQL Browser lookup failed


### PR DESCRIPTION
Shared memory connections can be made for "." or "localhost" or for a host name that matches the value returned by `os.Hostname()`. Just import the `sharedmemory` package to enable it.

To put shared memory as the primary connection option, set it as the first entry in `msdsn.ProtocolParsers`. To force only a shared memory connection, use the `lpc:` prefix on the host name in the connection string or set the "protocol" parameter to "lpc" in an `msdsn.Config`.
 
