### PR TITLE
fix: Fix problematic error returns

### DIFF
--- a/mssql_go19.go
+++ b/mssql_go19.go
@@ -196,6 +196,7 @@ func (s *Stmt) makeParamExtra(val driver.Value) (res param, err error) {
 		}
 		schema, name, errGetName := getSchemeAndName(val.TypeName)
 		if errGetName != nil {
+			err = errGetName
 			return
 		}
 		res.ti.UdtInfo.TypeName = name


### PR DESCRIPTION
If err is not assigned a value here, the default err (must be nil) is returned.