### PR TITLE
Replace panic with returning errors from key decryption providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+## 1.7.0
+
+### Changed
+
+* Changed always encrypted key provider error handling not to panic on failure
+
+### Features
+
+* Support DER certificates for server authentication (#152)
+
+### Bug fixes
+
+* Improved speed of CharsetToUTF8 (#154)
 
 ## 1.6.0
 

--- a/aecmk/akv/keyprovider_test.go
+++ b/aecmk/akv/keyprovider_test.go
@@ -4,6 +4,7 @@
 package akv
 
 import (
+	"context"
 	"crypto/rand"
 	"net/url"
 	"testing"
@@ -26,9 +27,13 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 	plainKey := make([]byte, 32)
 	_, _ = rand.Read(plainKey)
 	t.Log("Plainkey:", plainKey)
-	encryptedKey := p.EncryptColumnEncryptionKey(keyPath, aecmk.KeyEncryptionAlgorithm, plainKey)
-	t.Log("Encryptedkey:", encryptedKey)
-	assert.NotEqualValues(t, plainKey, encryptedKey, "encryptedKey is the same as plainKey")
-	decryptedKey := p.DecryptColumnEncryptionKey(keyPath, aecmk.KeyEncryptionAlgorithm, encryptedKey)
-	assert.Equalf(t, plainKey, decryptedKey, "decryptedkey doesn't match plainKey. %v : %v", decryptedKey, plainKey)
+	encryptedKey, err := p.EncryptColumnEncryptionKey(context.Background(), keyPath, aecmk.KeyEncryptionAlgorithm, plainKey)
+	if assert.NoError(t, err, "EncryptColumnEncryptionKey") {
+		t.Log("Encryptedkey:", encryptedKey)
+		assert.NotEqualValues(t, plainKey, encryptedKey, "encryptedKey is the same as plainKey")
+		decryptedKey, err := p.DecryptColumnEncryptionKey(context.Background(), keyPath, aecmk.KeyEncryptionAlgorithm, encryptedKey)
+		if assert.NoError(t, err, "DecryptColumnEncryptionKey") {
+			assert.Equalf(t, plainKey, decryptedKey, "decryptedkey doesn't match plainKey. %v : %v", decryptedKey, plainKey)
+		}
+	}
 }

--- a/aecmk/error.go
+++ b/aecmk/error.go
@@ -1,0 +1,39 @@
+package aecmk
+
+import "fmt"
+
+// Operation specifies the action that returned an error
+type Operation int
+
+const (
+	Decryption Operation = iota
+	Encryption
+	Validation
+)
+
+// Error is the type of all errors returned by key encryption providers
+type Error struct {
+	Operation Operation
+	err       error
+	msg       string
+}
+
+func (e *Error) Error() string {
+	return e.msg
+}
+
+func (e *Error) Unwrap() error {
+	return e.err
+}
+
+func NewError(operation Operation, msg string, err error) error {
+	return &Error{
+		Operation: operation,
+		msg:       msg,
+		err:       err,
+	}
+}
+
+func KeyPathNotAllowed(path string, operation Operation) error {
+	return NewError(operation, fmt.Sprintf("Key path not allowed:  %s", path), nil)
+}

--- a/aecmk/localcert/keyprovider.go
+++ b/aecmk/localcert/keyprovider.go
@@ -4,6 +4,7 @@
 package localcert
 
 import (
+	"context"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
@@ -11,7 +12,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -61,52 +62,65 @@ func init() {
 
 // DecryptColumnEncryptionKey decrypts the specified encrypted value of a column encryption key.
 // The encrypted value is expected to be encrypted using the column master key with the specified key path and using the specified algorithm.
-func (p *Provider) DecryptColumnEncryptionKey(masterKeyPath string, encryptionAlgorithm string, encryptedCek []byte) (decryptedKey []byte) {
+func (p *Provider) DecryptColumnEncryptionKey(ctx context.Context, masterKeyPath string, encryptionAlgorithm string, encryptedCek []byte) (decryptedKey []byte, err error) {
 	decryptedKey = nil
-	pk, cert, allowed := p.tryLoadCertificate(masterKeyPath)
-	if !allowed {
+	err = validateEncryptionAlgorithm(aecmk.Encryption, encryptionAlgorithm)
+	if err != nil {
+		return
+	}
+	err = validateKeyPathLength(aecmk.Encryption, masterKeyPath)
+	if err != nil {
+		return
+	}
+	pk, cert, err := p.tryLoadCertificate(aecmk.Decryption, masterKeyPath)
+	if err != nil {
 		return
 	}
 	cekv := ae.LoadCEKV(encryptedCek)
 	if !cekv.Verify(cert) {
-		panic(fmt.Errorf("Invalid certificate provided for decryption. Key Store Path: %s. <%s>-<%v>", masterKeyPath, cekv.KeyPath, fmt.Sprintf("%02x", sha1.Sum(cert.Raw))))
+		err = aecmk.NewError(aecmk.Decryption, fmt.Sprintf("Invalid certificate provided for decryption. Key Store Path: %s. <%s>-<%v>", masterKeyPath, cekv.KeyPath, fmt.Sprintf("%02x", sha1.Sum(cert.Raw))), nil)
 	}
 
-	decryptedKey, err := cekv.Decrypt(pk.(*rsa.PrivateKey))
+	decryptedKey, err = cekv.Decrypt(pk.(*rsa.PrivateKey))
 	if err != nil {
-		panic(err)
+		err = aecmk.NewError(aecmk.Decryption, fmt.Sprintf("Decryption failed using %s", masterKeyPath), err)
 	}
 	return
 }
 
-func (p *Provider) tryLoadCertificate(masterKeyPath string) (privateKey interface{}, cert *x509.Certificate, allowed bool) {
-	allowed = len(p.AllowedLocations) == 0
+func (p *Provider) tryLoadCertificate(op aecmk.Operation, masterKeyPath string) (privateKey interface{}, cert *x509.Certificate, err error) {
+	allowed := len(p.AllowedLocations) == 0
 	if !allowed {
 	loop:
 		for _, l := range p.AllowedLocations {
-			if l == masterKeyPath {
+			if strings.HasPrefix(masterKeyPath, l) {
 				allowed = true
 				break loop
 			}
 		}
 	}
 	if !allowed {
+		err = aecmk.KeyPathNotAllowed(masterKeyPath, op)
 		return
 	}
 	switch p.name {
 	case PfxKeyProviderName:
-		privateKey, cert = p.loadLocalCertificate(masterKeyPath)
+		privateKey, cert, err = p.loadLocalCertificate(masterKeyPath)
 	case aecmk.CertificateStoreKeyProvider:
-		privateKey, cert = p.loadWindowsCertStoreCertificate(masterKeyPath)
+		privateKey, cert, err = p.loadWindowsCertStoreCertificate(masterKeyPath)
+	}
+	if err != nil {
+		err = aecmk.NewError(op, "Unable to load certificate", err)
 	}
 	return
 }
 
-func (p *Provider) loadLocalCertificate(path string) (privateKey interface{}, cert *x509.Certificate) {
-	if f, err := os.Open(path); err == nil {
-		pfxBytes, err := ioutil.ReadAll(f)
-		if err != nil {
-			panic(invalidCertificatePath(path, err))
+func (p *Provider) loadLocalCertificate(path string) (privateKey interface{}, cert *x509.Certificate, err error) {
+	if f, e := os.Open(path); e == nil {
+		pfxBytes, er := io.ReadAll(f)
+		if er != nil {
+			err = invalidCertificatePath(path, er)
+			return
 		}
 		pwd, ok := p.passwords[path]
 		if !ok {
@@ -116,75 +130,82 @@ func (p *Provider) loadLocalCertificate(path string) (privateKey interface{}, ce
 			}
 		}
 		privateKey, cert, err = pkcs.Decode(pfxBytes, pwd)
-		if err != nil {
-			panic(err)
-		}
 	} else {
-		panic(invalidCertificatePath(path, err))
+		err = invalidCertificatePath(path, err)
 	}
 	return
 }
 
 // EncryptColumnEncryptionKey encrypts a column encryption key using the column master key with the specified key path and using the specified algorithm.
-func (p *Provider) EncryptColumnEncryptionKey(masterKeyPath string, encryptionAlgorithm string, cek []byte) []byte {
+func (p *Provider) EncryptColumnEncryptionKey(ctx context.Context, masterKeyPath string, encryptionAlgorithm string, cek []byte) (buf []byte, err error) {
 
-	validateEncryptionAlgorithm(encryptionAlgorithm)
-	validateKeyPathLength(masterKeyPath)
-	pk, cert, allowed := p.tryLoadCertificate(masterKeyPath)
-	if !allowed {
-		panic(fmt.Errorf("Key path not allowed for use in column key encryption"))
+	err = validateEncryptionAlgorithm(aecmk.Encryption, encryptionAlgorithm)
+	if err != nil {
+		return
+	}
+	err = validateKeyPathLength(aecmk.Encryption, masterKeyPath)
+	if err != nil {
+		return
+	}
+	pk, cert, err := p.tryLoadCertificate(aecmk.Encryption, masterKeyPath)
+	if err != nil {
+		return nil, err
 	}
 	publicKey := cert.PublicKey.(*rsa.PublicKey)
 	keySizeInBytes := publicKey.Size()
 
 	enc := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewEncoder()
 	// Start with version byte == 1
-	buf := []byte{byte(1)}
+	tmp := []byte{byte(1)}
 	// EncryptedColumnEncryptionKey = version + keyPathLength + ciphertextLength + keyPath + ciphertext +  signature
 	// version
 	keyPathBytes, err := enc.Bytes([]byte(strings.ToLower(masterKeyPath)))
 	if err != nil {
-		panic(fmt.Errorf("Unable to serialize key path %w", err))
+		err = aecmk.NewError(aecmk.Encryption, fmt.Sprintf("Unable to serialize key path"), err)
+		return
 	}
 	k := uint16(len(keyPathBytes))
 	// keyPathLength
-	buf = append(buf, byte(k), byte(k>>8))
+	tmp = append(tmp, byte(k), byte(k>>8))
 
 	cipherText, err := rsa.EncryptOAEP(sha1.New(), rand.Reader, publicKey, cek, []byte{})
 	if err != nil {
-		panic(fmt.Errorf("Unable to encrypt data %w", err))
+		err = aecmk.NewError(aecmk.Encryption, "Unable to encrypt data", err)
+		return
 	}
 	l := uint16(len(cipherText))
 	// ciphertextLength
-	buf = append(buf, byte(l), byte(l>>8))
+	tmp = append(tmp, byte(l), byte(l>>8))
 	// keypath
-	buf = append(buf, keyPathBytes...)
+	tmp = append(tmp, keyPathBytes...)
 	// ciphertext
-	buf = append(buf, cipherText...)
-	hash := sha256.Sum256(buf)
+	tmp = append(tmp, cipherText...)
+	hash := sha256.Sum256(tmp)
 	// signature is the signed hash of the current buf
 	sig, err := rsa.SignPKCS1v15(rand.Reader, pk.(*rsa.PrivateKey), crypto.SHA256, hash[:])
 	if err != nil {
-		panic(err)
+		err = aecmk.NewError(aecmk.Encryption, "Unable to sign encrypted data", err)
+		return
 	}
 	if len(sig) != keySizeInBytes {
-		panic("Signature length doesn't match certificate key size")
+		err = aecmk.NewError(aecmk.Encryption, "Signature length doesn't match certificate key size", nil)
+	} else {
+		buf = append(tmp, sig...)
 	}
-	buf = append(buf, sig...)
-	return buf
+	return
 }
 
 // SignColumnMasterKeyMetadata digitally signs the column master key metadata with the column master key
 // referenced by the masterKeyPath parameter. The input values used to generate the signature should be the
 // specified values of the masterKeyPath and allowEnclaveComputations parameters. May return an empty slice if not supported.
-func (p *Provider) SignColumnMasterKeyMetadata(masterKeyPath string, allowEnclaveComputations bool) []byte {
-	return nil
+func (p *Provider) SignColumnMasterKeyMetadata(ctx context.Context, masterKeyPath string, allowEnclaveComputations bool) ([]byte, error) {
+	return nil, nil
 }
 
 // VerifyColumnMasterKeyMetadata verifies the specified signature is valid for the column master key
 // with the specified key path and the specified enclave behavior. Return nil if not supported.
-func (p *Provider) VerifyColumnMasterKeyMetadata(masterKeyPath string, allowEnclaveComputations bool) *bool {
-	return nil
+func (p *Provider) VerifyColumnMasterKeyMetadata(ctx context.Context, masterKeyPath string, allowEnclaveComputations bool) (*bool, error) {
+	return nil, nil
 }
 
 // KeyLifetime is an optional Duration. Keys fetched by this provider will be discarded after their lifetime expires.
@@ -194,16 +215,18 @@ func (p *Provider) KeyLifetime() *time.Duration {
 	return nil
 }
 
-func validateEncryptionAlgorithm(encryptionAlgorithm string) {
+func validateEncryptionAlgorithm(op aecmk.Operation, encryptionAlgorithm string) error {
 	if !strings.EqualFold(encryptionAlgorithm, "RSA_OAEP") {
-		panic(fmt.Errorf("Unsupported encryption algorithm %s", encryptionAlgorithm))
+		return aecmk.NewError(op, fmt.Sprintf("Unsupported encryption algorithm %s", encryptionAlgorithm), nil)
 	}
+	return nil
 }
 
-func validateKeyPathLength(keyPath string) {
+func validateKeyPathLength(op aecmk.Operation, keyPath string) error {
 	if len(keyPath) > 32767 {
-		panic(fmt.Errorf("Key path is too long. %d", len(keyPath)))
+		return aecmk.NewError(op, fmt.Sprintf("Key path is too long. %d", len(keyPath)), nil)
 	}
+	return nil
 }
 
 // InvalidCertificatePathError indicates the provided path could not be used to load a certificate

--- a/aecmk/localcert/keyprovider.go
+++ b/aecmk/localcert/keyprovider.go
@@ -79,6 +79,7 @@ func (p *Provider) DecryptColumnEncryptionKey(ctx context.Context, masterKeyPath
 	cekv := ae.LoadCEKV(encryptedCek)
 	if !cekv.Verify(cert) {
 		err = aecmk.NewError(aecmk.Decryption, fmt.Sprintf("Invalid certificate provided for decryption. Key Store Path: %s. <%s>-<%v>", masterKeyPath, cekv.KeyPath, fmt.Sprintf("%02x", sha1.Sum(cert.Raw))), nil)
+		return
 	}
 
 	decryptedKey, err = cekv.Decrypt(pk.(*rsa.PrivateKey))
@@ -161,7 +162,7 @@ func (p *Provider) EncryptColumnEncryptionKey(ctx context.Context, masterKeyPath
 	// version
 	keyPathBytes, err := enc.Bytes([]byte(strings.ToLower(masterKeyPath)))
 	if err != nil {
-		err = aecmk.NewError(aecmk.Encryption, fmt.Sprintf("Unable to serialize key path"), err)
+		err = aecmk.NewError(aecmk.Encryption, "Unable to serialize key path", err)
 		return
 	}
 	k := uint16(len(keyPathBytes))

--- a/aecmk/localcert/keyprovider_darwin.go
+++ b/aecmk/localcert/keyprovider_darwin.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 )
 
-func (p *Provider) loadWindowsCertStoreCertificate(path string) (privateKey interface{}, cert *x509.Certificate) {
-	panic(fmt.Errorf("Windows cert store not supported on this OS"))
+func (p *Provider) loadWindowsCertStoreCertificate(path string) (privateKey interface{}, cert *x509.Certificate, err error) {
+	err = fmt.Errorf("Windows cert store not supported on this OS")
 	return
 }

--- a/aecmk/localcert/keyprovider_linux.go
+++ b/aecmk/localcert/keyprovider_linux.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 )
 
-func (p *Provider) loadWindowsCertStoreCertificate(path string) (privateKey interface{}, cert *x509.Certificate) {
-	panic(fmt.Errorf("Windows cert store not supported on this OS"))
+func (p *Provider) loadWindowsCertStoreCertificate(path string) (privateKey interface{}, cert *x509.Certificate, err error) {
+	err = fmt.Errorf("Windows cert store not supported on this OS")
 	return
 }

--- a/alwaysencrypted_test.go
+++ b/alwaysencrypted_test.go
@@ -200,9 +200,8 @@ func testProviderErrorHandling(t *testing.T, name string, provider aecmk.ColumnE
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(1*time.Hour))
 	defer cancel()
 	rows, err := conn.QueryContext(ctx, sel)
-	if err != nil {
-		defer rows.Close()
-	}
+	defer rows.Close()
+
 	if assert.NoError(t, err, "Exec should return no error") {
 		if rows.Next() {
 			assert.Fail(t, "rows.Next should have failed")

--- a/alwaysencrypted_test.go
+++ b/alwaysencrypted_test.go
@@ -1,6 +1,7 @@
 package mssql
 
 import (
+	"context"
 	"crypto/rand"
 	"database/sql"
 	"fmt"
@@ -68,6 +69,8 @@ func TestAlwaysEncryptedE2E(t *testing.T) {
 		// {"int", "INT", ColumnEncryptionDeterministic, sql.NullInt32{Valid: false}},
 	}
 	for _, test := range providerTests {
+		// turn off key caching
+		aecmk.ColumnEncryptionKeyLifetime = 0
 		t.Run(test.Name(), func(t *testing.T) {
 			conn, _ := open(t)
 			defer conn.Close()
@@ -86,9 +89,10 @@ func TestAlwaysEncryptedE2E(t *testing.T) {
 			tableName := fmt.Sprintf("mssqlAe%d", r.Int64())
 			keyBytes := make([]byte, 32)
 			_, _ = rand.Read(keyBytes)
-			encryptedCek := test.GetProvider(t).EncryptColumnEncryptionKey(certPath, KeyEncryptionAlgorithm, keyBytes)
+			encryptedCek, err := test.GetProvider(t).EncryptColumnEncryptionKey(context.Background(), certPath, KeyEncryptionAlgorithm, keyBytes)
+			assert.NoError(t, err, "Encrypt")
 			createCek := fmt.Sprintf(createColumnEncryptionKey, cekName, certPath, encryptedCek)
-			_, err := conn.Exec(createCek)
+			_, err = conn.Exec(createCek)
 			assert.NoError(t, err, "Unable to create CEK")
 			defer func() {
 				_, err := conn.Exec(fmt.Sprintf(dropColumnEncryptionKey, cekName))
@@ -178,8 +182,39 @@ func TestAlwaysEncryptedE2E(t *testing.T) {
 			_ = rows.Next()
 			err = rows.Err()
 			assert.NoError(t, err, "rows.Err() has non-nil values")
+			testProviderErrorHandling(t, test.Name(), test.GetProvider(t), sel.String(), insert.String(), insertArgs)
 		})
 	}
+}
+
+func testProviderErrorHandling(t *testing.T, name string, provider aecmk.ColumnEncryptionKeyProvider, sel string, insert string, insertArgs []interface{}) {
+	t.Helper()
+	testProvider := &testKeyProvider{fallback: provider}
+	connector, _ := getTestConnector(t)
+	connector.RegisterCekProvider(name, testProvider)
+	conn := sql.OpenDB(connector)
+	defer conn.Close()
+	testProvider.decrypt = func(ctx context.Context, masterKeyPath string, encryptionAlgorithm string, cek []byte) ([]byte, error) {
+		return nil, context.DeadlineExceeded
+	}
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(1*time.Hour))
+	defer cancel()
+	rows, err := conn.QueryContext(ctx, sel)
+	if assert.NoError(t, err, "Exec should return no error") {
+		if rows.Next() {
+			assert.Fail(t, "rows.Next should have failed")
+		}
+		assert.ErrorIs(t, rows.Err(), context.DeadlineExceeded)
+	}
+
+	var notAllowed error
+	testProvider.decrypt = func(ctx context.Context, masterKeyPath string, encryptionAlgorithm string, cek []byte) ([]byte, error) {
+		notAllowed = aecmk.KeyPathNotAllowed(masterKeyPath, aecmk.Decryption)
+		return nil, notAllowed
+	}
+	_, err = conn.Exec(insert, insertArgs...)
+	assert.ErrorIs(t, err, notAllowed, "Insert should fail with key path not allowed")
+
 }
 
 func comparisonValueFromObject(object interface{}) string {
@@ -221,3 +256,45 @@ const (
 				COLUMN_ENCRYPTION_KEY = [%s])
 		)`
 )
+
+// Parameterized implementation of a key provider
+type testKeyProvider struct {
+	encrypt  func(ctx context.Context, masterKeyPath string, encryptionAlgorithm string, cek []byte) ([]byte, error)
+	decrypt  func(ctx context.Context, masterKeyPath string, encryptionAlgorithm string, encryptedCek []byte) ([]byte, error)
+	lifetime *time.Duration
+	fallback aecmk.ColumnEncryptionKeyProvider
+}
+
+func (p *testKeyProvider) DecryptColumnEncryptionKey(ctx context.Context, masterKeyPath string, encryptionAlgorithm string, encryptedCek []byte) (decryptedKey []byte, err error) {
+	if p.decrypt != nil {
+		return p.decrypt(ctx, masterKeyPath, encryptionAlgorithm, encryptedCek)
+	}
+	return p.fallback.DecryptColumnEncryptionKey(ctx, masterKeyPath, encryptionAlgorithm, encryptedCek)
+}
+
+func (p *testKeyProvider) EncryptColumnEncryptionKey(ctx context.Context, masterKeyPath string, encryptionAlgorithm string, cek []byte) ([]byte, error) {
+	if p.encrypt != nil {
+		return p.encrypt(ctx, masterKeyPath, encryptionAlgorithm, cek)
+	}
+	return p.fallback.EncryptColumnEncryptionKey(ctx, masterKeyPath, encryptionAlgorithm, cek)
+}
+
+func (p *testKeyProvider) SignColumnMasterKeyMetadata(ctx context.Context, masterKeyPath string, allowEnclaveComputations bool) ([]byte, error) {
+	return nil, nil
+}
+
+// VerifyColumnMasterKeyMetadata verifies the specified signature is valid for the column master key
+// with the specified key path and the specified enclave behavior. Return nil if not supported.
+func (p *testKeyProvider) VerifyColumnMasterKeyMetadata(ctx context.Context, masterKeyPath string, allowEnclaveComputations bool) (*bool, error) {
+	return nil, nil
+}
+
+// KeyLifetime is an optional Duration. Keys fetched by this provider will be discarded after their lifetime expires.
+// If it returns nil, the keys will expire based on the value of ColumnEncryptionKeyLifetime.
+// If it returns zero, the keys will not be cached.
+func (p *testKeyProvider) KeyLifetime() *time.Duration {
+	if p.lifetime != nil {
+		return p.lifetime
+	}
+	return p.fallback.KeyLifetime()
+}

--- a/alwaysencrypted_test.go
+++ b/alwaysencrypted_test.go
@@ -200,7 +200,9 @@ func testProviderErrorHandling(t *testing.T, name string, provider aecmk.ColumnE
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(1*time.Hour))
 	defer cancel()
 	rows, err := conn.QueryContext(ctx, sel)
-	defer rows.Close()
+	if err != nil {
+		defer rows.Close()
+	}
 	if assert.NoError(t, err, "Exec should return no error") {
 		if rows.Next() {
 			assert.Fail(t, "rows.Next should have failed")

--- a/alwaysencrypted_test.go
+++ b/alwaysencrypted_test.go
@@ -200,6 +200,7 @@ func testProviderErrorHandling(t *testing.T, name string, provider aecmk.ColumnE
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(1*time.Hour))
 	defer cancel()
 	rows, err := conn.QueryContext(ctx, sel)
+	defer rows.Close()
 	if assert.NoError(t, err, "Exec should return no error") {
 		if rows.Next() {
 			assert.Fail(t, "rows.Next should have failed")

--- a/internal/certs/certs_windows.go
+++ b/internal/certs/certs_windows.go
@@ -15,9 +15,8 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func FindCertBySignatureHash(storeHandle windows.Handle, hash []byte) (interface{}, *x509.Certificate) {
+func FindCertBySignatureHash(storeHandle windows.Handle, hash []byte) (pk interface{}, cert *x509.Certificate, err error) {
 	var certContext *windows.CertContext
-	var err error
 	cryptoAPIBlob := windows.CryptHashBlob{
 		Size: uint32(len(hash)),
 		Data: &hash[0],
@@ -32,15 +31,11 @@ func FindCertBySignatureHash(storeHandle windows.Handle, hash []byte) (interface
 		nil)
 
 	if err != nil {
-
-		panic(fmt.Errorf("Unable to find certificate by signature hash. %s", err.Error()))
+		err = fmt.Errorf("Unable to find certificate by signature hash. %w", err)
+		return
 	}
-	pk, cert, err := certContextToX509(certContext)
-	if err != nil {
-		panic(err)
-	}
-
-	return pk, cert
+	pk, cert, err = certContextToX509(certContext)
+	return
 }
 
 func certContextToX509(ctx *windows.CertContext) (pk interface{}, cert *x509.Certificate, err error) {

--- a/tds_go110_test.go
+++ b/tds_go110_test.go
@@ -22,5 +22,5 @@ func getTestConnector(t testing.TB) (*Connector, *testLogger) {
 		t.Error("Open connection failed:", err.Error())
 		return nil, &tl
 	}
-	return connector, nil
+	return connector, &tl
 }

--- a/tds_go110_test.go
+++ b/tds_go110_test.go
@@ -1,3 +1,4 @@
+//go:build go1.10
 // +build go1.10
 
 package mssql
@@ -8,6 +9,12 @@ import (
 )
 
 func open(t testing.TB) (*sql.DB, *testLogger) {
+	connector, logger := getTestConnector(t)
+	conn := sql.OpenDB(connector)
+	return conn, logger
+}
+
+func getTestConnector(t testing.TB) (*Connector, *testLogger) {
 	tl := testLogger{t: t}
 	SetLogger(&tl)
 	connector, err := NewConnector(makeConnStr(t).String())
@@ -15,6 +22,5 @@ func open(t testing.TB) (*sql.DB, *testLogger) {
 		t.Error("Open connection failed:", err.Error())
 		return nil, &tl
 	}
-	conn := sql.OpenDB(connector)
-	return conn, &tl
+	return connector, nil
 }

--- a/token.go
+++ b/token.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 
 	"github.com/golang-sql/sqlexp"
+	"github.com/microsoft/go-mssqldb/aecmk"
 	"github.com/microsoft/go-mssqldb/internal/github.com/swisscom/mssql-always-encrypted/pkg/algorithms"
 	"github.com/microsoft/go-mssqldb/internal/github.com/swisscom/mssql-always-encrypted/pkg/encryption"
 	"github.com/microsoft/go-mssqldb/internal/github.com/swisscom/mssql-always-encrypted/pkg/keys"
@@ -694,7 +695,7 @@ func parseCryptoMetadata(r *tdsBuffer, cekTable *cekTable) cryptoMetadata {
 
 	if cekTable != nil {
 		if int(ordinal) > len(cekTable.entries)-1 {
-			panic(fmt.Errorf("invalid ordinal, cekTable only has %d entries", len(cekTable.entries)))
+			badStreamPanicf("invalid ordinal, cekTable only has %d entries", len(cekTable.entries))
 		}
 		entry = &cekTable.entries[ordinal]
 	}
@@ -732,7 +733,7 @@ func readCekTableEntry(r *tdsBuffer) cekTableEntry {
 	var cekMdVersion = make([]byte, 8)
 	_, err := r.Read(cekMdVersion)
 	if err != nil {
-		panic("unable to read cekMdVersion")
+		badStreamPanicf("unable to read cekMdVersion")
 	}
 
 	cekValueCount := uint(r.byte())
@@ -784,7 +785,7 @@ func readCekTableEntry(r *tdsBuffer) cekTableEntry {
 }
 
 // http://msdn.microsoft.com/en-us/library/dd357254.aspx
-func parseRow(r *tdsBuffer, s *tdsSession, columns []columnStruct, row []interface{}) {
+func parseRow(ctx context.Context, r *tdsBuffer, s *tdsSession, columns []columnStruct, row []interface{}) error {
 	for i, column := range columns {
 		columnContent := column.ti.Reader(&column.ti, r, nil)
 		if columnContent == nil {
@@ -793,13 +794,17 @@ func parseRow(r *tdsBuffer, s *tdsSession, columns []columnStruct, row []interfa
 		}
 
 		if column.isEncrypted() {
-			buffer := decryptColumn(column, s, columnContent)
+			buffer, err := decryptColumn(ctx, column, s, columnContent)
+			if err != nil {
+				return err
+			}
 			// Decrypt
-			row[i] = column.cryptoMeta.typeInfo.Reader(&column.cryptoMeta.typeInfo, &buffer, column.cryptoMeta)
+			row[i] = column.cryptoMeta.typeInfo.Reader(&column.cryptoMeta.typeInfo, buffer, column.cryptoMeta)
 		} else {
 			row[i] = columnContent
 		}
 	}
+	return nil
 }
 
 type RWCBuffer struct {
@@ -818,7 +823,7 @@ func (R RWCBuffer) Close() error {
 	return nil
 }
 
-func decryptColumn(column columnStruct, s *tdsSession, columnContent interface{}) tdsBuffer {
+func decryptColumn(ctx context.Context, column columnStruct, s *tdsSession, columnContent interface{}) (*tdsBuffer, error) {
 	encType := encryption.From(column.cryptoMeta.encType)
 	cekValue := column.cryptoMeta.entry.cekValues[column.cryptoMeta.ordinal]
 	if (s.logFlags & uint64(msdsn.LogDebug)) == uint64(msdsn.LogDebug) {
@@ -827,17 +832,18 @@ func decryptColumn(column columnStruct, s *tdsSession, columnContent interface{}
 
 	cekProvider, ok := s.aeSettings.keyProviders[cekValue.keyStoreName]
 	if !ok {
-		panic(fmt.Errorf("Unable to find provider %s to decrypt CEK", cekValue.keyStoreName))
+		// The app hasn't installed the key provider it needs
+		panic(aecmk.NewError(aecmk.Decryption, fmt.Sprintf("Unable to find provider %s to decrypt CEK", cekValue.keyStoreName), nil))
 	}
-	cek, err := cekProvider.GetDecryptedKey(cekValue.keyPath, column.cryptoMeta.entry.cekValues[0].encryptedKey)
+	cek, err := cekProvider.GetDecryptedKey(ctx, cekValue.keyPath, column.cryptoMeta.entry.cekValues[0].encryptedKey)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	k := keys.NewAeadAes256CbcHmac256(cek)
 	alg := algorithms.NewAeadAes256CbcHmac256Algorithm(k, encType, byte(cekValue.cekVersion))
 	d, err := alg.Decrypt(columnContent.([]byte))
 	if err != nil {
-		panic(err)
+		return nil, aecmk.NewError(aecmk.Decryption, "Unable to decrypt key using AES256", err)
 	}
 
 	// Decrypt returns a minimum of 8 bytes so truncate to the actual data size
@@ -853,11 +859,11 @@ func decryptColumn(column columnStruct, s *tdsSession, columnContent interface{}
 
 	column.cryptoMeta.typeInfo.Buffer = d
 	buffer := tdsBuffer{rpos: 0, rsize: len(newBuff), rbuf: newBuff, transport: rwc}
-	return buffer
+	return &buffer, nil
 }
 
 // http://msdn.microsoft.com/en-us/library/dd304783.aspx
-func parseNbcRow(r *tdsBuffer, s *tdsSession, columns []columnStruct, row []interface{}) {
+func parseNbcRow(ctx context.Context, r *tdsBuffer, s *tdsSession, columns []columnStruct, row []interface{}) error {
 	bitlen := (len(columns) + 7) / 8
 	pres := make([]byte, bitlen)
 	r.ReadFull(pres)
@@ -868,14 +874,17 @@ func parseNbcRow(r *tdsBuffer, s *tdsSession, columns []columnStruct, row []inte
 		}
 		columnContent := col.ti.Reader(&col.ti, r, nil)
 		if col.isEncrypted() {
-			buffer := decryptColumn(col, s, columnContent)
+			buffer, err := decryptColumn(ctx, col, s, columnContent)
+			if err != nil {
+				return err
+			}
 			// Decrypt
-			row[i] = col.cryptoMeta.typeInfo.Reader(&col.cryptoMeta.typeInfo, &buffer, col.cryptoMeta)
+			row[i] = col.cryptoMeta.typeInfo.Reader(&col.cryptoMeta.typeInfo, buffer, col.cryptoMeta)
 		} else {
 			row[i] = columnContent
 		}
-
 	}
+	return nil
 }
 
 // http://msdn.microsoft.com/en-us/library/dd304156.aspx
@@ -1079,11 +1088,19 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 
 		case tokenRow:
 			row := make([]interface{}, len(columns))
-			parseRow(sess.buf, sess, columns, row)
+			err = parseRow(ctx, sess.buf, sess, columns, row)
+			if err != nil {
+				ch <- err
+				return
+			}
 			ch <- row
 		case tokenNbcRow:
 			row := make([]interface{}, len(columns))
-			parseNbcRow(sess.buf, sess, columns, row)
+			err = parseNbcRow(ctx, sess.buf, sess, columns, row)
+			if err != nil {
+				ch <- err
+				return
+			}
 			ch <- row
 		case tokenEnvChange:
 			processEnvChg(ctx, sess)

--- a/version.go
+++ b/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Update this variable with the release tag before pushing the tag
 // This value is written to the prelogin and login7 packets during a new connection
-const driverVersion = "v1.6.0"
+const driverVersion = "v1.7.0"
 
 func getDriverVersion(ver string) uint32 {
 	var majorVersion uint32


### PR DESCRIPTION
 - Pass along the `context` for running queries so key decryption participates in timeouts etc
 - Return errors from the key providers directly instead of panicking
 - Prep for v1.7
Fixes #144 