### PR TITLE
Support for UDT (hierarchyid, geometry and geography)

### DIFF
--- a/queries_test.go
+++ b/queries_test.go
@@ -1684,7 +1684,7 @@ func TestColumnTypeIntrospection(t *testing.T) {
 		{"cast(N'abc' as nchar(3))", "NCHAR", reflect.TypeOf(""), true, 3, false, 0, 0},
 		{"cast(1 as sql_variant)", "SQL_VARIANT", reflect.TypeOf(nil), false, 0, false, 0, 0},
 		{"geometry::STGeomFromText('LINESTRING (100 100, 20 180, 180 180)', 0)", "GEOMETRY", reflect.TypeOf([]byte{}), true, 2147483647, false, 0, 0},
-		{"geography::STGeomFromText('LINESTRING(-122.360 47.656, -122.343 47.656 )', 4326)", "GEOGRAPHY", reflect.TypeOf([]byte{}), true, 2147483647, false, 0, 0},
+		{"geography::STGeomFromText('LINESTRING(-122.360 47.656, -122.343 47.656 )', 4326)", "GEOGRAPHY", reflect.TypeOf([]byte{}), false, 2147483647, false, 0, 0},
 		{"cast('/1/2/3/' as hierarchyid)", "HIERARCHYID", reflect.TypeOf([]byte{}), true, 892, false, 0, 0},
 	}
 	conn, logger := open(t)

--- a/queries_test.go
+++ b/queries_test.go
@@ -135,6 +135,7 @@ func TestSelect(t *testing.T) {
 			{"cast(cast('abc' as varchar(3)) as sql_variant)", "abc"},
 			{"cast(cast('abc' as char(3)) as sql_variant)", "abc"},
 			{"cast(N'abc' as sql_variant)", "abc"},
+			{"cast('/' as hierarchyid)", []byte{}},
 		}
 
 		for _, test := range values {
@@ -1682,6 +1683,9 @@ func TestColumnTypeIntrospection(t *testing.T) {
 		{"cast('abc' as char(3))", "CHAR", reflect.TypeOf(""), true, 3, false, 0, 0},
 		{"cast(N'abc' as nchar(3))", "NCHAR", reflect.TypeOf(""), true, 3, false, 0, 0},
 		{"cast(1 as sql_variant)", "SQL_VARIANT", reflect.TypeOf(nil), false, 0, false, 0, 0},
+		{"geometry::STGeomFromText('LINESTRING (100 100, 20 180, 180 180)', 0)", "geometry", reflect.TypeOf([]byte{}), true, 2147483647, false, 0, 0},
+		{"geography::STGeomFromText('LINESTRING(-122.360 47.656, -122.343 47.656 )', 4326)", "geograhy", reflect.TypeOf([]byte{}), true, 2147483647, false, 0, 0},
+		{"cast('/1/2/3/' as hierarchyid)", "hierarchyid", reflect.TypeOf([]byte{}), true, 892, false, 0, 0},
 	}
 	conn, logger := open(t)
 	defer conn.Close()

--- a/queries_test.go
+++ b/queries_test.go
@@ -1683,9 +1683,9 @@ func TestColumnTypeIntrospection(t *testing.T) {
 		{"cast('abc' as char(3))", "CHAR", reflect.TypeOf(""), true, 3, false, 0, 0},
 		{"cast(N'abc' as nchar(3))", "NCHAR", reflect.TypeOf(""), true, 3, false, 0, 0},
 		{"cast(1 as sql_variant)", "SQL_VARIANT", reflect.TypeOf(nil), false, 0, false, 0, 0},
-		{"geometry::STGeomFromText('LINESTRING (100 100, 20 180, 180 180)', 0)", "geometry", reflect.TypeOf([]byte{}), true, 2147483647, false, 0, 0},
-		{"geography::STGeomFromText('LINESTRING(-122.360 47.656, -122.343 47.656 )', 4326)", "geography", reflect.TypeOf([]byte{}), true, 2147483647, false, 0, 0},
-		{"cast('/1/2/3/' as hierarchyid)", "hierarchyid", reflect.TypeOf([]byte{}), true, 892, false, 0, 0},
+		{"geometry::STGeomFromText('LINESTRING (100 100, 20 180, 180 180)', 0)", "GEOMETRY", reflect.TypeOf([]byte{}), true, 2147483647, false, 0, 0},
+		{"geography::STGeomFromText('LINESTRING(-122.360 47.656, -122.343 47.656 )', 4326)", "GEOGRAPHY", reflect.TypeOf([]byte{}), true, 2147483647, false, 0, 0},
+		{"cast('/1/2/3/' as hierarchyid)", "HIERARCHYID", reflect.TypeOf([]byte{}), true, 892, false, 0, 0},
 	}
 	conn, logger := open(t)
 	defer conn.Close()

--- a/queries_test.go
+++ b/queries_test.go
@@ -1684,7 +1684,7 @@ func TestColumnTypeIntrospection(t *testing.T) {
 		{"cast(N'abc' as nchar(3))", "NCHAR", reflect.TypeOf(""), true, 3, false, 0, 0},
 		{"cast(1 as sql_variant)", "SQL_VARIANT", reflect.TypeOf(nil), false, 0, false, 0, 0},
 		{"geometry::STGeomFromText('LINESTRING (100 100, 20 180, 180 180)', 0)", "geometry", reflect.TypeOf([]byte{}), true, 2147483647, false, 0, 0},
-		{"geography::STGeomFromText('LINESTRING(-122.360 47.656, -122.343 47.656 )', 4326)", "geograhy", reflect.TypeOf([]byte{}), true, 2147483647, false, 0, 0},
+		{"geography::STGeomFromText('LINESTRING(-122.360 47.656, -122.343 47.656 )', 4326)", "geography", reflect.TypeOf([]byte{}), true, 2147483647, false, 0, 0},
 		{"cast('/1/2/3/' as hierarchyid)", "hierarchyid", reflect.TypeOf([]byte{}), true, 892, false, 0, 0},
 	}
 	conn, logger := open(t)

--- a/types.go
+++ b/types.go
@@ -1501,7 +1501,7 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 			// https://learn.microsoft.com/en-us/sql/t-sql/data-types/hierarchyid-data-type-method-reference?view=sql-server-ver16
 			return 892, true
 		} else {
-			panic(fmt.Sprintf("not implemented makeGoLangTypeLength for user defined type %d", ti.TypeId))
+			panic(fmt.Sprintf("not implemented makeGoLangTypeLength for user defined type %s", ti.UdtInfo.TypeName))
 		}
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangTypeLength for type %d", ti.TypeId))

