### PR TITLE
Fixed #93: servername was not supplied to TLS cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug fixes
+
+* Fixed uninitialized server name in TLS config ([#93](https://github.com/microsoft/go-mssqldb/issues/93))([#94](https://github.com/microsoft/go-mssqldb/pull/94))
+
 ## 0.20.0
 
 ### Features

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -81,6 +81,7 @@ type Config struct {
 	ProtocolParameters map[string]interface{}
 }
 
+// Build a tls.Config object from the supplied certificate.
 func SetupTLS(certificate string, insecureSkipVerify bool, hostInCertificate string, minTLSVersion string) (*tls.Config, error) {
 	config := tls.Config{
 		ServerName:         hostInCertificate,
@@ -113,11 +114,10 @@ func SetupTLS(certificate string, insecureSkipVerify bool, hostInCertificate str
 	return &config, nil
 }
 
+// Parse and handle encryption parameters. If encryption is desired, it returns the corresponding tls.Config object.
 func parseTLS(params map[string]string, host string) (Encryption, *tls.Config, error) {
-	var (
-		trustServerCert = false
-		certificate     = ""
-	)
+	var trustServerCert = false
+
 	var encryption Encryption = EncryptionOff
 	encrypt, ok := params["encrypt"]
 	if ok {
@@ -145,7 +145,7 @@ func parseTLS(params map[string]string, host string) (Encryption, *tls.Config, e
 			return encryption, nil, fmt.Errorf(f, trust, err.Error())
 		}
 	}
-	certificate = params["certificate"]
+	certificate := params["certificate"]
 	if encryption != EncryptionDisabled {
 		tlsMin := params["tlsmin"]
 		tlsConfig, err := SetupTLS(certificate, trustServerCert, host, tlsMin)
@@ -349,8 +349,7 @@ func Parse(dsn string) (Config, error) {
 		p.DialTimeout = time.Duration(timeout) * time.Second
 	}
 
-	var hostInCertificate = ""
-	hostInCertificate, ok = params["hostnameincertificate"]
+	hostInCertificate, ok := params["hostnameincertificate"]
 	if ok {
 		p.HostInCertificateProvided = true
 	} else {
@@ -658,16 +657,6 @@ func splitConnectionStringOdbc(dsn string) (map[string]string, error) {
 // Normalizes the given string as an ODBC-format key
 func normalizeOdbcKey(s string) string {
 	return strings.ToLower(strings.TrimRightFunc(s, unicode.IsSpace))
-}
-
-const defaultServerPort = 1433
-
-func resolveServerPort(port uint64) uint64 {
-	if port == 0 {
-		return defaultServerPort
-	}
-
-	return port
 }
 
 // ProtocolParser can populate Config with parameters to dial using its protocol

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -116,7 +116,7 @@ func SetupTLS(certificate string, insecureSkipVerify bool, hostInCertificate str
 
 // Parse and handle encryption parameters. If encryption is desired, it returns the corresponding tls.Config object.
 func parseTLS(params map[string]string, host string) (Encryption, *tls.Config, error) {
-	var trustServerCert = false
+	trustServerCert := false
 
 	var encryption Encryption = EncryptionOff
 	encrypt, ok := params["encrypt"]

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -217,6 +217,17 @@ func TestConnParseRoundTripFixed(t *testing.T) {
 	}
 }
 
+func TestServerNameInTLSConfig(t *testing.T) {
+	connStr := "sqlserver://someuser:somepass@somehost?TrustServerCertificate=false&encrypt=true"
+	cfg, err := Parse(connStr)
+	if err != nil {
+		t.Errorf("Could not parse valid connection string %s: %v", connStr, err)
+	}
+	if cfg.TLSConfig.ServerName != "somehost" {
+		t.Errorf("Expected somehost as TLS server, but got %s (cfg.Host was %s)", cfg.TLSConfig.ServerName, cfg.Host)
+	}
+}
+
 func TestAllKeysAreAvailableInParametersMap(t *testing.T) {
 	keys := map[string]string{
 		"user id":            "1",

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -218,16 +218,32 @@ func TestConnParseRoundTripFixed(t *testing.T) {
 }
 
 func TestServerNameInTLSConfig(t *testing.T) {
-	connStr := "sqlserver://someuser:somepass@somehost?TrustServerCertificate=false&encrypt=true"
-	cfg, err := Parse(connStr)
-	if err != nil {
-		t.Errorf("Could not parse valid connection string %s: %v", connStr, err)
+	var tests = []struct {
+		dsn          string
+		host         string
+		hasTLSConfig bool
+	}{
+		{"sqlserver://someuser:somepass@somehost?TrustServerCertificate=false&encrypt=true", "somehost", true},
+		{"sqlserver://someuser:somepass@somehost?TrustServerCertificate=false&encrypt=false", "somehost", true},
+		{"sqlserver://someuser:somepass@somehost?TrustServerCertificate=false&encrypt=true&hostnameincertificate=someotherhost", "someotherhost", true},
+		{"sqlserver://someuser:somepass@somehost?TrustServerCertificate=false", "somehost", true},
+		{"sqlserver://someuser:somepass@somehost?TrustServerCertificate=false&encrypt=DISABLE", "", false},
+		{"sqlserver://someuser:somepass@somehost?TrustServerCertificate=false&encrypt=DISABLE&hostnameincertificate=someotherhost", "", false},
+		{"sqlserver://someuser:somepass@somehost?TrustServerCertificate=false&encrypt=false", "somehost", true},
 	}
-	if cfg.TLSConfig.ServerName != "somehost" {
-		t.Errorf("Expected somehost as TLS server, but got %s (cfg.Host was %s)", cfg.TLSConfig.ServerName, cfg.Host)
+	for _, test := range tests {
+		cfg, err := Parse(test.dsn)
+		if err != nil {
+			t.Errorf("Could not parse valid connection string %s: %v", test.dsn, err)
+		}
+		if !test.hasTLSConfig && cfg.TLSConfig != nil {
+			t.Errorf("Expected empty TLS config, but got %v (cfg.Host was %s)", cfg.TLSConfig, cfg.Host)
+		}
+		if test.hasTLSConfig && cfg.TLSConfig.ServerName != test.host {
+			t.Errorf("Expected somehost as TLS server, but got %s (cfg.Host was %s)", cfg.TLSConfig.ServerName, cfg.Host)
+		}
 	}
 }
-
 func TestAllKeysAreAvailableInParametersMap(t *testing.T) {
 	keys := map[string]string{
 		"user id":            "1",


### PR DESCRIPTION
A change in fd44003 moved the code for setting p.Host down in the parse function, resulting in an empty p.Host value at the time of the creation of p.TLSConfig. I extracted the TLS parsing into a separate function and moved the TLSConfig creation to the end of the parsing function.

closes #93 