### PR TITLE
fix stuck message queue

### DIFF
--- a/encrypt.go
+++ b/encrypt.go
@@ -145,7 +145,7 @@ func (s *Stmt) decryptCek(ctx context.Context, cekInfo []*cekData) error {
 	for _, info := range cekInfo {
 		kp, ok := s.c.sess.aeSettings.keyProviders[info.cmkStoreName]
 		if !ok {
-			return fmt.Errorf("No provider found for key store %s", info.cmkStoreName)
+			return fmt.Errorf("no provider found for key store %s", info.cmkStoreName)
 		}
 		dk, err := kp.GetDecryptedKey(ctx, info.cmkPath, info.encryptedValue)
 		if err != nil {
@@ -285,7 +285,7 @@ func processDescribeParameterEncryption(rows driver.Rows) (cekInfo []*cekData, p
 		if qerr != io.EOF {
 			err = qerr
 		} else {
-			badStreamPanic(fmt.Errorf("No parameter encryption rows were returned from sp_describe_parameter_encryption"))
+			badStreamPanic(fmt.Errorf("no parameter encryption rows were returned from sp_describe_parameter_encryption"))
 		}
 	}
 	return

--- a/rpc.go
+++ b/rpc.go
@@ -28,20 +28,21 @@ type param struct {
 }
 
 var (
-	sp_Cursor          = procId{1, ""}
-	sp_CursorOpen      = procId{2, ""}
-	sp_CursorPrepare   = procId{3, ""}
-	sp_CursorExecute   = procId{4, ""}
-	sp_CursorPrepExec  = procId{5, ""}
-	sp_CursorUnprepare = procId{6, ""}
-	sp_CursorFetch     = procId{7, ""}
-	sp_CursorOption    = procId{8, ""}
-	sp_CursorClose     = procId{9, ""}
-	sp_ExecuteSql      = procId{10, ""}
-	sp_Prepare         = procId{11, ""}
-	sp_PrepExec        = procId{13, ""}
-	sp_PrepExecRpc     = procId{14, ""}
-	sp_Unprepare       = procId{15, ""}
+	//	sp_Cursor          = procId{1, ""}
+	//	sp_CursorOpen      = procId{2, ""}
+	//	sp_CursorPrepare   = procId{3, ""}
+	//	sp_CursorExecute   = procId{4, ""}
+	//	sp_CursorPrepExec  = procId{5, ""}
+	//	sp_CursorUnprepare = procId{6, ""}
+	//	sp_CursorFetch     = procId{7, ""}
+	//	sp_CursorOption    = procId{8, ""}
+	//	sp_CursorClose     = procId{9, ""}
+	sp_ExecuteSql = procId{10, ""}
+
+// sp_Prepare         = procId{11, ""}
+// sp_PrepExec        = procId{13, ""}
+// sp_PrepExecRpc     = procId{14, ""}
+// sp_Unprepare       = procId{15, ""}
 )
 
 // http://msdn.microsoft.com/en-us/library/dd357576.aspx

--- a/session.go
+++ b/session.go
@@ -34,7 +34,7 @@ func (s *tdsSession) preparePreloginFields(ctx context.Context, p msdsn.Config, 
 	var encrypt byte
 	switch p.Encryption {
 	default:
-		panic(fmt.Errorf("Unsupported Encryption Config %v", p.Encryption))
+		panic(fmt.Errorf("unsupported encryption config %v", p.Encryption))
 	case msdsn.EncryptionDisabled:
 		encrypt = encryptNotSup
 	case msdsn.EncryptionRequired:

--- a/tds.go
+++ b/tds.go
@@ -1411,5 +1411,4 @@ func getClientId(mac *[6]byte) {
 			}
 		}
 	}
-	return
 }

--- a/token_string.go
+++ b/token_string.go
@@ -38,7 +38,7 @@ func (i token) String() string {
 	case 237 <= i && i <= 238:
 		i -= 237
 		return _token_name_5[_token_index_5[i]:_token_index_5[i+1]]
-	case 253 <= i && i <= 255:
+	case 253 <= i:
 		i -= 253
 		return _token_name_6[_token_index_6[i]:_token_index_6[i+1]]
 	default:


### PR DESCRIPTION
Fixes https://github.com/microsoft/go-sqlcmd/issues/571
When the `sql` package detects that there are no more rowsets coming after a `rows.Next()` call, it calls `Close` on the `rows` object. The `rowsq` implementation was immediately cancelling the context, which causes the message queue to go dormant.  This fix queues the `MsgNextResult` before cancelling the context, so the app can make the next call to `rows.NextResultSet` and be informed it's done.

Because the `processSingleResponse` is running in a separate goroutine there was a race condition between the cancel signal being received and the `MsgNextResult` being queued and processed.

I've also fixed a few lint issues.