### PR TITLE
Collect all error messages for Error.Error()

### DIFF
--- a/error.go
+++ b/error.go
@@ -3,6 +3,7 @@ package mssql
 import (
 	"database/sql/driver"
 	"fmt"
+	"strings"
 )
 
 // Error represents an SQL Server error. This
@@ -24,7 +25,14 @@ type Error struct {
 }
 
 func (e Error) Error() string {
-	return "mssql: " + e.Message
+	var msg strings.Builder
+	for i, err := range e.All {
+		if i > 0 {
+			msg.WriteByte('\n')
+		}
+		msg.WriteString(fmt.Sprintf("mssql: %s (%d)", err.Message, err.Number))
+	}
+	return msg.String()
 }
 
 func (e Error) String() string {

--- a/error.go
+++ b/error.go
@@ -3,6 +3,7 @@ package mssql
 import (
 	"database/sql/driver"
 	"fmt"
+	"strings"
 )
 
 // Error represents an SQL Server error. This
@@ -24,7 +25,18 @@ type Error struct {
 }
 
 func (e Error) Error() string {
-	return "mssql: " + e.Message
+	errChain := e.All
+	if len(errChain) == 0 {
+		errChain = []Error{e}
+	}
+	var msg strings.Builder
+	for i, err := range errChain {
+		if i > 0 {
+			msg.WriteByte('\n')
+		}
+		fmt.Fprintf(&msg, "mssql: %s (%d)", err.Message, err.Number)
+	}
+	return msg.String()
 }
 
 func (e Error) String() string {

--- a/error_test.go
+++ b/error_test.go
@@ -99,6 +99,9 @@ func TestError_Methods(t *testing.T) {
 		ProcName:   "TestProc",
 		LineNo:     42,
 	}
+	// Error.All must always contain the error itself.
+	// See func (d doneStruct) getError() Error
+	err.All = []Error{err}
 
 	// Test Error() method
 	errorStr := err.Error()

--- a/queries_test.go
+++ b/queries_test.go
@@ -724,6 +724,19 @@ func TestError(t *testing.T) {
 		if sqlerr.Number != 2812 { // Could not find stored procedure 'bad'
 			t.Fatalf("Should be specific error code 2812, actually %d %s", sqlerr.Number, sqlerr)
 		}
+		if len(sqlerr.All) != 1 {
+			t.Fatalf("Should have one error, actually %d: %+v", len(sqlerr.All), sqlerr.All)
+		}
+		if sqlerr.Number != sqlerr.All[0].Number {
+			t.Fatalf("Should have the same error number, actually %d and %d", sqlerr.Number, sqlerr.All[0].Number)
+		}
+
+		// Error() reports one and only error in the list, in this case:
+		//     "mssql: Could not find stored procedure 'bad'."
+		expectedErrorText := fmt.Sprintf(`mssql: %s`, sqlerr.Message)
+		if err.Error() != expectedErrorText {
+			t.Fatalf("Expected error text '%s', got '%s'", expectedErrorText, err.Error())
+		}
 	}
 }
 
@@ -757,6 +770,13 @@ func TestMultipleErrors(t *testing.T) {
 		}
 		if sqlerr.All[0].Number != 8111 { // Cannot define PRIMARY KEY constraint on nullable column in table
 			t.Fatalf("Should be specific error code 8111, actually %d %s", sqlerr.All[0].Number, sqlerr.All[0])
+		}
+
+		// Error() reports only the last error message, in this case:
+		//     "mssql: Could not create constraint or index. See previous errors."
+		expectedErrorText := fmt.Sprintf(`mssql: %s`, sqlerr.Message)
+		if err.Error() != expectedErrorText {
+			t.Fatalf("Expected error text '%s', got '%s'", expectedErrorText, err.Error())
 		}
 	}
 }

--- a/queries_test.go
+++ b/queries_test.go
@@ -732,8 +732,8 @@ func TestError(t *testing.T) {
 		}
 
 		// Error() reports one and only error in the list, in this case:
-		//     "mssql: Could not find stored procedure 'bad'."
-		expectedErrorText := fmt.Sprintf(`mssql: %s`, sqlerr.Message)
+		//     "mssql: Could not find stored procedure 'bad'. (2812)"
+		expectedErrorText := fmt.Sprintf("mssql: %s (%d)", sqlerr.Message, sqlerr.Number)
 		if err.Error() != expectedErrorText {
 			t.Fatalf("Expected error text '%s', got '%s'", expectedErrorText, err.Error())
 		}
@@ -772,9 +772,15 @@ func TestMultipleErrors(t *testing.T) {
 			t.Fatalf("Should be specific error code 8111, actually %d %s", sqlerr.All[0].Number, sqlerr.All[0])
 		}
 