--- a/types.go
+++ b/types.go
@@ -1509,6 +1509,8 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangTypeLength for type %d", ti.TypeId))
 	}
+
+	return 0, false
 }
 
 // makes go/sql type precision and scale as described below

--- a/types.go
+++ b/types.go
@@ -1370,7 +1370,6 @@ func makeGoLangTypeName(ti typeInfo) string {
 	case typeBigBinary:
 		return "BINARY"
 	case typeUdt:
-		fmt.Println("asdadsadsaasd" + strings.ToUpper(ti.UdtInfo.TypeName))
 		return strings.ToUpper(ti.UdtInfo.TypeName)
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangTypeName for type %d", ti.TypeId))

--- a/types.go
+++ b/types.go
@@ -1496,10 +1496,14 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 	case typeBigBinary:
 		return int64(ti.Size), true
 	case typeUdt:
-		if ti.UdtInfo.TypeName == "hierarchyid" {
+		switch ti.UdtInfo.TypeName {
+		case "hierarchyid":
 			// https://learn.microsoft.com/en-us/sql/t-sql/data-types/hierarchyid-data-type-method-reference?view=sql-server-ver16
 			return 892, true
-		} else {
+		case "geography":
+		case "geometry":
+			return 2147483647, true
+		default:
 			panic(fmt.Sprintf("not implemented makeGoLangTypeLength for user defined type %s", ti.UdtInfo.TypeName))
 		}
 	default:

--- a/types.go
+++ b/types.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/microsoft/go-mssqldb/internal/cp"
@@ -1137,6 +1138,8 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 		return reflect.TypeOf([]byte{})
 	case typeVariant:
 		return reflect.TypeOf(nil)
+	case typeUdt:
+		return reflect.TypeOf([]byte{})
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangScanType for type %d", ti.TypeId))
 	}
@@ -1366,6 +1369,9 @@ func makeGoLangTypeName(ti typeInfo) string {
 		return "SQL_VARIANT"
 	case typeBigBinary:
 		return "BINARY"
+	case typeUdt:
+		fmt.Println("asdadsadsaasd" + strings.ToUpper(ti.UdtInfo.TypeName))
+		return strings.ToUpper(ti.UdtInfo.TypeName)
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangTypeName for type %d", ti.TypeId))
 	}
@@ -1490,6 +1496,13 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 		return 0, false
 	case typeBigBinary:
 		return int64(ti.Size), true
+	case typeUdt:
+		if ti.UdtInfo.TypeName == "hierarchyid" {
+			// https://learn.microsoft.com/en-us/sql/t-sql/data-types/hierarchyid-data-type-method-reference?view=sql-server-ver16
+			return 892, true
+		} else {
+			panic(fmt.Sprintf("not implemented makeGoLangTypeLength for user defined type %d", ti.TypeId))
+		}
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangTypeLength for type %d", ti.TypeId))
 	}
@@ -1601,6 +1614,8 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 	case typeVariant:
 		return 0, 0, false
 	case typeBigBinary:
+		return 0, 0, false
+	case typeUdt:
 		return 0, 0, false
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangTypePrecisionScale for type %d", ti.TypeId))


### PR DESCRIPTION
  - Adds support for hierarchyid, geometry and geography SQL type.
  - Currently a panic is thrown when the system tries to scan any UDT (user defined type)
  - This has been brought up many times (e.g. [167](https://github.com/microsoft/go-mssqldb/issues/167), [79](https://github.com/microsoft/go-mssqldb/issues/79))
  - Doesn't make sense to have a official driver that doesn't support all official SQL types.
  - There are some forks such as [this one](https://github.com/bytebase/go-mssqldb) to try to solve this issue and the solutions seems to work correctly for every case.
  - I have tested the solution for all proposed types and have implemented a [library to handle hierarchyid](https://github.com/tentone/hierarchyid) encoding and decoding in Go, that has been developed with the modified driver.