### PR TITLE
isProc: added `COMMIT` and `ROLLBACK` command to the builtin commands

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -565,7 +565,10 @@ func (s *Stmt) sendQuery(ctx context.Context, args []namedValue) (err error) {
 
 // Builtin commands are not stored procs, but rather T-SQL commands
 // those commands can be invoke without extra options
-var builtinCommands = []string{"RECONFIGURE", "SHUTDOWN", "CHECKPOINT"}
+var builtinCommands = []string{
+	"RECONFIGURE", "SHUTDOWN", "CHECKPOINT",
+	"COMMIT", "ROLLBACK",
+}
 
 // isProc takes the query text in s and determines if it is a stored proc name
 // or SQL text.

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -51,6 +51,8 @@ func TestIsProc(t *testing.T) {
 		{"RECONFIGURE", false},
 		{"SHUTDOWN", false},
 		{"CHECKPOINT", false},
+		{"COMMIT", false},
+		{"ROLLBACK", false},
 	}
 
 	for _, item := range list {


### PR DESCRIPTION
Fix: https://github.com/microsoft/go-sqlcmd/issues/569