### PR TITLE
Fix process query response missing errors

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -750,7 +750,7 @@ loop:
 		tok, err := reader.nextToken()
 		if err == nil {
 			if tok == nil {
-				break
+				break loop
 			} else {
 				switch token := tok.(type) {
 				// By ignoring DONE token we effectively
@@ -762,7 +762,6 @@ loop:
 				//break loop
 				case []columnStruct:
 					cols = token
-					break loop
 				case doneStruct:
 					if token.isError() {
 						// need to cleanup cancellable context

--- a/queries_test.go
+++ b/queries_test.go
@@ -1056,6 +1056,22 @@ func TestProcessQueryError(t *testing.T) {
 	}
 }
 
+func TestProcessQueryWithParamsAndError(t *testing.T) {
+	conn, logger := open(t)
+	defer conn.Close()
+	defer logger.StopLogging()
+	_, err := conn.Exec("create table test (f int identity, g text)")
+	defer conn.Exec("drop table test")
+	if err != nil {
+		t.Fatal("create table failed with error", err)
+	}
+
+	_, err = conn.Query("insert into test (f, g) output inserted.f, inserted.g values (@p1, @p2)", 1, "sffd")
+	if err == nil || err.Error() != "mssql: Cannot insert explicit value for identity column in table 'test' when IDENTITY_INSERT is set to OFF." {
+		t.Error("Error failed to be processed after query")
+	}
+}
+
 func TestStmt_SetQueryNotification(t *testing.T) {
 	checkConnStr(t)
 	tl := testLogger{t: t}

--- a/queries_test.go
+++ b/queries_test.go
@@ -1040,6 +1040,22 @@ func TestIgnoreEmptyResults(t *testing.T) {
 	}
 }
 
+func TestProcessQueryError(t *testing.T) {
+	conn, logger := open(t)
+	defer conn.Close()
+	defer logger.StopLogging()
+	_, err := conn.Exec("create table test (f int identity, g text)")
+	defer conn.Exec("drop table test")
+	if err != nil {
+		t.Fatal("create table failed with error", err)
+	}
+
+	_, err = conn.Query("insert into test (f, g) output inserted.f, inserted.g values (1, 'testValue');")
+	if err == nil || err.Error() != "mssql: Cannot insert explicit value for identity column in table 'test' when IDENTITY_INSERT is set to OFF." {
+		t.Error("Error failed to be processed after query")
+	}
+}
+
 func TestStmt_SetQueryNotification(t *testing.T) {
 	checkConnStr(t)
 	tl := testLogger{t: t}


### PR DESCRIPTION
In `processQueryResponse` if a token is an array of `columnStruct`, it would break the loop and fail to process the following tokens. These tokens should be processed since they may contain errors from the query that should be returned. 

There is a test included which sets up a table, and performs an insert query with output variables. The first token returned in process query response is an array of column struct, relating to the output variables, and second token is an error indicating you cannot insert a value for an identity column. Previously, it would return with no error and an empty set of rows, and now it catches the error and returns it from the query.