### PR TITLE
Allow for local dns resolution with a custom dialer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.0
+
+### Features
+
+* A connector's dialer can now be used to resolve DNS if the dialer implements the `HostDialer` interface
+
 ## 1.0.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Other supported formats are listed below.
 
 If no pipe name can be derived from the DSN, connection attempts will first query the SQL Browser service to find the pipe name for the instance.
 
+### DNS Resolution through a Custom Dialer
+
+Custom Dialers can be used to resolve DNS if the Connection's Dialer implements the `HostDialer` interface. This is helpful when the dialer is proxying requests to a different, private network and the DNS record is local to the private network.
+
 ### Protocol configuration
 
 To force a specific protocol for the connection there two several options:

--- a/mssql.go
+++ b/mssql.go
@@ -194,13 +194,22 @@ type Connector struct {
 	// SessionInitSQL is empty.
 	SessionInitSQL string
 
-	// Dialer sets a custom dialer for all network operations.
+	// Dialer sets a custom dialer for all network operations, except DNS resolution unless
+	// the dialer implements the HostDialer.
+	//
 	// If Dialer is not set, normal net dialers are used.
 	Dialer Dialer
 }
 
 type Dialer interface {
 	DialContext(ctx context.Context, network string, addr string) (net.Conn, error)
+}
+
+// HostDialer should be used if the dialer is proxying requests to a different network
+// and DNS should be resolved in that other network
+type HostDialer interface {
+	Dialer
+	HostName() string
 }
 
 func (c *Connector) getDialer(p *msdsn.Config) Dialer {

--- a/protocol.go
+++ b/protocol.go
@@ -51,6 +51,14 @@ func (t tcpDialer) DialSqlConnection(ctx context.Context, c *Connector, p *msdsn
 	var ips []net.IP
 	ip := net.ParseIP(p.Host)
 	if ip == nil {
+		// if the dialer has been updated, the dialer may be proxying to a different network, and so the
+		// dialer should be used to connect so the DNS is resolved within the right network
+		if c != nil && c.Dialer != nil {
+			d := c.getDialer(p)
+			addr := net.JoinHostPort(p.Host, strconv.Itoa(int(resolveServerPort(p.Port))))
+			return d.DialContext(ctx, "tcp", addr)
+		}
+
 		ips, err = net.LookupIP(p.Host)
 		if err != nil {
 			return

--- a/protocol.go
+++ b/protocol.go
@@ -51,10 +51,10 @@ func (t tcpDialer) DialSqlConnection(ctx context.Context, c *Connector, p *msdsn
 	var ips []net.IP
 	ip := net.ParseIP(p.Host)
 	if ip == nil {
-		// if the dialer has been updated, the dialer may be proxying to a different network, and so the
-		// dialer should be used to connect so the DNS is resolved within the right network
-		if c != nil && c.Dialer != nil {
-			d := c.getDialer(p)
+		// if the custom dialer is a host dialer, the DNS is resolved within the network
+		// the dialer is sending the request to, rather than the one the driver is running on
+		d := c.getDialer(p)
+		if _, ok := d.(HostDialer); ok {
 			addr := net.JoinHostPort(p.Host, strconv.Itoa(int(resolveServerPort(p.Port))))
 			return d.DialContext(ctx, "tcp", addr)
 		}

--- a/tds_login_test.go
+++ b/tds_login_test.go
@@ -43,6 +43,19 @@ func (d *MockTransportDialer) DialContext(ctx context.Context, network string, a
 	return d.client, nil
 }
 
+type MockHostTransportDialer struct {
+	Dialer *MockTransportDialer
+	Host   string
+}
+
+func (m MockHostTransportDialer) DialContext(ctx context.Context, network string, addr string) (conn net.Conn, err error) {
+	return m.Dialer.DialContext(ctx, network, addr)
+}
+
+func (m MockHostTransportDialer) HostName() string {
+	return m.Host
+}
+
 func testLoginSequenceServer(result chan error, conn net.Conn, expectedPackets, responsePackets []string) {
 	defer func() {
 		conn.Close()

--- a/tds_test.go
+++ b/tds_test.go
@@ -971,3 +971,44 @@ func versionToHexString(v uint32) string {
 	binary.LittleEndian.PutUint32(b, v)
 	return hex.EncodeToString(b)
 }
+
+func TestDialSqlConnectionCustomDialer(t *testing.T) {
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
+
+	params := msdsn.Config{
+		Host: "nonexistant-dns.svc.cluster.local",
+	}
+	connector, err := NewConnector(params.URL().String())
+	if err != nil {
+		t.Error(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	// if a dialer is specified, the dialer should be used to make the connection
+	mock := NewMockTransportDialer(
+		[]string{},
+		[]string{},
+	)
+	connector.Dialer = mock
+	if mock.count != 0 {
+		t.Error("expecting no connections")
+	}
+	sqlDialer, _ := msdsn.ProtocolDialers["tcp"].(MssqlProtocolDialer)
+	conn, err := sqlDialer.DialSqlConnection(ctx, connector, &params)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if mock.count != 1 {
+		t.Error("expecting 1 connection")
+	}
+
+	err = conn.Close()
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/tds_test.go
+++ b/tds_test.go
@@ -1020,7 +1020,7 @@ func TestDialSqlConnectionCustomDialer(t *testing.T) {
 	connector.Dialer = mock
 	sqlDialer, _ = msdsn.ProtocolDialers["tcp"].(MssqlProtocolDialer)
 	_, err = sqlDialer.DialSqlConnection(ctx, connector, &params)
-	if !strings.Contains(err.Error(), "no such host") {
+	if err == nil {
 		t.Error(fmt.Errorf("dialer should not be used to resolve dns if not a host dialer"))
 	}
 }


### PR DESCRIPTION
If the custom dialer updates the transport to proxy the mssql connection, and only the proxy can reach the network that mssql is running in, then any local DNS resolution will fail.

To address this, this PR ensures the custom dialer is used, if defined, to resolve the DNS.

We've been using this logic on [Grafana's forked repo](https://github.com/grafana/go-mssqldb) for the past few months.