### PR TITLE
Add admin protocol for DAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.22.0
+
+### Features
+
+* `admin` protocol for dedicated administrator connections
+
+### Changed
+
+* Added `Hidden()` method to `ProtocolParser` interface
+
 ## 0.21.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.22.0
+## 1.0.0
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ To force a specific protocol for the connection there two several options:
 
 `msdsn.ProtocolParsers` can be reordered to prioritize other protocols ahead of `tcp`
 
+The `admin` protocol will not be used for dialing unless the connection string explicitly specifies it. Note SQL Server allows only 1 admin (or DAC) connection to be active at a time.
+
 ### Kerberos Active Directory authentication outside Windows
 
 To connect with kerberos authentication from a Linux server you can use the optional krb5 package. 
@@ -403,6 +405,7 @@ db.QueryContext(ctx, `select * from t2 where user_name = @p1;`, mssql.VarChar(na
 * Pluggable Dialer implementations through `msdsn.ProtocolParsers` and `msdsn.ProtocolDialers`
 * A `namedpipe` package to support connections using named pipes (np:) on Windows
 * A `sharedmemory` package to support connections using shared memory (lpc:) on Windows
+* Dedicated Administrator Connection (DAC) is supported using `admin` protocol
 
 ## Tests
 

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -386,13 +386,12 @@ func (p Config) URL() *url.URL {
 	}
 	host := p.Host
 	protocol := ""
-	hostParts := strings.Split(p.Host, ":")
-	if len(hostParts) > 1 {
-		host = hostParts[1]
-		protocol = hostParts[0]
+	if p, h, ok := strings.Cut(p.Host, ":"); ok {
+		protocol = p
+		host = h
 	}
 	if p.Port > 0 {
-		host = fmt.Sprintf("%s:%d", p.Host, p.Port)
+		host = fmt.Sprintf("%s:%d", host, p.Port)
 	}
 	q.Add("disableRetry", fmt.Sprintf("%t", p.DisableRetry))
 	protocolParam, ok := p.Parameters["protocol"]

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -386,10 +386,13 @@ func (p Config) URL() *url.URL {
 	}
 	host := p.Host
 	protocol := ""
-	hostParts := strings.SplitN(p.Host, ":", 2)
-	if len(hostParts) > 1 {
-		host = hostParts[1]
-		protocol = hostParts[0]
+	// Can't just check for a : because of IPv6 host names
+	if strings.HasPrefix(host, "admin") || strings.HasPrefix(host, "np") || strings.HasPrefix(host, "sm") || strings.HasPrefix(host, "tcp") {
+		hostParts := strings.SplitN(p.Host, ":", 2)
+		if len(hostParts) > 1 {
+			host = hostParts[1]
+			protocol = hostParts[0]
+		}
 	}
 	if p.Port > 0 {
 		host = fmt.Sprintf("%s:%d", host, p.Port)

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -18,6 +18,7 @@ import (
 type (
 	Encryption int
 	Log        uint64
+	BrowserMsg int
 )
 
 const (
@@ -35,6 +36,12 @@ const (
 	LogTransaction Log = 32
 	LogDebug       Log = 64
 	LogRetries     Log = 128
+)
+
+const (
+	BrowserDefault      BrowserMsg = 0
+	BrowserAllInstances BrowserMsg = 0x03
+	BrowserDAC          BrowserMsg = 0x0f
 )
 
 type Config struct {
@@ -79,6 +86,8 @@ type Config struct {
 	Protocols []string
 	// ProtocolParameters are written by non-tcp ProtocolParser implementations
 	ProtocolParameters map[string]interface{}
+	// BrowserMsg is the message identifier to fetch instance data from SQL browser
+	BrowserMessage BrowserMsg
 }
 
 // Build a tls.Config object from the supplied certificate.
@@ -316,7 +325,7 @@ func Parse(dsn string) (Config, error) {
 	protocol, ok := params["protocol"]
 
 	for _, parser := range ProtocolParsers {
-		if !ok || parser.Protocol() == protocol {
+		if (!ok && !parser.Hidden()) || parser.Protocol() == protocol {
 			err = parser.ParseServer(server, &p)
 			if err != nil {
 				// if the caller only wants this protocol , fail right away
@@ -661,16 +670,27 @@ func normalizeOdbcKey(s string) string {
 
 // ProtocolParser can populate Config with parameters to dial using its protocol
 type ProtocolParser interface {
+	// ParseServer updates the Config with protocol properties from the server. Returns an error if the server isn't compatible.
 	ParseServer(server string, p *Config) error
+	// Protocol returns the name of the protocol dialer
 	Protocol() string
+	// Hidden returns true if this protocol must be explicitly chosen by the application
+	Hidden() bool
 }
 
 // ProtocolParsers is an ordered list of protocols that can be dialed. Each parser must have a corresponding Dialer in mssql.ProtocolDialers
 var ProtocolParsers []ProtocolParser = []ProtocolParser{
-	tcpParser{},
+	tcpParser{Prefix: "tcp"},
+	tcpParser{Prefix: "admin"},
 }
 
-type tcpParser struct{}
+type tcpParser struct {
+	Prefix string
+}
+
+func (t tcpParser) Hidden() bool {
+	return t.Prefix == "admin"
+}
 
 func (t tcpParser) ParseServer(server string, p *Config) error {
 	// a server name can have different forms
@@ -681,6 +701,11 @@ func (t tcpParser) ParseServer(server string, p *Config) error {
 	}
 	if len(parts) > 1 {
 		p.Instance = parts[1]
+	}
+	if t.Prefix == "admin" {
+		p.BrowserMessage = BrowserDAC
+	} else {
+		p.BrowserMessage = BrowserAllInstances
 	}
 	return nil
 }

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -386,9 +386,10 @@ func (p Config) URL() *url.URL {
 	}
 	host := p.Host
 	protocol := ""
-	if p, h, ok := strings.Cut(p.Host, ":"); ok {
-		protocol = p
-		host = h
+	hostParts := strings.SplitN(p.Host, ":", 2)
+	if len(hostParts) > 1 {
+		host = hostParts[1]
+		protocol = hostParts[0]
 	}
 	if p.Port > 0 {
 		host = fmt.Sprintf("%s:%d", host, p.Port)

--- a/msdsn/protocolparse_test.go
+++ b/msdsn/protocolparse_test.go
@@ -10,6 +10,10 @@ type testProtocol struct{}
 
 var protocolImpl = testProtocol{}
 
+func (t testProtocol) Hidden() bool {
+	return false
+}
+
 func (t testProtocol) ParseServer(server string, p *Config) error {
 	if strings.HasPrefix(server, "**") {
 		p.ProtocolParameters[t.Protocol()] = "special"

--- a/mssql.go
+++ b/mssql.go
@@ -23,9 +23,9 @@ import (
 
 // ReturnStatus may be used to return the return value from a proc.
 //
-//   var rs mssql.ReturnStatus
-//   _, err := db.Exec("theproc", &rs)
-//   log.Printf("return status = %d", rs)
+//	var rs mssql.ReturnStatus
+//	_, err := db.Exec("theproc", &rs)
+//	log.Printf("return status = %d", rs)
 type ReturnStatus int32
 
 var driverInstance = &Driver{processQueryText: true}
@@ -878,12 +878,13 @@ func (r *Rows) ColumnTypeDatabaseTypeName(index int) string {
 // not a variable length type ok should return false.
 // If length is not limited other than system limits, it should return math.MaxInt64.
 // The following are examples of returned values for various types:
-//   TEXT          (math.MaxInt64, true)
-//   varchar(10)   (10, true)
-//   nvarchar(10)  (10, true)
-//   decimal       (0, false)
-//   int           (0, false)
-//   bytea(30)     (30, true)
+//
+//	TEXT          (math.MaxInt64, true)
+//	varchar(10)   (10, true)
+//	nvarchar(10)  (10, true)
+//	decimal       (0, false)
+//	int           (0, false)
+//	bytea(30)     (30, true)
 func (r *Rows) ColumnTypeLength(index int) (int64, bool) {
 	return makeGoLangTypeLength(r.cols[index].ti)
 }
@@ -891,9 +892,10 @@ func (r *Rows) ColumnTypeLength(index int) (int64, bool) {
 // It should return
 // the precision and scale for decimal types. If not applicable, ok should be false.
 // The following are examples of returned values for various types:
-//   decimal(38, 4)    (38, 4, true)
-//   int               (0, 0, false)
-//   decimal           (math.MaxInt64, math.MaxInt64, true)
+//
+//	decimal(38, 4)    (38, 4, true)
+//	int               (0, 0, false)
+//	decimal           (math.MaxInt64, math.MaxInt64, true)
 func (r *Rows) ColumnTypePrecisionScale(index int) (int64, int64, bool) {
 	return makeGoLangTypePrecisionScale(r.cols[index].ti)
 }
@@ -1320,12 +1322,13 @@ func (r *Rowsq) ColumnTypeDatabaseTypeName(index int) string {
 // not a variable length type ok should return false.
 // If length is not limited other than system limits, it should return math.MaxInt64.
 // The following are examples of returned values for various types:
-//   TEXT          (math.MaxInt64, true)
-//   varchar(10)   (10, true)
-//   nvarchar(10)  (10, true)
-//   decimal       (0, false)
-//   int           (0, false)
-//   bytea(30)     (30, true)
+//
+//	TEXT          (math.MaxInt64, true)
+//	varchar(10)   (10, true)
+//	nvarchar(10)  (10, true)
+//	decimal       (0, false)
+//	int           (0, false)
+//	bytea(30)     (30, true)
 func (r *Rowsq) ColumnTypeLength(index int) (int64, bool) {
 	return makeGoLangTypeLength(r.cols[index].ti)
 }
@@ -1333,9 +1336,10 @@ func (r *Rowsq) ColumnTypeLength(index int) (int64, bool) {
 // It should return
 // the precision and scale for decimal types. If not applicable, ok should be false.
 // The following are examples of returned values for various types:
-//   decimal(38, 4)    (38, 4, true)
-//   int               (0, 0, false)
-//   decimal           (math.MaxInt64, math.MaxInt64, true)
+//
+//	decimal(38, 4)    (38, 4, true)
+//	int               (0, 0, false)
+//	decimal           (math.MaxInt64, math.MaxInt64, true)
 func (r *Rowsq) ColumnTypePrecisionScale(index int) (int64, int64, bool) {
 	return makeGoLangTypePrecisionScale(r.cols[index].ti)
 }

--- a/mssql.go
+++ b/mssql.go
@@ -30,6 +30,7 @@ type ReturnStatus int32
 
 var driverInstance = &Driver{processQueryText: true}
 var driverInstanceNoProcess = &Driver{processQueryText: false}
+var tcpDialerInstance *tcpDialer = &tcpDialer{}
 
 func init() {
 	sql.Register("mssql", driverInstance)
@@ -41,7 +42,8 @@ func init() {
 		}
 		return netDialer{&net.Dialer{KeepAlive: ka}}
 	}
-	msdsn.ProtocolDialers["tcp"] = tcpDialer{}
+	msdsn.ProtocolDialers["tcp"] = *tcpDialerInstance
+	msdsn.ProtocolDialers["admin"] = *tcpDialerInstance
 }
 
 var createDialer func(p *msdsn.Config) Dialer

--- a/namedpipe/namedpipe_windows.go
+++ b/namedpipe/namedpipe_windows.go
@@ -56,6 +56,10 @@ func (n namedPipeDialer) Protocol() string {
 	return "np"
 }
 
+func (n namedPipeDialer) Hidden() bool {
+	return false
+}
+
 func (n namedPipeDialer) ParseBrowserData(data msdsn.BrowserData, p *msdsn.Config) error {
 	// If instance is specified, but no port, check SQL Server Browser
 	// for the instance and discover its port.

--- a/namedpipe/stub.go
+++ b/namedpipe/stub.go
@@ -19,6 +19,10 @@ func (n namedPipeDialer) Protocol() string {
 	return "np"
 }
 
+func (n namedPipeDialer) Hidden() bool {
+	return false
+}
+
 func (n namedPipeDialer) ParseBrowserData(data msdsn.BrowserData, p *msdsn.Config) error {
 	return fmt.Errorf("Named pipe connections are not supported on this operating system")
 }

--- a/queries_go110_test.go
+++ b/queries_go110_test.go
@@ -1,3 +1,4 @@
+//go:build go1.10
 // +build go1.10
 
 package mssql
@@ -35,7 +36,7 @@ SET ARITHIGNORE ON; -- 128
 `
 
 	pool := sql.OpenDB(connector)
-
+	defer pool.Close()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -1048,6 +1048,7 @@ func TestClearReturnStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer conn.Close()
 
 	_, err = conn.ExecContext(ctx, "CREATE PROC #get_answer AS RETURN 42")
 	if err != nil {

--- a/queries_test.go
+++ b/queries_test.go
@@ -1036,6 +1036,7 @@ func TestStmt_SetQueryNotification(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open connection: %v", err)
 	}
+	defer cn.Close()
 	stmt, err := cn.Prepare("SELECT 1")
 	if err != nil {
 		t.Error("Connection failed", err)
@@ -2759,5 +2760,25 @@ func skipIfNamedPipesEnabled(t *testing.T) {
 	t.Helper()
 	if len(msdsn.ProtocolParsers) > 1 {
 		t.Skip("Skipping test due to named pipes dialer")
+	}
+}
+
+func TestAdminConnection(t *testing.T) {
+	params := testConnParams(t)
+	protocol, ok := params.Parameters["protocol"]
+	if ok && protocol != "admin" {
+		t.Skip("Test is not running with admin protocol set")
+	}
+	conn, _ := open(t)
+	defer conn.Close()
+	row := conn.QueryRow(`SELECT  c.net_transport 
+	FROM sys.dm_exec_connections c
+	JOIN sys.tcp_endpoints e ON c.endpoint_id = e.endpoint_id
+	WHERE c.session_id = @@SPID AND e.name = 'Dedicated Admin Connection'`)
+	if err := row.Scan(&protocol); err != nil {
+		t.Fatalf("Unable to query connection protocol or not connected on DAC %s", err.Error())
+	}
+	if !strings.EqualFold(protocol, "tcp") {
+		t.Fatalf("Tcp connection not made. Protocol: %s", protocol)
 	}
 }

--- a/queries_test.go
+++ b/queries_test.go
@@ -2766,7 +2766,7 @@ func skipIfNamedPipesEnabled(t *testing.T) {
 func TestAdminConnection(t *testing.T) {
 	params := testConnParams(t)
 	protocol, ok := params.Parameters["protocol"]
-	if ok && protocol != "admin" {
+	if !ok || protocol != "admin" {
 		t.Skip("Test is not running with admin protocol set")
 	}
 	conn, _ := open(t)

--- a/sharedmemory/sharedmemory_windows.go
+++ b/sharedmemory/sharedmemory_windows.go
@@ -41,6 +41,10 @@ func (n sharedMemoryDialer) Protocol() string {
 	return "lpc"
 }
 
+func (n sharedMemoryDialer) Hidden() bool {
+	return false
+}
+
 func (n sharedMemoryDialer) ParseBrowserData(data msdsn.BrowserData, p *msdsn.Config) error {
 	return nil
 }

--- a/sharedmemory/stub.go
+++ b/sharedmemory/stub.go
@@ -19,6 +19,10 @@ func (n sharedMemoryDialer) Protocol() string {
 	return "np"
 }
 
+func (n sharedMemoryDialer) Hidden() bool {
+	return false
+}
+
 func (n sharedMemoryDialer) ParseBrowserData(data msdsn.BrowserData, p *msdsn.Config) error {
 	return fmt.Errorf("Shared memory connections are not supported on this operating system")
 }

--- a/sharedmemory_test.go
+++ b/sharedmemory_test.go
@@ -26,6 +26,7 @@ func TestSharedMemoryConnection(t *testing.T) {
 		t.Skip("Test is not running with named pipe protocol set")
 	}
 	conn, _ := open(t)
+	defer conn.Close()
 	row := conn.QueryRow("SELECT net_transport FROM sys.dm_exec_connections WHERE session_id = @@SPID")
 	if err := row.Scan(&protocol); err != nil {
 		t.Fatalf("Unable to query connection protocol %s", err.Error())

--- a/tds.go
+++ b/tds.go
@@ -19,6 +19,14 @@ import (
 	"github.com/microsoft/go-mssqldb/msdsn"
 )
 
+func parseDAC(msg []byte, instance string) msdsn.BrowserData {
+	results := msdsn.BrowserData{}
+	if len(msg) == 6 && msg[0] == 5 {
+		results[strings.ToUpper(instance)]["tcp"] = fmt.Sprint(binary.LittleEndian.Uint16(msg[5:]))
+	}
+	return results
+}
+
 func parseInstances(msg []byte) msdsn.BrowserData {
 	results := msdsn.BrowserData{}
 	if len(msg) > 3 && msg[0] == 5 {
@@ -48,12 +56,16 @@ func parseInstances(msg []byte) msdsn.BrowserData {
 	return results
 }
 
-func getInstances(ctx context.Context, d Dialer, address string, browserMsg msdsn.BrowserMsg) (msdsn.BrowserData, error) {
+func getInstances(ctx context.Context, d Dialer, address string, browserMsg msdsn.BrowserMsg, instance string) (msdsn.BrowserData, error) {
 	emptyInstances := msdsn.BrowserData{}
 	var bmsg []byte
 	var resp []byte
 	if browserMsg == msdsn.BrowserDAC {
-		return emptyInstances, fmt.Errorf("not implemented yet")
+		bmsg = make([]byte, 3+len(instance))
+		bmsg[0] = byte(msdsn.BrowserDAC)
+		bmsg[1] = 1
+		_ = copy(bmsg[3:], instance)
+		resp = make([]byte, 6)
 	} else { // default to AllInstances
 		bmsg = []byte{byte(msdsn.BrowserAllInstances)}
 		resp = make([]byte, 16*1024-1)
@@ -73,6 +85,9 @@ func getInstances(ctx context.Context, d Dialer, address string, browserMsg msds
 	read, err := conn.Read(resp)
 	if err != nil {
 		return emptyInstances, err
+	}
+	if browserMsg == msdsn.BrowserDAC {
+		return parseDAC(resp[:read], instance), nil
 	}
 	return parseInstances(resp[:read]), nil
 }
@@ -912,7 +927,7 @@ func dialConnection(ctx context.Context, c *Connector, p *msdsn.Config, logger C
 		if dialer.CallBrowser(p) {
 			if instances == nil {
 				d := c.getDialer(p)
-				instances, err = getInstances(ctx, d, p.Host, p.BrowserMessage)
+				instances, err = getInstances(ctx, d, p.Host, p.BrowserMessage, p.Instance)
 				if err != nil && logger != nil && uint64(p.LogFlags)&logErrors != 0 {
 					e := fmt.Sprintf("unable to get instances from Sql Server Browser on host %v: %v", p.Host, err.Error())
 					logger.Log(ctx, msdsn.Log(logErrors), e)


### PR DESCRIPTION
Fixes #108 
I've attempted to adhere to this spec for DAC: https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/diagnostic-connection-for-database-administrators?view=sql-server-ver15

The doc confuses me a bit. I don't know how an app is supposed to tell the difference between `admin:<instance_name>` and `admin:<server_name>`
The driver requires the full `admin:server\instance` syntax or separate parameters for `server` and `protocol`.

