### PR TITLE
prep for tag 1.4

### DIFF
--- a/version.go
+++ b/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Update this variable with the release tag before pushing the tag
 // This value is written to the prelogin and login7 packets during a new connection
-const driverVersion = "v0.20.0"
+const driverVersion = "v1.4.0"
 
 func getDriverVersion(ver string) uint32 {
 	var majorVersion uint32


### PR DESCRIPTION
I've neglected updating the version number in our login packet for a few releases.
This updates it to 1.4. Once this goes in I will push the tag.
