### PR TITLE
fix(CharsetToUTF8): use strings.Builder

### DIFF
--- a/internal/cp/charset.go
+++ b/internal/cp/charset.go
@@ -1,5 +1,9 @@
 package cp
 
+import (
+	"strings"
+)
+
 type charsetMap struct {
 	sb [256]rune    // single byte runes, -1 for a double byte character lead byte
 	db map[int]rune // double byte runes
@@ -91,7 +95,9 @@ func CharsetToUTF8(col Collation, s []byte) string {
 	if cm == nil {
 		return string(s)
 	}
-	buf := make([]rune, 0, len(s))
+
+	buf := strings.Builder{}
+	buf.Grow(len(s))
 	for i := 0; i < len(s); i++ {
 		ch := cm.sb[s[i]]
 		if ch == -1 {
@@ -107,7 +113,7 @@ func CharsetToUTF8(col Collation, s []byte) string {
 				}
 			}
 		}
-		buf = append(buf, ch)
+		buf.WriteRune(ch)
 	}
-	return string(buf)
+	return buf.String()
 }


### PR DESCRIPTION
This PR changes how returning string is created in `CharsetToUTF8` function.

<details>
  <summary>Code</summary>

```
import (
	"strings"
)

var str string

func CharsetToUTF8(s []byte) {
	buf := make([]rune, 0, len(s))
	for i := 0; i < len(s); i++ {
		ch := cp950.sb[s[i]]
		if ch == -1 {
			if i+1 == len(s) {
				ch = 0xfffd
			} else {
				n := int(s[i+1]) + (int(s[i]) << 8)
				i++
				var ok bool
				ch, ok = cp950.db[n]
				if !ok {
					ch = 0xfffd
				}
			}
		}
		buf = append(buf, ch)
	}
	str = string(buf)
}

func CharsetToUTF8_2(s []byte) {
	b := strings.Builder{}
	b.Grow(len(s))
	for i := 0; i < len(s); i++ {
		ch := cp950.sb[s[i]]
		if ch == -1 {
			if i+1 == len(s) {
				ch = 0xfffd
			} else {
				n := int(s[i+1]) + (int(s[i]) << 8)
				i++
				var ok bool
				ch, ok = cp950.db[n]
				if !ok {
					ch = 0xfffd
				}
			}
		}
		b.WriteRune(ch)
	}
	str = b.String()
}
```

Benchmarks:

```
import (
	"testing"
)

const (
	testStringASCII = "qwertyuiopasdfghjklzxcvbnm1234567890!@#$%^&*()"
	testStringMixed = "IUd=h'1c^-~+%He@.nCTB{uAiwq23sN)a54JyVtEp;D>m№FWo(Q0ы^]|,$$фф*(у`ыт|ипксю;лр`р{`~*йа#б~а_'юг"
)

func BenchmarkCharsetToUTF8ASCIIToString(b *testing.B) {
	bs := []byte(testStringASCII)
	for i := 0; i < b.N; i++ {
		CharsetToUTF8(bs)
	}
}

func BenchmarkCharsetToUTF8ASCIIBuilder(b *testing.B) {
	bs := []byte(testStringASCII)
	for i := 0; i < b.N; i++ {
		CharsetToUTF8_2(bs)
	}
}

func BenchmarkCharsetToUTF8MixedToString(b *testing.B) {
	bs := []byte(testStringMixed)
	for i := 0; i < b.N; i++ {
		CharsetToUTF8(bs)
	}
}

func BenchmarkCharsetToUTF8MixedBuilder(b *testing.B) {
	bs := []byte(testStringMixed)
	for i := 0; i < b.N; i++ {
		CharsetToUTF8_2(bs)
	}
}
```
</details>


Benchmarks results:

```
❯ go test -bench=. -benchmem -benchtime=10000000x
goos: darwin
goarch: amd64
pkg: benchrune
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkCharsetToUTF8ASCIIToString-12          10000000               361.5 ns/op           256 B/op          2 allocs/op
BenchmarkCharsetToUTF8ASCIIBuilder-12           10000000               196.9 ns/op            48 B/op          1 allocs/op
BenchmarkCharsetToUTF8MixedToString-12          10000000               949.6 ns/op           624 B/op          2 allocs/op
BenchmarkCharsetToUTF8MixedBuilder-12           10000000               685.1 ns/op           368 B/op          2 allocs/op
```