### PR TITLE
Fix: handle float32 according to spec in all cases

### DIFF
--- a/types.go
+++ b/types.go
@@ -334,7 +334,7 @@ func readFixedType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata) interface{} {
 	case typeDateTim4:
 		return decodeDateTim4(buf)
 	case typeFlt4:
-		return math.Float32frombits(binary.LittleEndian.Uint32(buf))
+		return float64(math.Float32frombits(binary.LittleEndian.Uint32(buf)))
 	case typeMoney4:
 		return decodeMoney4(buf)
 	case typeMoney:


### PR DESCRIPTION
I encountered what looks quite similar to the issue submitter's case, so I replied in that issue and did a follow-up there: https://github.com/uptrace/bun/issues/993#issuecomment-2253340639.

According to the spec (https://pkg.go.dev/database/sql#Scanner), single-precision float values must always be returned as doubles, which could then be downcasted to recover the original value (leaving the binary representation unchanged, so there is no loss of precision if handled properly).

This bug is only present in `readFixedType`, so it seems to be due to carelessness.