### PR TITLE
Change returned reflect.Value in Rows.ColumnTypeScanType to UniqueIdentifer for GUID types

### DIFF
--- a/types.go
+++ b/types.go
@@ -1124,7 +1124,7 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 	case typeNChar:
 		return reflect.TypeOf("")
 	case typeGuid:
-		return reflect.TypeOf([]byte{})
+		return reflect.TypeOf(UniqueIdentifier{})
 	case typeXml:
 		return reflect.TypeOf("")
 	case typeText:


### PR DESCRIPTION
The Rows.ColumnScanType is returning `reflect.TypeOf([]byte{})` for GUID types (`typeGuid`). This changes it so that it instead returns `reflect.TypeOf(UniqueIdentifier{})`, which has the knock down effects of using packages being able to correctly ascertain the column type for for `UniqueIdentifier`'s.

This is needed for use by `usql` (see xo/usql#439) in order to correctly format/display GUIDs cleanly and as users expect.