-		// Error() reports only the last error message, in this case:
-		//     "mssql: Could not create constraint or index. See previous errors."
-		expectedErrorText := fmt.Sprintf(`mssql: %s`, sqlerr.Message)
+		// Error() reports all error messages in the same order as
+		// they are reported by tools like sqlcmd (first to last):
+		//     mssql: Cannot define PRIMARY KEY constraint on nullable column in table '#bad'. (8111)
+		//     mssql: Could not create constraint or index. See previous errors. (1750)
+		expectedErrorText := fmt.Sprintf(
+			"mssql: %s (%d)\nmssql: %s (%d)",
+			sqlerr.All[0].Message, sqlerr.All[0].Number,
+			sqlerr.All[1].Message, sqlerr.All[1].Number,
+		)
 		if err.Error() != expectedErrorText {
 			t.Fatalf("Expected error text '%s', got '%s'", expectedErrorText, err.Error())
 		}

--- a/queries_test.go
+++ b/queries_test.go
@@ -742,8 +742,8 @@ func TestError(t *testing.T) {
 		}
 
 		// Error() reports one and only error in the list, in this case:
-		//     "mssql: Could not find stored procedure 'bad'."
-		expectedErrorText := fmt.Sprintf(`mssql: %s`, sqlerr.Message)
+		//     "mssql: Could not find stored procedure 'bad'. (2812)"
+		expectedErrorText := fmt.Sprintf("mssql: %s (%d)", sqlerr.Message, sqlerr.Number)
 		if err.Error() != expectedErrorText {
 			t.Fatalf("Expected error text '%s', got '%s'", expectedErrorText, err.Error())
 		}
@@ -782,9 +782,15 @@ func TestMultipleErrors(t *testing.T) {
 			t.Fatalf("Should be specific error code 8111, actually %d %s", sqlerr.All[0].Number, sqlerr.All[0])
 		}
 
-		// Error() reports only the last error message, in this case:
-		//     "mssql: Could not create constraint or index. See previous errors."
-		expectedErrorText := fmt.Sprintf(`mssql: %s`, sqlerr.Message)
+		// Error() reports all error messages in the same order as
+		// they are reported by tools like sqlcmd (first to last):
+		//     mssql: Cannot define PRIMARY KEY constraint on nullable column in table '#bad'. (8111)
+		//     mssql: Could not create constraint or index. See previous errors. (1750)
+		expectedErrorText := fmt.Sprintf(
+			"mssql: %s (%d)\nmssql: %s (%d)",
+			sqlerr.All[0].Message, sqlerr.All[0].Number,
+			sqlerr.All[1].Message, sqlerr.All[1].Number,
+		)
 		if err.Error() != expectedErrorText {
 			t.Fatalf("Expected error text '%s', got '%s'", expectedErrorText, err.Error())
 		}

--- a/queries_test.go
+++ b/queries_test.go
@@ -734,6 +734,19 @@ func TestError(t *testing.T) {
 		if sqlerr.Number != 2812 { // Could not find stored procedure 'bad'
 			t.Fatalf("Should be specific error code 2812, actually %d %s", sqlerr.Number, sqlerr)
 		}
+		if len(sqlerr.All) != 1 {
+			t.Fatalf("Should have one error, actually %d: %+v", len(sqlerr.All), sqlerr.All)
+		}
+		if sqlerr.Number != sqlerr.All[0].Number {
+			t.Fatalf("Should have the same error number, actually %d and %d", sqlerr.Number, sqlerr.All[0].Number)
+		}
+
+		// Error() reports one and only error in the list, in this case:
+		//     "mssql: Could not find stored procedure 'bad'."
+		expectedErrorText := fmt.Sprintf(`mssql: %s`, sqlerr.Message)
+		if err.Error() != expectedErrorText {
+			t.Fatalf("Expected error text '%s', got '%s'", expectedErrorText, err.Error())
+		}
 	}
 }
 
@@ -767,6 +780,13 @@ func TestMultipleErrors(t *testing.T) {
 		}
 		if sqlerr.All[0].Number != 8111 { // Cannot define PRIMARY KEY constraint on nullable column in table
 			t.Fatalf("Should be specific error code 8111, actually %d %s", sqlerr.All[0].Number, sqlerr.All[0])
+		}
+
+		// Error() reports only the last error message, in this case:
+		//     "mssql: Could not create constraint or index. See previous errors."
+		expectedErrorText := fmt.Sprintf(`mssql: %s`, sqlerr.Message)
+		if err.Error() != expectedErrorText {
+			t.Fatalf("Expected error text '%s', got '%s'", expectedErrorText, err.Error())
 		}
 	}
 }


### PR DESCRIPTION
Sometimes mssql server reports a chain of errors with the last error having a message like: `Could not drop constraint. See previous errors.`. Since users code will generally print an error by simply using `.Error()` method to get the details about an underlying error then the method should provide as much detail as possible in my opinion.

## CHANGELOG

**BREAKING CHANGE:**

Before this patch an `Error()` method would return a message like:

`mssql: message`

After this commit it returns:

`mssql: message (error number)`

And even:

```
mssql: message 1 (error number 1)
mssql: message 2 (error number 2)
...
```