### PR TITLE
Fixes MarshalText and adds UnmarshalJSON interface for UniqueIdentifier

### DIFF
--- a/uniqueidentifier.go
+++ b/uniqueidentifier.go
@@ -84,11 +84,10 @@ func (u UniqueIdentifier) MarshalText() (text []byte, err error) {
 // Unmarshals a string representation of a UniqueIndentifier to bytes
 // "01234567-89AB-CDEF-0123-456789ABCDEF" -> [48, 49, 50, 51, 52, 53, 54, 55, 45, 56, 57, 65, 66, 45, 67, 68, 69, 70, 45, 48, 49, 50, 51, 45, 52, 53, 54, 55, 56, 57, 65, 66, 67, 68, 69, 70]
 func (u *UniqueIdentifier) UnmarshalJSON(b []byte) error {
-	input := string(b)
 	// remove quotes
-	input = strings.Trim(input, `"`)
+	input := strings.Trim(string(b), `"`)
 	// decode
-	bytes, err := hex.DecodeString(strings.ReplaceAll(input, "-", ""))
+	bytes, err := hex.DecodeString(strings.Replace(input, "-", "", -1))
 
 	if err != nil {
 		return err

--- a/uniqueidentifier.go
+++ b/uniqueidentifier.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 type UniqueIdentifier [16]byte
@@ -75,6 +76,25 @@ func (u UniqueIdentifier) String() string {
 
 // MarshalText converts Uniqueidentifier to bytes corresponding to the stringified hexadecimal representation of the Uniqueidentifier
 // e.g., "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" -> [65 65 65 65 65 65 65 65 45 65 65 65 65 45 65 65 65 65 45 65 65 65 65 65 65 65 65 65 65 65 65]
-func (u UniqueIdentifier) MarshalText() []byte {
-	return []byte(u.String())
+func (u UniqueIdentifier) MarshalText() (text []byte, err error) {
+	text = []byte(u.String())
+	return
+}
+
+// Unmarshals a string representation of a UniqueIndentifier to bytes
+// "01234567-89AB-CDEF-0123-456789ABCDEF" -> [48, 49, 50, 51, 52, 53, 54, 55, 45, 56, 57, 65, 66, 45, 67, 68, 69, 70, 45, 48, 49, 50, 51, 45, 52, 53, 54, 55, 56, 57, 65, 66, 67, 68, 69, 70]
+func (u *UniqueIdentifier) UnmarshalJSON(b []byte) error {
+	input := string(b)
+	// remove quotes
+	input = strings.Trim(input, `"`)
+	// decode
+	bytes, err := hex.DecodeString(strings.ReplaceAll(input, "-", ""))
+
+	if err != nil {
+		return err
+	}
+	// Copy the bytes to the UniqueIdentifier
+	copy(u[:], bytes)
+
+	return nil
 }

--- a/uniqueidentifier_test.go
+++ b/uniqueidentifier_test.go
@@ -69,8 +69,23 @@ func TestUniqueIdentifierString(t *testing.T) {
 func TestUniqueIdentifierMarshalText(t *testing.T) {
 	sut := UniqueIdentifier{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}
 	expected := []byte{48, 49, 50, 51, 52, 53, 54, 55, 45, 56, 57, 65, 66, 45, 67, 68, 69, 70, 45, 48, 49, 50, 51, 45, 52, 53, 54, 55, 56, 57, 65, 66, 67, 68, 69, 70}
-	if actual := sut.MarshalText(); !reflect.DeepEqual(actual, expected) {
+	text, _ := sut.MarshalText()
+	if actual := text; !reflect.DeepEqual(actual, expected) {
 		t.Errorf("sut.MarshalText() = %v; want %v", actual, expected)
+	}
+}
+
+func TestUniqueIdentifierUnmarshalJSON(t *testing.T) {
+	input := []byte("01234567-89AB-CDEF-0123-456789ABCDEF")
+	var u UniqueIdentifier
+
+	err := u.UnmarshalJSON(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := UniqueIdentifier{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}
+	if u != expected {
+		t.Errorf("u.UnmarshalJSON() = %v; want %v", u, expected)
 	}
 }
 


### PR DESCRIPTION
Addresses #92 
- The existing MarshalText() for the UniqueIdentifier type had a bad signature. It omitted returning an error that the interface expects.
- Added UnmarshalJSON() interface to the UniqueIdentifier type with a test as well