### PR TITLE
Feature: Support for DSN flag - sendStringParametersAsUnicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Other supported formats are listed below.
 * `multisubnetfailover`
   * `true` (Default) Client attempt to connect to all IPs simultaneously. 
   * `false` Client attempts to connect to IPs in serial.
+* `sendStringParametersAsUnicode`
+  * `true` (Default) Go default string types sent as `nvarchar`.
+  * `false` Go default string types sent as `varchar`.
 
 ### Connection parameters for namedpipe package
 * `pipe`  - If set, no Browser query is made and named pipe used will be `\\<host>\pipe\<pipe>`
@@ -371,7 +374,7 @@ To pass specific types to the query parameters, say `varchar` or `date` types,
 you must convert the types to the type before passing in. The following types
 are supported:
 
-* string -> nvarchar
+* string -> nvarchar(by default, will be varchar if `sendStringParametersAsUnicode` is set to true)
 * mssql.VarChar -> varchar
 * time.Time -> datetimeoffset or datetime (TDS version dependent)
 * mssql.DateTime1 -> datetime

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -53,32 +53,33 @@ const (
 )
 
 const (
-	Database               = "database"
-	Encrypt                = "encrypt"
-	Password               = "password"
-	ChangePassword         = "change password"
-	UserID                 = "user id"
-	Port                   = "port"
-	TrustServerCertificate = "trustservercertificate"
-	Certificate            = "certificate"
-	TLSMin                 = "tlsmin"
-	PacketSize             = "packet size"
-	LogParam               = "log"
-	ConnectionTimeout      = "connection timeout"
-	HostNameInCertificate  = "hostnameincertificate"
-	KeepAlive              = "keepalive"
-	ServerSpn              = "serverspn"
-	WorkstationID          = "workstation id"
-	AppName                = "app name"
-	ApplicationIntent      = "applicationintent"
-	FailoverPartner        = "failoverpartner"
-	FailOverPort           = "failoverport"
-	DisableRetry           = "disableretry"
-	Server                 = "server"
-	Protocol               = "protocol"
-	DialTimeout            = "dial timeout"
-	Pipe                   = "pipe"
-	MultiSubnetFailover    = "multisubnetfailover"
+	Database                      = "database"
+	Encrypt                       = "encrypt"
+	Password                      = "password"
+	ChangePassword                = "change password"
+	UserID                        = "user id"
+	Port                          = "port"
+	TrustServerCertificate        = "trustservercertificate"
+	Certificate                   = "certificate"
+	TLSMin                        = "tlsmin"
+	PacketSize                    = "packet size"
+	LogParam                      = "log"
+	ConnectionTimeout             = "connection timeout"
+	HostNameInCertificate         = "hostnameincertificate"
+	KeepAlive                     = "keepalive"
+	ServerSpn                     = "serverspn"
+	WorkstationID                 = "workstation id"
+	AppName                       = "app name"
+	ApplicationIntent             = "applicationintent"
+	FailoverPartner               = "failoverpartner"
+	FailOverPort                  = "failoverport"
+	DisableRetry                  = "disableretry"
+	Server                        = "server"
+	Protocol                      = "protocol"
+	DialTimeout                   = "dial timeout"
+	Pipe                          = "pipe"
+	MultiSubnetFailover           = "multisubnetfailover"
+	SendStringParametersAsUnicode = "sendstringparametersasunicode"
 )
 
 type Config struct {
@@ -131,6 +132,9 @@ type Config struct {
 	ColumnEncryption bool
 	// Attempt to connect to all IPs in parallel when MultiSubnetFailover is true
 	MultiSubnetFailover bool
+
+	// Sets a boolean value that indicates if sending string parameters to the server in UNICODE format is enabled.
+	SendStringParametersAsUnicode bool
 }
 
 func readDERFile(filename string) ([]byte, error) {
@@ -504,6 +508,19 @@ func Parse(dsn string) (Config, error) {
 		// Defaulting to true to prevent breaking change although other client libraries default to false
 		p.MultiSubnetFailover = true
 	}
+
+	sendStringParametersAsUnicode, ok := params[SendStringParametersAsUnicode]
+	if ok {
+		p.SendStringParametersAsUnicode, err = strconv.ParseBool(sendStringParametersAsUnicode)
+		if err != nil {
+			return p, fmt.Errorf("invalid %s '%s': %s", SendStringParametersAsUnicode,
+				sendStringParametersAsUnicode, err.Error())
+		}
+	} else {
+		// defaulting to true for backward compatibility
+		p.SendStringParametersAsUnicode = true
+	}
+
 	return p, nil
 }
 

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -193,6 +193,15 @@ func TestValidConnectionString(t *testing.T) {
 		{"sqlserver://somehost?encrypt=true&tlsmin=1.1&columnencryption=1", func(p Config) bool {
 			return p.Host == "somehost" && p.Encryption == EncryptionRequired && p.TLSConfig.MinVersion == tls.VersionTLS11 && p.ColumnEncryption
 		}},
+		{"sqlserver://somehost", func(p Config) bool {
+			return p.Host == "somehost" && p.SendStringParametersAsUnicode
+		}},
+		{"sqlserver://somehost?sendStringParametersAsUnicode=true", func(p Config) bool {
+			return p.Host == "somehost" && p.SendStringParametersAsUnicode
+		}},
+		{"sqlserver://somehost?sendStringParametersAsUnicode=false", func(p Config) bool {
+			return p.Host == "somehost" && !p.SendStringParametersAsUnicode
+		}},
 	}
 	for _, ts := range connStrings {
 		p, err := Parse(ts.connStr)

--- a/mssql.go
+++ b/mssql.go
@@ -563,8 +563,8 @@ func (s *Stmt) sendQuery(ctx context.Context, args []namedValue) (err error) {
 			if err != nil {
 				return
 			}
-			params[0] = makeStrParam(s.query)
-			params[1] = makeStrParam(strings.Join(decls, ","))
+			params[0] = makeStrParam(s.query, true)
+			params[1] = makeStrParam(strings.Join(decls, ","), true)
 		}
 		if err = sendRpc(conn.sess.buf, headers, proc, 0, params, reset); err != nil {
 			if conn.sess.logFlags&logErrors != 0 {
@@ -968,9 +968,19 @@ func (r *Rows) ColumnTypeNullable(index int) (nullable, ok bool) {
 	return
 }
 
-func makeStrParam(val string) (res param) {
-	res.ti.TypeId = typeNVarChar
-	res.buffer = str2ucs2(val)
+func getSendStringParametersAsUnicode(s *Stmt) bool {
+	return s == nil || s.c == nil || s.c.connector == nil || s.c.connector.params.SendStringParametersAsUnicode
+}
+
+func makeStrParam(val string, sendStringParametersAsUnicode bool) (res param) {
+	if sendStringParametersAsUnicode {
+		res.ti.TypeId = typeNVarChar
+		res.buffer = str2ucs2(val)
+		res.ti.Size = len(res.buffer)
+		return
+	}
+	res.ti.TypeId = typeBigVarChar
+	res.buffer = []byte(val)
 	res.ti.Size = len(res.buffer)
 	return
 }
@@ -1046,7 +1056,7 @@ func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 		res.ti.Size = len(val)
 		res.buffer = val
 	case string:
-		res = makeStrParam(val)
+		res = makeStrParam(val, getSendStringParametersAsUnicode(s))
 	case sql.NullString:
 		// only null values should be getting here
 		res.ti.TypeId = typeNVarChar

--- a/queries_test.go
+++ b/queries_test.go
@@ -347,8 +347,8 @@ func TestSelectWithVarchar(t *testing.T) {
 			{"cast(cast('abc' as varchar(3)) as sql_variant)", []interface{}{}, "abc"},
 			{"cast(cast('abc' as char(3)) as sql_variant)", []interface{}{}, "abc"},
 			{"cast(N'abc' as sql_variant)", []interface{}{}, "abc"},
-			{"$1", []interface{}{"abc"}, "abc"},
-			{"$1", []interface{}{longstr}, longstr},
+			{"@p1", []interface{}{"abc"}, "abc"},
+			{"@p1", []interface{}{longstr}, longstr},
 		}
 
 		for _, test := range values {

--- a/tds_go110_test.go
+++ b/tds_go110_test.go
@@ -24,3 +24,22 @@ func getTestConnector(t testing.TB) (*Connector, *testLogger) {
 	}
 	return connector, &tl
 }
+
+func openWithVarcharDSN(t testing.TB) (*sql.DB, *testLogger) {
+	connector, logger := getTestConnectorWithVarcharDSN(t)
+	conn := sql.OpenDB(connector)
+	return conn, logger
+}
+
+func getTestConnectorWithVarcharDSN(t testing.TB) (*Connector, *testLogger) {
+	tl := testLogger{t: t}
+	SetLogger(&tl)
+	s := testConnParams(t)
+	s.SendStringParametersAsUnicode = true
+	connector, err := NewConnector(s.URL().String())
+	if err != nil {
+		t.Error("Open connection failed:", err.Error())
+		return nil, &tl
+	}
+	return connector, &tl
+}


### PR DESCRIPTION
This is a feature addition for a new DSN flag - `sendStringParametersAsUnicode` which basically allows us to specify if the Go default string types should be sent as UNICODE(if true) or not(if false).

[Official Support for `sendStringParametersAsUnicode` in JDBC](https://learn.microsoft.com/en-us/sql/connect/jdbc/reference/setsendstringparametersasunicode-method-sqlserverdatasource?view=sql-server-ver15)