### PR TITLE
DATETIME: fix 1/300 of a seconds rounding logic (Bulk Copy related)

### DIFF
--- a/types.go
+++ b/types.go
@@ -328,7 +328,7 @@ func threeHundredthsOfASecondToNanos(ths int) int {
 }
 
 func nanosToThreeHundredthsOfASecond(ns int) int {
-	return ns * 300 / 1e9
+	return int(math.Round(float64(ns) * 3 / 1e7))
 }
 
 func readFixedType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata) interface{} {

--- a/types.go
+++ b/types.go
@@ -296,7 +296,7 @@ func encodeDateTime(t time.Time) (res []byte) {
 	basedays := gregorianDays(1900, 1)
 	// days since Jan 1st 1900 (same TZ as t)
 	days := gregorianDays(t.Year(), t.YearDay()) - basedays
-	tm := 300*(t.Second()+t.Minute()*60+t.Hour()*60*60) + t.Nanosecond()*300/1e9
+	tm := 300*(t.Second()+t.Minute()*60+t.Hour()*60*60) + nanosToThreeHundredthsOfASecond(t.Nanosecond())
 	// minimum and maximum possible
 	mindays := gregorianDays(1753, 1) - basedays
 	maxdays := gregorianDays(9999, 365) - basedays
@@ -317,10 +317,18 @@ func encodeDateTime(t time.Time) (res []byte) {
 func decodeDateTime(buf []byte) time.Time {
 	days := int32(binary.LittleEndian.Uint32(buf))
 	tm := binary.LittleEndian.Uint32(buf[4:])
-	ns := int(math.Trunc(float64(tm%300)/0.3+0.5)) * 1000000
+	ns := threeHundredthsOfASecondToNanos(int(tm % 300))
 	secs := int(tm / 300)
 	return time.Date(1900, 1, 1+int(days),
 		0, 0, secs, ns, time.UTC)
+}
+
+func threeHundredthsOfASecondToNanos(ths int) int {
+	return int(math.Trunc(float64(ths)/0.3+0.5)) * 1000000
+}
+
+func nanosToThreeHundredthsOfASecond(ns int) int {
+	return ns * 300 / 1e9
 }
 
 func readFixedType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata) interface{} {

--- a/types_date_and_time_test.go
+++ b/types_date_and_time_test.go
@@ -1,0 +1,150 @@
+package mssql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestDatetimeAccuracy validates that DATETIME type values
+// are properly created from time.Time giving the same rounding
+// logic as SQL Server itself implements.
+//
+// Datetime is rounded to increments of .000, .003, or .007 seconds (accuracy is 1/300 of a second)
+// (see: https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime-transact-sql?view=sql-server-ver16).
+//
+// This test creates 3 schematically identical tables filled in 3 different ways:
+//
+//   - datetime_test_insert_time_as_str (filled via regular INSERT with time as str params)
+//   - datetime_test_insert_time_as_time (filled via regular INSERT with time as go time.Time params)
+//   - datetime_test_insert_bulk (filled via Bulk Copy)
+//
+// After creating these 3 tables the test will compare the data read from all of the tables
+// expecting the data to be identical.
+func TestDatetimeAccuracy(t *testing.T) {
+	ctx := context.Background()
+	conn, logger := open(t)
+	t.Cleanup(func() {
+		conn.Close()
+		logger.StopLogging()
+	})
+
+	createTable := func(tableName string) {
+		_, err := conn.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName))
+		if err != nil {
+			t.Fatal("Failed to drop table: ", err)
+		}
+		_, err = conn.Exec(fmt.Sprintf(`CREATE TABLE %s (
+			id INT NOT NULL PRIMARY KEY,
+			dt DATETIME
+		)`, tableName))
+		if err != nil {
+			t.Fatal("Failed to create table: ", err)
+		}
+		t.Cleanup(func() { _, _ = conn.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) })
+	}
+
+	fillTable := func(tableName string, dts []any) {
+		for i, dt := range dts {
+			_, err := conn.Exec(fmt.Sprintf("INSERT INTO %s (id, dt) VALUES (@p1, @p2)", tableName), i, dt)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	fillTableBulkCopy := func(tableName string, dts []any) {
+		conn, err := conn.Conn(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = conn.Close() }()
+		stmt, err := conn.PrepareContext(ctx, CopyIn(tableName, BulkOptions{}, "id", "dt"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i, dt := range dts {
+			if _, err = stmt.Exec(i, dt); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err = stmt.Exec(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	readTable := func(tableName string) (res []time.Time) {
+		rows, err := conn.QueryContext(ctx, fmt.Sprintf("SELECT dt FROM %s ORDER BY id", tableName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var dt time.Time
+			if err = rows.Scan(&dt); err != nil {
+				t.Fatal(err)
+			}
+			res = append(res, dt)
+		}
+		if rows.Err() != nil {
+			t.Fatal(rows.Err())
+		}
+		return res
+	}
+
+	// generate data to be inserted into the tables:
+	// times with fraction of a second from .000 to .999.
+	var dtsTime []any
+	var dtsStrs []any
+	for i := 0; i < 1000; i++ {
+		ns := int(time.Duration(i) * (time.Second / 1000) * time.Nanosecond)
+		dt := time.Date(2025, 4, 11, 10, 30, 42, ns, time.UTC)
+		str := dt.Format("2006-01-02T15:04:05.999Z")
+		dtsTime = append(dtsTime, dt)
+		dtsStrs = append(dtsStrs, str)
+	}
+
+	createTable("datetime_test_insert_time_as_str")
+	fillTable("datetime_test_insert_time_as_str", dtsStrs)
+
+	createTable("datetime_test_insert_time_as_time")
+	fillTable("datetime_test_insert_time_as_time", dtsTime)
+
+	createTable("datetime_test_insert_bulk")
+	fillTableBulkCopy("datetime_test_insert_bulk", dtsTime)
+
+	as := readTable("datetime_test_insert_time_as_str")
+	bs := readTable("datetime_test_insert_time_as_time")
+	cs := readTable("datetime_test_insert_bulk")
+
+	if len(dtsTime) != len(as) || len(dtsTime) != len(bs) || len(dtsTime) != len(cs) {
+		t.Fatalf("Not all data inserted into tables: want = %d, got = %d %d %d", len(dtsTime), len(as), len(bs), len(cs))
+	}
+
+	for i := 0; i < len(dtsTime); i++ {
+		if !as[i].Equal(bs[i]) || !as[i].Equal(cs[i]) {
+			t.Fatalf(`Rows not equal at #%d:
+			| %-36s | %-36s | %-36s |
+			| %36s | %36s | %36s |`,
+				i,
+				"datetime_test_insert_time_as_str",
+				"datetime_test_insert_time_as_time",
+				"datetime_test_insert_bulk",
+				as[i].Format(time.RFC3339Nano),
+				bs[i].Format(time.RFC3339Nano),
+				cs[i].Format(time.RFC3339Nano),
+			)
+		}
+	}
+}
+
+func TestThreeHundredthsToNanosConverter(t *testing.T) {
+	for want := 0; want < 300; want++ {
+		ns := threeHundredthsOfASecondToNanos(want)
+		got := nanosToThreeHundredthsOfASecond(ns)
+		if want != got {
+			t.Fatalf("want = %d, got = %d", want, got)
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes an issue: https://github.com/microsoft/go-mssqldb/issues/181