### PR TITLE
Restore tests against Azure resources

### DIFF
--- a/.pipelines/TestSql2017.yml
+++ b/.pipelines/TestSql2017.yml
@@ -43,6 +43,7 @@ steps:
     inlineScript: |
       Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_CLIENT_ID;]$env:AZURESUBSCRIPTION_CLIENT_ID"
       Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_TENANT_ID;]$env:AZURESUBSCRIPTION_TENANT_ID"
+      Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_SERVICE_CONNECTION_ID;]$env:AZURESUBSCRIPTION_SERVICE_CONNECTION_ID"
       gci env:* | sort-object name
 
 - task: Docker@2
@@ -52,10 +53,9 @@ steps:
     arguments: '-m 2GB -e ACCEPT_EULA=1 -d --name sql2022 -p:1433:1433 -e SA_PASSWORD=$(TESTPASSWORD) mcr.microsoft.com/mssql/server:2022-latest'
 
 - script: |
-    ~/go/bin/gotestsum --junitfile testresults.xml -- -coverprofile=coverage.txt -covermode count ./...
+    ~/go/bin/gotestsum --junitfile testresults.xml -- ./... -coverprofile=coverage.txt -covermode count 
     ~/go/bin/gocov convert coverage.txt > coverage.json
     ~/go/bin/gocov-xml < coverage.json > coverage.xml
-    mkdir coverage
   workingDirectory: '$(Build.SourcesDirectory)'
   displayName: 'run tests'
   env:

--- a/.pipelines/TestSql2017.yml
+++ b/.pipelines/TestSql2017.yml
@@ -46,10 +46,10 @@ steps:
       gci env:* | sort-object name
 
 - task: Docker@2
-  displayName: 'Run SQL 2017 docker image'
+  displayName: 'Run SQL 2022 docker image'
   inputs:
     command: run
-    arguments: '-m 2GB -e ACCEPT_EULA=1 -d --name sql2017 -p:1433:1433 -e SA_PASSWORD=$(TESTPASSWORD) mcr.microsoft.com/mssql/server:2017-latest'
+    arguments: '-m 2GB -e ACCEPT_EULA=1 -d --name sql2022 -p:1433:1433 -e SA_PASSWORD=$(TESTPASSWORD) mcr.microsoft.com/mssql/server:2022-latest'
 
 - script: |
     ~/go/bin/gotestsum --junitfile testresults.xml -- -coverprofile=coverage.txt -covermode count ./...
@@ -75,10 +75,10 @@ steps:
     testResultsFiles: 'testresults.xml'
     testResultsFormat: JUnit
     searchFolder: '$(Build.SourcesDirectory)'
-    testRunTitle: 'SQL 2017 - $(Build.SourceBranchName)'
+    testRunTitle: 'SQL 2022 - $(Build.SourceBranchName)'
+    failTaskOnFailedTests: true
   condition: always()
-  continueOnError: true
-
+  
 - task: PublishCodeCoverageResults@2
   inputs:
     pathToSources: '$(Build.SourcesDirectory)'

--- a/.pipelines/TestSql2017.yml
+++ b/.pipelines/TestSql2017.yml
@@ -34,6 +34,16 @@ steps:
     arguments: 'github.com/AlekSi/gocov-xml@latest'
     workingDirectory: '$(System.DefaultWorkingDirectory)'
 
+- task: AzureCLI@2
+  inputs:
+    addSpnToEnvironment: true
+    azureSubscription: $(AZURESUBSCRIPTION_SERVICE_CONNECTION_NAME)
+    scriptType: pscore
+    scriptLocation: inlineScript
+    inlineScript: |
+      Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_CLIENT_ID;]$env:AZURESUBSCRIPTION_CLIENT_ID"
+      Write-Host "##vso[task.setvariable variable=AZURESUBSCRIPTION_TENANT_ID;]$env:AZURESUBSCRIPTION_TENANT_ID"
+      gci env:* | sort-object name
 
 - task: Docker@2
   displayName: 'Run SQL 2017 docker image'
@@ -52,6 +62,12 @@ steps:
 # skipping Azure related tests due to lack of access
     SQLPASSWORD: $(SQLPASSWORD)
     SQLSERVER_DSN: $(SQLSERVER_DSN)
