### PR TITLE
fix: Added multisubnetfailover option, set to false to prevent issue #158

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Other supported formats are listed below.
 * `ApplicationIntent` - Can be given the value `ReadOnly` to initiate a read-only connection to an Availability Group listener. The `database` must be specified when connecting with `Application Intent` set to `ReadOnly`.
 * `protocol` - forces use of a protocol. Make sure the corresponding package is imported.
 * `columnencryption` or `column encryption setting` - a boolean value indicating whether Always Encrypted should be enabled on the connection.
+* `multisubnetfailover`
+  * `true` (Default) Client attempt to connect to all IPs simultaneously. 
+  * `false` Client attempts to connect to IPs in serial.
 
 ### Connection parameters for namedpipe package
 * `pipe`  - If set, no Browser query is made and named pipe used will be `\\<host>\pipe\<pipe>`

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -25,6 +25,7 @@ func TestInvalidConnectionString(t *testing.T) {
 		"failoverport=invalid",
 		"applicationintent=ReadOnly",
 		"disableretry=invalid",
+		"multisubnetfailover=invalid",
 
 		// ODBC mode
 		"odbc:password={",
@@ -104,6 +105,8 @@ func TestValidConnectionString(t *testing.T) {
 		{"disableretry=1", func(p Config) bool { return p.DisableRetry }},
 		{"disableretry=0", func(p Config) bool { return !p.DisableRetry }},
 		{"", func(p Config) bool { return p.DisableRetry == disableRetryDefault }},
+		{"MultiSubnetFailover=true", func(p Config) bool { return p.MultiSubnetFailover }},
+		{"MultiSubnetFailover=false", func(p Config) bool { return !p.MultiSubnetFailover }},
 
 		// those are supported currently, but maybe should not be
 		{"someparam", func(p Config) bool { return true }},

--- a/protocol.go
+++ b/protocol.go
@@ -69,12 +69,14 @@ func (t tcpDialer) DialConnection(ctx context.Context, p *msdsn.Config) (conn ne
 func (t tcpDialer) DialSqlConnection(ctx context.Context, c *Connector, p *msdsn.Config) (conn net.Conn, err error) {
 	var ips []net.IP
 	ip := net.ParseIP(p.Host)
+	portStr := strconv.Itoa(int(resolveServerPort(p.Port)))
+
 	if ip == nil {
 		// if the custom dialer is a host dialer, the DNS is resolved within the network
 		// the dialer is sending the request to, rather than the one the driver is running on
 		d := c.getDialer(p)
 		if _, ok := d.(HostDialer); ok {
-			addr := net.JoinHostPort(p.Host, strconv.Itoa(int(resolveServerPort(p.Port))))
+			addr := net.JoinHostPort(p.Host, portStr)
 			return d.DialContext(ctx, "tcp", addr)
 		}
 
@@ -85,11 +87,12 @@ func (t tcpDialer) DialSqlConnection(ctx context.Context, c *Connector, p *msdsn
 	} else {
 		ips = []net.IP{ip}
 	}
+
 	if len(ips) == 1 || !p.MultiSubnetFailover {
 		// Try to connect to IPs sequentially until one is successful per MultiSubnetFailover false rules
 		for _, ipaddress := range ips {
 			d := c.getDialer(p)
-			addr := net.JoinHostPort(ipaddress.String(), strconv.Itoa(int(resolveServerPort(p.Port))))
+			addr := net.JoinHostPort(ipaddress.String(), portStr)
 			conn, err = d.DialContext(ctx, "tcp", addr)
 			if err == nil {
 				break
@@ -99,7 +102,7 @@ func (t tcpDialer) DialSqlConnection(ctx context.Context, c *Connector, p *msdsn
 		//Try Dials in parallel to avoid waiting for timeouts.
 		connChan := make(chan net.Conn, len(ips))
 		errChan := make(chan error, len(ips))
-		portStr := strconv.Itoa(int(resolveServerPort(p.Port)))
+
 		for _, ip := range ips {
 			go func(ip net.IP) {
 				d := c.getDialer(p)


### PR DESCRIPTION
Fixes #158 if the connection string sets multisubnetfailover to false.  

I believe most other libraries default this to false but to prevent a breaking change I kept the current behavior (defaulted to true).  
