### PR TITLE
Fix error checks during certificatePath reading and parsing in azuread

### DIFF
--- a/azuread/configuration.go
+++ b/azuread/configuration.go
@@ -184,11 +184,11 @@ func (p *azureFedAuthConfig) provideActiveDirectoryToken(ctx context.Context, se
 		case p.certificatePath != "":
 			var certData []byte
 			certData, err = os.ReadFile(p.certificatePath)
-			if err != nil {
+			if err == nil {
 				var certs []*x509.Certificate
 				var key crypto.PrivateKey
 				certs, key, err = azidentity.ParseCertificates(certData, []byte(p.clientSecret))
-				if err != nil {
+				if err == nil {
 					cred, err = azidentity.NewClientCertificateCredential(tenant, p.clientID, certs, key, nil)
 				}
 			}


### PR DESCRIPTION
Before this PR certificate-based authentication (in case of a `ActiveDirectoryServicePrincipal` or `ActiveDirectoryApplication` fed auth) would panic (nil pointer dereference at `github.com/microsoft/go-mssqldb@v1.7.2/azuread/configuration.go:228`) because of wrong error checks.