### PR TITLE
Fixes for named pipe dialer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 ### Features
 
 * Add driver version and name to TDS login packets
+* Add `pipe` connection string parameter for named pipe dialer
 
 ### Bug fixes
 
 * Added checks while reading prelogin for invalid data ([#64](https://github.com/microsoft/go-mssqldb/issues/64))([86ecefd8b](https://github.com/microsoft/go-mssqldb/commit/86ecefd8b57683aeb5ad9328066ee73fbccd62f5))
+
+* Fixed multi-protocol dialer path to avoid unneeded SQL Browser queries

--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ Other supported formats are listed below.
 * `ServerSPN` - The kerberos SPN (Service Principal Name) for the server. Default is MSSQLSvc/host:port.
 * `Workstation ID` - The workstation name (default is the host name)
 * `ApplicationIntent` - Can be given the value `ReadOnly` to initiate a read-only connection to an Availability Group listener. The `database` must be specified when connecting with `Application Intent` set to `ReadOnly`.
+* `protocol` - forces use of a protocol. Make sure the corresponding package is imported.
+
+### Connection parameters for namedpipe package
+* `pipe`  - If set, no Browser query is made and named pipe used will be `\\<host>\pipe\<pipe>`
+* `protocol` can be set to `np`
+* For a non-URL DSN, the `server` parameter can be set to the full pipe name like `\\host\pipe\sql\query`
+
+If no pipe name can be derived from the DSN, connection attempts will first query the SQL Browser service to find the pipe name for the instance.
+
+### Protocol configuration
+
+To force a specific protocol for the connection there two several options:
+1. Prepend the server name in a DSN with the protocol and a colon, like `np:host` or `lpc:host` or `tcp:host`
+2. Set the `protocol` parameter to the protocol name
+
+`msdsn.ProtocolParsers` can be reordered to prioritize other protocols ahead of `tcp`
 
 ### Kerberos Active Directory authentication outside Windows
 The package supports authentication via 3 methods.

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -197,20 +197,6 @@ func Parse(dsn string) (Config, error) {
 		}
 		p.ConnTimeout = time.Duration(timeout) * time.Second
 	}
-	f := len(p.Protocols)
-	if f == 0 {
-		f = 1
-	}
-	p.DialTimeout = time.Duration(15*f) * time.Second
-	if strdialtimeout, ok := params["dial timeout"]; ok {
-		timeout, err := strconv.ParseUint(strdialtimeout, 10, 64)
-		if err != nil {
-			f := "invalid dial timeout '%v': %v"
-			return p, fmt.Errorf(f, strdialtimeout, err.Error())
-		}
-
-		p.DialTimeout = time.Duration(timeout) * time.Second
-	}
 
 	// default keep alive should be 30 seconds according to spec:
 	// https://msdn.microsoft.com/en-us/library/dd341108.aspx
@@ -353,6 +339,21 @@ func Parse(dsn string) (Config, error) {
 		return p, fmt.Errorf("No protocol handler is available for protocol: '%s'", protocol)
 	}
 
+	f := len(p.Protocols)
+	if f == 0 {
+		f = 1
+	}
+	p.DialTimeout = time.Duration(15*f) * time.Second
+	if strdialtimeout, ok := params["dial timeout"]; ok {
+		timeout, err := strconv.ParseUint(strdialtimeout, 10, 64)
+		if err != nil {
+			f := "invalid dial timeout '%v': %v"
+			return p, fmt.Errorf(f, strdialtimeout, err.Error())
+		}
+
+		p.DialTimeout = time.Duration(timeout) * time.Second
+	}
+
 	return p, nil
 }
 
