### PR TITLE
Fix named pipe path handling to preserve "."

### DIFF
--- a/namedpipe/namepipe_windows_test.go
+++ b/namedpipe/namepipe_windows_test.go
@@ -1,0 +1,54 @@
+package namedpipe
+
+import (
+	"testing"
+
+	"github.com/microsoft/go-mssqldb/msdsn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseServer(t *testing.T) {
+	c := &msdsn.Config{
+		Port: 1000,
+	}
+	n := &namedPipeDialer{}
+	err := n.ParseServer("server", c)
+	assert.Errorf(t, err, "ParseServer with a Port")
+
+	c = &msdsn.Config{
+		Parameters:         make(map[string]string),
+		ProtocolParameters: make(map[string]interface{}),
+	}
+	err = n.ParseServer(`\\.\pipe\MSSQL$Instance\sql\query`, c)
+	assert.NoError(t, err, "ParseServer with a full pipe name")
+	assert.Equal(t, "", c.Host, "Config Host with a full pipe name")
+
+	c = &msdsn.Config{
+		Parameters:         make(map[string]string),
+		ProtocolParameters: make(map[string]interface{}),
+	}
+	err = n.ParseServer(`.\instance`, c)
+	assert.NoError(t, err, "ParseServer .")
+	assert.Equal(t, "localhost", c.Host, `Config Host with server == .\instance`)
+	assert.Equal(t, "instance", c.Instance, `Config Instance with server == .\instance`)
+	_, ok := c.ProtocolParameters[n.Protocol()]
+	assert.Equal(t, ok, false, "Should have no namedPipeData when pipe name omitted")
+
+	c = &msdsn.Config{
+		Host:               "server",
+		Parameters:         make(map[string]string),
+		ProtocolParameters: make(map[string]interface{}),
+	}
+	c.Parameters["pipe"] = `myinstance\sql\query`
+	err = n.ParseServer(`anything`, c)
+	assert.NoError(t, err, "ParseServer anything")
+	data, ok := c.ProtocolParameters[n.Protocol()]
+	assert.True(t, ok, "Should have added ProtocolParameters when pipe name is provided")
+	switch d := data.(type) {
+	case namedPipeData:
+		assert.Equal(t, `\\server\pipe\myinstance\sql\query`, d.PipeName, "Pipe name in ProtocolParameters")
+	default:
+		assert.Fail(t, "Incorrect protocol parameters type:", d)
+	}
+
+}


### PR DESCRIPTION
Fix for https://github.com/microsoft/go-sqlcmd/issues/506

Sqlcmd converts the named pipe given by the user into its component parts to include in a URL connection string it hands to the driver.  When the named pipe path uses `.` as the server name, the driver converts it to `localhost` so connections to the browser service work. However, for some named pipe SQL connections like those to Windows Internal Database, the reconstructed pipe name has to use `.` as the server component. 

This change preserves `.` in the pipe name while still switching to `localhost` for the SQL browser calls.

Built sqlcmd with a local version of the driver with this fix:
```
C:\git\go-sqlcmd\cmd\modern>modern -S np:\\.\pipe\microsoft##wid\tsql\query -Q "select @@version"
                                                                                                                                                                                                                                                
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Microsoft SQL Server 2014 (SP2-GDR) (KB4057120) - 12.0.5214.6 (X64)
        Jan  9 2018 15:03:12
        Copyright (c) Microsoft Corporation
        Windows Internal Database (64-bit) on Windows NT 6.3 <X64> (Build 17763: ) (Hypervisor)


(1 row affected)
```