+    AZURESERVER_DSN: $(AZURESERVER_DSN)
+    AZURESUBSCRIPTION_SERVICE_CONNECTION_ID: $(AZURESUBSCRIPTION_SERVICE_CONNECTION_ID)
+    AZURESUBSCRIPTION_CLIENT_ID: $(AZURESUBSCRIPTION_CLIENT_ID)
+    AZURESUBSCRIPTION_TENANT_ID: $(AZURESUBSCRIPTION_TENANT_ID)
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    KEY_VAULT_NAME: $(KEY_VAULT_NAME)
   continueOnError: true
 - task: PublishTestResults@2
   displayName: "Publish junit-style results"
@@ -63,12 +79,10 @@ steps:
   condition: always()
   continueOnError: true
 
-- task: PublishCodeCoverageResults@1
+- task: PublishCodeCoverageResults@2
   inputs:
-    codeCoverageTool: Cobertura 
     pathToSources: '$(Build.SourcesDirectory)'
     summaryFileLocation: $(Build.SourcesDirectory)/**/coverage.xml
-    reportDirectory: $(Build.SourcesDirectory)/**/coverage
     failIfCoverageEmpty: true
   condition: always()
   continueOnError: true

--- a/aecmk/akv/keyprovider.go
+++ b/aecmk/akv/keyprovider.go
@@ -221,8 +221,7 @@ func (p *Provider) getKeyData(ctx context.Context, masterKeyPath string, op aecm
 	r, err := client.GetKey(ctx, k.name, k.version, nil)
 	if err != nil {
 		err = aecmk.NewError(op, "Unable to get key from AKV. Name:"+masterKeyPath, err)
-	}
-	if r.Key.Kty == nil || (*r.Key.Kty != azkeys.KeyTypeRSA && *r.Key.Kty != azkeys.KeyTypeRSAHSM) {
+	} else if r.Key.Kty == nil || (*r.Key.Kty != azkeys.KeyTypeRSA && *r.Key.Kty != azkeys.KeyTypeRSAHSM) {
 		err = aecmk.NewError(op, "Key type not supported for Always Encrypted", nil)
 	}
 	if err == nil {

--- a/aecmk/akv/keyprovider_test.go
+++ b/aecmk/akv/keyprovider_test.go
@@ -6,6 +6,7 @@ package akv
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"net/url"
 	"testing"
 
@@ -23,11 +24,17 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 	assert.NoError(t, err, "CreateRSAKey")
 	defer akvkeys.DeleteRSAKey(client, name)
 	keyPath, _ := url.JoinPath(vaultURL, name)
+	t.Log("KeyPath:", keyPath)
 	p := &KeyProvider
 	plainKey := make([]byte, 32)
 	_, _ = rand.Read(plainKey)
 	t.Log("Plainkey:", plainKey)
 	encryptedKey, err := p.EncryptColumnEncryptionKey(context.Background(), keyPath, aecmk.KeyEncryptionAlgorithm, plainKey)
+	if err != nil {
+		if unwrapped := errors.Unwrap(err); unwrapped != nil {
+			t.Logf("Inner error: %+v", unwrapped)
+		}
+	}
 	if assert.NoError(t, err, "EncryptColumnEncryptionKey") {
 		t.Log("Encryptedkey:", encryptedKey)
 		assert.NotEqualValues(t, plainKey, encryptedKey, "encryptedKey is the same as plainKey")

--- a/aecmk/akv/keyprovider_test.go
+++ b/aecmk/akv/keyprovider_test.go
@@ -16,11 +16,11 @@ import (
 )
 
 func TestEncryptDecryptRoundTrip(t *testing.T) {
-	client, vaultURL, err := akvkeys.GetTestAKV(t)
+	client, vaultURL, err := akvkeys.GetTestAKV()
 	if err != nil {
 		t.Skip("No access to AKV")
 	}
-	cred, err := akvkeys.GetProviderCredential(t)
+	cred, err := akvkeys.GetProviderCredential()
 	if err != nil {
 		t.Skip("No access to AKV")
 	}

--- a/aecmk/akv/keyprovider_test.go
+++ b/aecmk/akv/keyprovider_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestEncryptDecryptRoundTrip(t *testing.T) {
-	client, vaultURL, err := akvkeys.GetTestAKV()
+	client, vaultURL, err := akvkeys.GetTestAKV(t)
 	if err != nil {
 		t.Skip("No access to AKV")
 	}

--- a/aecmk/akv/keyprovider_test.go
+++ b/aecmk/akv/keyprovider_test.go
@@ -20,12 +20,17 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Skip("No access to AKV")
 	}
+	cred, err := akvkeys.GetProviderCredential(t)
+	if err != nil {
+		t.Skip("No access to AKV")
+	}
 	name, err := akvkeys.CreateRSAKey(client)
 	assert.NoError(t, err, "CreateRSAKey")
 	defer akvkeys.DeleteRSAKey(client, name)
 	keyPath, _ := url.JoinPath(vaultURL, name)
 	t.Log("KeyPath:", keyPath)
 	p := &KeyProvider
+	p.SetCertificateCredential("", cred)
 	plainKey := make([]byte, 32)
 	_, _ = rand.Read(plainKey)
 	t.Log("Plainkey:", plainKey)

--- a/alwaysencrypted_akv_test.go
+++ b/alwaysencrypted_akv_test.go
@@ -21,7 +21,7 @@ type akvProviderTest struct {
 
 func (p *akvProviderTest) ProvisionMasterKey(t *testing.T) string {
 	t.Helper()
-	client, vaultURL, err := akvkeys.GetTestAKV()
+	client, vaultURL, err := akvkeys.GetTestAKV(t)
 	if err != nil {
 		t.Skip("Unable to access AKV")
 	}

--- a/alwaysencrypted_akv_test.go
+++ b/alwaysencrypted_akv_test.go
@@ -21,7 +21,7 @@ type akvProviderTest struct {
 
 func (p *akvProviderTest) ProvisionMasterKey(t *testing.T) string {
 	t.Helper()
-	client, vaultURL, err := akvkeys.GetTestAKV(t)
+	client, vaultURL, err := akvkeys.GetTestAKV()
 	if err != nil {
 		t.Skip("Unable to access AKV")
 	}

--- a/azuread/configuration_test.go
+++ b/azuread/configuration_test.go
@@ -358,6 +358,11 @@ func TestValidateParametersErrors(t *testing.T) {
 		},
 	}
 	for _, tst := range tests {
+		t.Setenv("SYSTEM_ACCESSTOKEN", "")                      // Clear any existing value to avoid conflicts
+		t.Setenv("AZURESUBSCRIPTION_CLIENT_ID", "")             // Clear any existing value to avoid conflicts
+		t.Setenv("AZURESUBSCRIPTION_TENANT_ID", "")             // Clear any existing value to avoid conflicts
+		t.Setenv("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID", "") // Clear any existing value to avoid conflicts
+
 		t.Run(tst.name, func(t *testing.T) {
 			_, err := parse(tst.dsn)
 			if err == nil {

--- a/azuread/configuration_test.go
+++ b/azuread/configuration_test.go
@@ -159,7 +159,7 @@ func TestValidateParameters(t *testing.T) {
 			dsn:  "server=someserver.database.windows.net;fedauth=ActiveDirectoryWorkloadIdentity;user id=service-principal-id@tenant-id",
 			expected: &azureFedAuthConfig{
 				clientID:        "service-principal-id",
-				tenantID:        "tenant-id", 
+				tenantID:        "tenant-id",
 				adalWorkflow:    mssql.FedAuthADALWorkflowPassword,
 				fedAuthWorkflow: ActiveDirectoryWorkloadIdentity,
 			},
@@ -199,11 +199,11 @@ func TestValidateParameters(t *testing.T) {
 			name: "on behalf of with secret",
 			dsn:  "server=someserver.database.windows.net;fedauth=ActiveDirectoryOnBehalfOf;user id=service-principal-id@tenant-id;password=somesecret;userassertion=user-token",
 			expected: &azureFedAuthConfig{
-				clientID:      "service-principal-id",
-				tenantID:      "tenant-id",
-				clientSecret:  passphrase,
-				userAssertion: "user-token",
-				adalWorkflow:  mssql.FedAuthADALWorkflowPassword,
+				clientID:        "service-principal-id",
+				tenantID:        "tenant-id",
+				clientSecret:    passphrase,
+				userAssertion:   "user-token",
+				adalWorkflow:    mssql.FedAuthADALWorkflowPassword,
 				fedAuthWorkflow: ActiveDirectoryOnBehalfOf,
 			},
 		},
@@ -479,16 +479,14 @@ func TestAzurePipelinesEnvironmentVariables(t *testing.T) {
 
 	for _, tst := range tests {
 		t.Run(tst.name, func(t *testing.T) {
+			t.Setenv("SYSTEM_ACCESSTOKEN", "")                      // Clear any existing value to avoid conflicts
+			t.Setenv("AZURESUBSCRIPTION_CLIENT_ID", "")             // Clear any existing value to avoid conflicts
+			t.Setenv("AZURESUBSCRIPTION_TENANT_ID", "")             // Clear any existing value to avoid conflicts
+			t.Setenv("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID", "") // Clear any existing value to avoid conflicts
 			// Set environment variables
 			for key, value := range tst.envVars {
 				os.Setenv(key, value)
 			}
-			// Clean up environment variables after test
-			defer func() {
-				for key := range tst.envVars {
-					os.Unsetenv(key)
-				}
-			}()
 
 			config, err := parse(tst.dsn)
 			if tst.shouldError {

--- a/internal/akvkeys/utils.go
+++ b/internal/akvkeys/utils.go
@@ -10,13 +10,15 @@ import (
 	"math/big"
 	"net/url"
 	"os"
+	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
 )
 
-func GetTestAKV() (client *azkeys.Client, u string, err error) {
+func GetTestAKV(t testing.TB) (client *azkeys.Client, u string, err error) {
+	t.Helper()
 	vaultName := os.Getenv("KEY_VAULT_NAME")
 	if len(vaultName) == 0 {
 		err = fmt.Errorf("KEY_VAULT_NAME is not set in the environment")
@@ -30,6 +32,7 @@ func GetTestAKV() (client *azkeys.Client, u string, err error) {
 	}
 	sc := os.Getenv("AZURESUBSCRIPTION_SERVICE_CONNECTION_ID")
 	if len(sc) > 0 {
+		t.Log("Using Azure Pipelines credential for AKV access")
 		tenant := os.Getenv("AZURESUBSCRIPTION_TENANT_ID")
 		clientID := os.Getenv("AZURESUBSCRIPTION_CLIENT_ID")
 		token := os.Getenv("SYSTEM_ACCESSTOKEN")
@@ -42,6 +45,9 @@ func GetTestAKV() (client *azkeys.Client, u string, err error) {
 			if err != nil {
 				return
 			}
+		} else {
+			t.Logf("Failed to create AzurePipelinesCredential: %v", errp)
+			t.Log("Using DefaultAzureCredential for AKV access")
 		}
 	}
 

--- a/tds_test.go
+++ b/tds_test.go
@@ -313,7 +313,7 @@ func GetConnParams() (*msdsn.Config, error) {
 			if err == nil {
 				params.Encoding.Timezone = tz
 			}
-
+		}
 		return &params, nil
 	}
 	if len(os.Getenv("HOST")) > 0 && len(os.Getenv("DATABASE")) > 0 {

--- a/tds_test.go
+++ b/tds_test.go
@@ -308,6 +308,12 @@ func GetConnParams() (*msdsn.Config, error) {
 		if os.Getenv("COLUMNENCRYPTION") != "" {
 			params.ColumnEncryption = true
 		}
+		if os.Getenv("TIME_ZONE") != "" {
+			tz, err := time.LoadLocation(os.Getenv("TIME_ZONE"))
+			if err == nil {
+				params.Encoding.Timezone = tz
+			}
+
 		return &params, nil
 	}
 	if len(os.Getenv("HOST")) > 0 && len(os.Getenv("DATABASE")) > 0 {


### PR DESCRIPTION
now that `AzurePipelinesCredential` is available, our internal ADO pipeline can use it.