@@ -374,6 +375,10 @@ func (p Config) URL() *url.URL {
 	protocol, ok := p.Parameters["protocol"]
 	if ok {
 		q.Add("protocol", protocol)
+	}
+	pipe, ok := p.Parameters["pipe"]
+	if ok {
+		q.Add("pipe", pipe)
 	}
 	res := url.URL{
 		Scheme: "sqlserver",

--- a/namedpipe_test.go
+++ b/namedpipe_test.go
@@ -4,6 +4,7 @@
 package mssql
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/microsoft/go-mssqldb/msdsn"
@@ -22,7 +23,7 @@ func TestNamedPipeProtocolInstalled(t *testing.T) {
 func TestNamedPipeConnection(t *testing.T) {
 	params := testConnParams(t)
 	protocol, ok := params.Parameters["protocol"]
-	if ok && protocol != "np" {
+	if (ok && protocol != "np") || strings.Contains(params.Host, "database.windows.net") {
 		t.Skip("Test is not running with named pipe protocol set")
 	}
 	conn, _ := open(t)
@@ -31,6 +32,6 @@ func TestNamedPipeConnection(t *testing.T) {
 		t.Fatalf("Unable to query connection protocol %s", err.Error())
 	}
 	if protocol != "Named pipe" {
-		t.Fatalf("Named pips connection not made. Protocol: %s", protocol)
+		t.Fatalf("Named pipe connection not made. Protocol: %s", protocol)
 	}
 }

--- a/protocol.go
+++ b/protocol.go
@@ -21,8 +21,12 @@ type tcpDialer struct{}
 func (t tcpDialer) ParseBrowserData(data msdsn.BrowserData, p *msdsn.Config) error {
 	// If instance is specified, but no port, check SQL Server Browser
 	// for the instance and discover its port.
-	p.Instance = strings.ToUpper(p.Instance)
-	strport, ok := data[p.Instance]["tcp"]
+	ok := len(data) > 0
+	strport := ""
+	if ok {
+		p.Instance = strings.ToUpper(p.Instance)
+		strport, ok = data[p.Instance]["tcp"]
+	}
 	if !ok {
 		f := "no instance matching '%v' returned from host '%v'"
 		return fmt.Errorf(f, p.Instance, p.Host)
@@ -106,6 +110,7 @@ func (t tcpDialer) DialSqlConnection(ctx context.Context, c *Connector, p *msdsn
 	if p.ServerSPN == "" {
 		p.ServerSPN = generateSpn(p.Host, instanceOrPort(p.Instance, p.Port))
 	}
+	p.Port = resolveServerPort(p.Port)
 	return conn, err
 }
 

--- a/queries_test.go
+++ b/queries_test.go
@@ -2082,9 +2082,6 @@ func getLatency(t *testing.T) time.Duration {
 	}
 	c := &Connector{params: params}
 	now := time.Now()
-	if err := queryBrowser(context.Background(), context.Background(), c, nil, &params); err != nil {
-		t.Fatalf("queryBrowser failed: %s", err.Error())
-	}
 	// Dialing both tcp and np for a named-pipes only connection takes a long time
 	if len(params.Protocols) > 1 && testing.Short() {
 		t.Skip("short")

--- a/tds_test.go
+++ b/tds_test.go
@@ -249,6 +249,9 @@ func GetConnParams() (*msdsn.Config, error) {
 		if os.Getenv("PROTOCOL") != "" {
 			c.Parameters["protocol"] = os.Getenv("PROTOCOL")
 		}
+		if os.Getenv("PIPE") != "" {
+			c.Parameters["pipe"] = os.Getenv("PIPE")
+		}
 		return c, nil
 	}
 	// try loading connection string from file
@@ -364,7 +367,7 @@ func TestConnect(t *testing.T) {
 
 func TestConnectViaIp(t *testing.T) {
 	params := testConnParams(t)
-	if params.Encryption == msdsn.EncryptionRequired {
+	if params.Encryption == msdsn.EncryptionRequired || strings.Contains(params.Host, "database.windows.net") {
 		t.Skip("Unable to test connection to IP for servers that expect encryption")
 	}
 
@@ -596,7 +599,7 @@ func TestBadHost(t *testing.T) {
 }
 
 func TestSqlBrowserNotUsedIfPortSpecified(t *testing.T) {
-	const errorSubstrStringToCheckFor = "unable to get instances from Sql Server Browser"
+	const errorSubstrStringToCheckFor = "instance matching 'foobar' returned from host 'badhost'"
 
 	// Connect to an instance on a host that doesn't exist (so connection will always expectedly fail)
 	params := testConnParams(t)
@@ -611,7 +614,7 @@ func TestSqlBrowserNotUsedIfPortSpecified(t *testing.T) {
 
 	err := testConnectionBad(t, params.URL().String())
 
-	if !strings.Contains(err.Error(), errorSubstrStringToCheckFor) {
+	if !strings.Contains(strings.ToLower(err.Error()), errorSubstrStringToCheckFor) {
 		t.Fatalf("Connection should have tried to use SQL Browser. Error:%s", err.Error())
 	}
 


### PR DESCRIPTION
1 - add a `pipe` parameter so users can encode it in a URL DSN
2 - avoid unneeded browser queries when TCP protocol is first in the dialer list