### PR TITLE
Fix handling of `stateSep` in batch package. Addresses bug #247

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -123,6 +123,13 @@ func stateSep(l *lexer) stateFn {
 		return nil
 	}
 	s := l.Sql[l.At+len(l.Sep):]
+	if unicode.IsLetter(rune(s[0])) {
+		// If the first character after the separator is a letter, then
+		// it's a text line that happens to start with the separator.
+		// E.g. statement "goto", column name "gone", etc.
+		// We don't want to split here.
+		return stateText
+	}
 
 	parseNumberStart := -1
 loop:

--- a/batch/batch_test.go
+++ b/batch/batch_test.go
@@ -67,6 +67,29 @@ select top 1 1`,
 select top 1 1`,
 			},
 		},
+		testItem{
+			Sql: `
+create table t (
+    id      int,
+    gone_ts datetime
+)
+go
+select
+    gone_ts
+from test_table
+go`,
+			Expect: []string{`
+create table t (
+    id      int,
+    gone_ts datetime
+)
+`, `
+select
+    gone_ts
+from test_table
+`,
+			},
+		},
 		testItem{Sql: `"0'"`, Expect: []string{`"0'"`}},
 		testItem{Sql: "0'", Expect: []string{"0'"}},
 		testItem{Sql: "--", Expect: []string{"--"}},
@@ -78,6 +101,7 @@ select top 1 1`,
 		testItem{Sql: "select 'hi\\\r\n-hello';", Expect: []string{"select 'hi-hello';"}},
 		testItem{Sql: "select 'hi\\\r-hello';", Expect: []string{"select 'hi-hello';"}},
 		testItem{Sql: "select 'hi\\\n\nhello';", Expect: []string{"select 'hi\nhello';"}},
+		testItem{Sql: "select\ngone_ts\nfrom t;", Expect: []string{"select\ngone_ts\nfrom t;"}},
 	}
 
 	index := -1


### PR DESCRIPTION
As per the title this patch fixes a corner case in `stateSep` in batch package, used by `batch.Split()`.
The split shouldn't happen if the separator is immediately followed by a letter, as it might be an identifier or a `goto` statement.