### PR TITLE
Fix: make the message queue model work correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # Changelog
+## 1.9.2
+
+### Bug fixes
+
+* Fix race condition in message queue query model (#277)
+
+## 1.9.1
+
+### Bug fixes
+
+* Fix bulk insert failure with datetime values near midnight due to day overflow (#271)
+* Fix: apply guidConversion option in TestBulkcopy (#255)
+
+### Features
+
+* support configuring custom time.Location for datetime encoding and decoding via DSN (#260)
+* Implement support for the latest Azure credential types in the azuread package (#269)
+
 ## 1.8.2
 
 ### Bug fixes

--- a/mssql.go
+++ b/mssql.go
@@ -1267,9 +1267,7 @@ type Rowsq struct {
 }
 
 func (rc *Rowsq) Close() error {
-	rc.stmt.c.sess.LogF(rc.reader.ctx, msdsn.LogDebug, "Rowsq.Close() called, canceling reader after processing all tokens and queuing MsgNextResultSet")
-	_ = sqlexp.ReturnMessageEnqueue(rc.reader.ctx, rc.reader.outs.msgq, sqlexp.MsgNextResultSet{})
-	defer rc.cancel()
+	rc.cancel()
 	for {
 		tok, err := rc.reader.nextToken()
 		if err == nil {
@@ -1377,7 +1375,7 @@ func (rc *Rowsq) Next(dest []driver.Value) error {
 // In Message Queue mode, we always claim another resultset could be on the way
 // to avoid Rows being closed prematurely
 func (rc *Rowsq) HasNextResultSet() bool {
-	return !rc.requestDone
+	return true
 }
 
 // Scans to the end of the current statement being processed

--- a/token.go
+++ b/token.go
@@ -1001,7 +1001,6 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 		case tokenDoneInProc:
 			done := parseDoneInProc(sess.buf)
 
-			ch <- done
 			if done.Status&doneCount != 0 {
 				sess.LogF(ctx, msdsn.LogRows, "(%d rows affected)", done.RowCount)
 
@@ -1009,6 +1008,9 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 					_ = sqlexp.ReturnMessageEnqueue(ctx, outs.msgq, sqlexp.MsgRowsAffected{Count: int64(done.RowCount)})
 				}
 			}
+
+			ch <- done
+
 			if outs.msgq != nil {
 				// For now we ignore ctx->Done errors that ReturnMessageEnqueue might return
 				// It's not clear how to handle them correctly here, and data/sql seems
@@ -1041,7 +1043,6 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 				}
 				return
 			}
-			ch <- done
 			if done.Status&doneCount != 0 {
 				sess.LogF(ctx, msdsn.LogRows, "(Rows affected: %d)", done.RowCount)
 
@@ -1050,6 +1051,9 @@ func processSingleResponse(ctx context.Context, sess *tdsSession, ch chan tokenS
 				}
 
 			}
+
+			ch <- done
+
 			colsReceived = false
 			if outs.msgq != nil {
 				sess.LogF(ctx, msdsn.LogDebug, "queueing MsgNextResultSet after tokenDone or tokenDoneProc")

--- a/version.go
+++ b/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Update this variable with the release tag before pushing the tag
 // This value is written to the prelogin and login7 packets during a new connection
-const driverVersion = "v1.9.1"
+const driverVersion = "v1.9.2"
 
 func getDriverVersion(ver string) uint32 {
 	var majorVersion uint32


### PR DESCRIPTION
My first attempt at a fix was not correct. This change addresses the root cause - when `rowsQ.HasNextResultSet()` returns `false`, the `sql/data` package calls `Close` on it immediately, leading to the context getting cancelled and tokens dropped.
For some reason, in my initial implementation I wrote a comment with the correct behavior to always return `true` yet the body of the method didn't match and I can't recall why.
I've changed the method to match the comment and tested with a new sqlcmd build. I can't reproduce the hang.
I've also reordered the posting of `MsgRowsAffected` to precede sending the `done` event to the channel, to assure it can be processed even if the context cancels when the done is received.