### PR TITLE
Fix: Handle extended chars in SQL instance names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.5.0
+
+### Features
+
+### Bug fixes
+
+* Handle extended character in SQL instance names for browser lookup (#122)
+
+## 1.4.0
+
+### Features
+
+* Adds UnmarshalJSON interface for UniqueIdentifier (#126)
+
+### Bug fixes
+
+* Fixes MarshalText prototype for UniqueIdentifier
+
 ## 1.2.0
 
 ### Features

--- a/protocol.go
+++ b/protocol.go
@@ -23,9 +23,18 @@ func (t tcpDialer) ParseBrowserData(data msdsn.BrowserData, p *msdsn.Config) err
 	// for the instance and discover its port.
 	ok := len(data) > 0
 	strport := ""
+	inst := ""
 	if ok {
 		p.Instance = strings.ToUpper(p.Instance)
-		strport, ok = data[p.Instance]["tcp"]
+		instanceName := stringForInstanceNameComparison(p.Instance)
+		for _, i := range data {
+			inst, ok = i["InstanceName"]
+			if ok && stringForInstanceNameComparison(inst) == instanceName {
+				strport, ok = i["tcp"]
+				break
+			}
+			ok = false
+		}
 	}
 	if !ok {
 		f := "no instance matching '%v' returned from host '%v'"
@@ -38,6 +47,16 @@ func (t tcpDialer) ParseBrowserData(data msdsn.BrowserData, p *msdsn.Config) err
 	}
 	p.Port = port
 	return nil
+}
+
+// SQL returns ASCII encoded instance names with \x## escaped UTF16 code points.
+// We use QuoteToASCII to normalize strings like TJUTVÅ
+// SQL returns 0xc5 as the byte value for Å while the UTF8 bytes in a Go string are [195 133]
+// QuoteToASCII returns "TJUTV\u00c5" for both
+func stringForInstanceNameComparison(inst string) (instanceName string) {
+	instanceName = strings.ReplaceAll(strconv.QuoteToASCII(inst), `\u00`, `\x`)
+	instanceName = strings.ReplaceAll(instanceName, `\u`, `\x`)
+	return
 }
 
 func (t tcpDialer) DialConnection(ctx context.Context, p *msdsn.Config) (conn net.Conn, err error) {

--- a/protocol.go
+++ b/protocol.go
@@ -54,8 +54,8 @@ func (t tcpDialer) ParseBrowserData(data msdsn.BrowserData, p *msdsn.Config) err
 // SQL returns 0xc5 as the byte value for Å while the UTF8 bytes in a Go string are [195 133]
 // QuoteToASCII returns "TJUTV\u00c5" for both
 func stringForInstanceNameComparison(inst string) (instanceName string) {
-	instanceName = strings.ReplaceAll(strconv.QuoteToASCII(inst), `\u00`, `\x`)
-	instanceName = strings.ReplaceAll(instanceName, `\u`, `\x`)
+	instanceName = strings.Replace(strconv.QuoteToASCII(inst), `\u00`, `\x`, -1)
+	instanceName = strings.Replace(instanceName, `\u`, `\x`, -1)
 	return
 }
 

--- a/version.go
+++ b/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Update this variable with the release tag before pushing the tag
 // This value is written to the prelogin and login7 packets during a new connection
-const driverVersion = "v1.4.0"
+const driverVersion = "v1.5.0"
 
 func getDriverVersion(ver string) uint32 {
 	var majorVersion uint32


### PR DESCRIPTION
I couldn't find a standard package for converting the style of ASCII encoding that SQL uses into a UTF8 Go string, nor could I find something to convert from UTF8 to that ASCII byte array. `strconv.QuoteToASCII` is the only common conversion function I could find.
I was hoping to change the browser message we use to `4` which takes the instance name as parameter, but without the conversion to ASCII byte array I can use it.
