### PR TITLE
Vbump driver to 1.9.1

### DIFF
--- a/version.go
+++ b/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Update this variable with the release tag before pushing the tag
 // This value is written to the prelogin and login7 packets during a new connection
-const driverVersion = "v1.8.2"
+const driverVersion = "v1.9.1"
 
 func getDriverVersion(ver string) uint32 {
 	var majorVersion uint32


### PR DESCRIPTION
Sadly I forgot to change the version number to 1.9 before I pushed the 1.9 tag, so I'll set it to 1.9.1 then push that tag after it merges.
