### PR TITLE
Work around build error introduced by the new 'go vet' tests analyser

### DIFF
--- a/lastinsertid_example_test.go
+++ b/lastinsertid_example_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 // This example shows the usage of Connector type
-func ExampleLastInsertId() {
-
+func Example_lastinsertid() {
 	connString := makeConnURL().String()
 
 	db, err := sql.Open("sqlserver", connString)


### PR DESCRIPTION
Build's started failing under Go v1.24 which were traced back to a new 'go vet' analyser. Changing the function name in this patch marked it as an example for the package as a whole - as long as the part under the underscore is in lower-case.
   
See: https://go.dev/blog/examples