### PR TITLE
Fix: Support nullable types in Always Encrypted

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,9 +427,8 @@ If the correct key provider is included in your application, decryption of encry
 
 Encryption of parameters passed to `Exec` and `Query` variants requires an extra round trip per query to fetch the encryption metadata. If the error returned by a query attempt indicates a type mismatch between the parameter and the destination table, most likely your input type is not a strict match for the SQL Server data type of the destination. You may be using a Go `string` when you need to use one of the driver-specific aliases like `VarChar` or `NVarCharMax`.
 
-*** NOTE *** - Currently `char` and `varchar` types do not include a collation parameter component so can't be used for inserting encrypted values. Also, using a nullable sql package type like `sql.NullableInt32` to pass a `NULL` value for an encrypted column will not work unless the encrypted column type is `nvarchar`. 
+*** NOTE *** - Currently `char` and `varchar` types do not include a collation parameter component so can't be used for inserting encrypted values. 
 https://github.com/microsoft/go-mssqldb/issues/129
-https://github.com/microsoft/go-mssqldb/issues/130
 
 
 ### Local certificate AE key provider

--- a/alwaysencrypted_test.go
+++ b/alwaysencrypted_test.go
@@ -67,7 +67,9 @@ func TestAlwaysEncryptedE2E(t *testing.T) {
 		{"datetime2(7)", "DATETIME2", ColumnEncryptionDeterministic, civil.DateTimeOf(dt)},
 		{"nvarchar(max)", "NVARCHAR", ColumnEncryptionRandomized, NVarCharMax("nvarcharmaxval")},
 		{"int", "INT", ColumnEncryptionDeterministic, sql.NullInt32{Valid: false}},
-		{"int", "INT", ColumnEncryptionDeterministic, sql.NullInt64{Int64: 128, Valid: true}},
+		{"bigint", "BIGINT", ColumnEncryptionDeterministic, sql.NullInt64{Int64: 128, Valid: true}},
+		{"uniqueidentifier", "UNIQUEIDENTIFIER", ColumnEncryptionRandomized, UniqueIdentifier{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF}},
+		{"uniqueidentifier", "UNIQUEIDENTIFIER", ColumnEncryptionRandomized, NullUniqueIdentifier{Valid: false}},
 	}
 	for _, test := range providerTests {
 		// turn off key caching
@@ -231,8 +233,6 @@ func comparisonValueFromObject(object interface{}) string {
 	case time.Time:
 		return civil.DateTimeOf(v).String()
 		//return v.Format(time.RFC3339)
-	case fmt.Stringer:
-		return v.String()
 	case bool:
 		if v == true {
 			return "1"
@@ -244,6 +244,8 @@ func comparisonValueFromObject(object interface{}) string {
 			return "<nil>"
 		}
 		return comparisonValueFromObject(val)
+	case fmt.Stringer:
+		return v.String()
 	default:
 		return fmt.Sprintf("%v", v)
 	}

--- a/mssql.go
+++ b/mssql.go
@@ -982,6 +982,17 @@ func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 		res.ti.Size = 0
 		return
 	}
+	// If the value has a non-nil value, call MakeParam on its Value
+	if valuer, ok := val.(driver.Valuer); ok {
+		val, e := driver.DefaultParameterConverter.ConvertValue(valuer)
+		if e != nil {
+			err = e
+			return
+		}
+		if val != nil {
+			return s.makeParam(val)
+		}
+	}
 	switch val := val.(type) {
 	case int:
 		res.ti.TypeId = typeIntN
@@ -1020,6 +1031,10 @@ func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 		// only null values should be getting here
 		res.ti.TypeId = typeIntN
 		res.ti.Size = 8
+		res.buffer = []byte{}
+	case sql.NullInt32:
+		res.ti.TypeId = typeIntN
+		res.ti.Size = 4
 		res.buffer = []byte{}
 	case byte:
 		res.ti.TypeId = typeIntN

--- a/mssql_go19.go
+++ b/mssql_go19.go
@@ -75,6 +75,8 @@ func convertInputParameter(val interface{}) (interface{}, error) {
 	// 	return nil
 	case float32:
 		return val, nil
+	case driver.Valuer:
+		return val, nil
 	default:
 		return driver.DefaultParameterConverter.ConvertValue(v)
 	}

--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -46,10 +46,6 @@ func TestOutputParam(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer db.ExecContext(ctx, sqltextdrop)
-		if err != nil {
-			t.Error(err)
-		}
-
 		nullstr := sql.NullString{}
 		_, err := db.ExecContext(ctx, sqltextrun,
 			sql.Named("strparam", sql.Out{Dest: &nullstr}),

--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,6 +32,36 @@ func TestOutputParam(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	t.Run("varchar(max) to sql.NullString", func(t *testing.T) {
+		sqltextcreate := `CREATE PROCEDURE [GetTask]
+		@strparam varchar(max) = NULL OUTPUT
+	AS
+	SELECT @strparam = REPLICATE('a', 8000)
+	RETURN 0`
+		sqltextdrop := `drop procedure GetTask`
+		sqltextrun := `GetTask`
+		_, _ = db.ExecContext(ctx, sqltextdrop)
+		_, err = db.ExecContext(ctx, sqltextcreate)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.ExecContext(ctx, sqltextdrop)
+		if err != nil {
+			t.Error(err)
+		}
+
+		nullstr := sql.NullString{}
+		_, err := db.ExecContext(ctx, sqltextrun,
+			sql.Named("strparam", sql.Out{Dest: &nullstr}),
+		)
+		if err != nil {
+			t.Error(err)
+		}
+		defer db.ExecContext(ctx, sqltextdrop)
+		if nullstr.String != strings.Repeat("a", 8000) {
+			t.Error("Got incorrect NullString of length:", len(nullstr.String))
+		}
+	})
 	t.Run("sp with rows", func(t *testing.T) {
 		sqltextcreate := `
 CREATE PROCEDURE spwithrows

--- a/queries_test.go
+++ b/queries_test.go
@@ -198,6 +198,19 @@ func TestSelect(t *testing.T) {
 			}
 		})
 	})
+	t.Run("scan into sql.NullString", func(t *testing.T) {
+		row := conn.QueryRow("SELECT REPLICATE('a', 8000)")
+		var out sql.NullString
+		err := row.Scan(&out)
+		if err != nil {
+			t.Error("Scan to NullString failed", err.Error())
+			return
+		}
+
+		if out.String != strings.Repeat("a", 8000) {
+			t.Error("got back a string with count:", len(out.String))
+		}
+	})
 }
 
 func TestSelectDateTimeOffset(t *testing.T) {


### PR DESCRIPTION
Previously the driver would use `char(1)` as the parameter declaration for all null-valued parameters. This change preserves type information for `driver.Valuer` implementations. It has the additional benefit of declaring guid parameters as `uniqueidentifier` type instead of `varbinary[16]`.