### PR TITLE
Fix: Flush pending TLS handshake packet before switching transport

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -1242,6 +1242,14 @@ initiate_connection:
 			if err != nil {
 				return nil, fmt.Errorf("TLS Handshake failed: %v", err)
 			}
+			// Flush any pending packet from the handshake
+			// The driver's Finished message is still in the buffer
+			if handshakeConn.packetPending {
+				handshakeConn.packetPending = false
+				if err := handshakeConn.buf.FinishPacket(); err != nil {
+					return nil, fmt.Errorf("TLS Handshake flush failed: %v", err)
+				}
+			}
 			if encrypt == encryptOff {
 				outbuf.afterFirst = func() {
 					outbuf.transport = toconn


### PR DESCRIPTION
This PR fixes a race condition in the TLS handshake process where the final TLS Finished message may not be sent to the server.

Problem:

The tlsHandshakeConn wrapper buffers TLS handshake messages inside TDS packets. When Write() is called with the Finished message, it sets packetPending = true but doesn't immediately flush. The packet is only flushed when Read() is called. However, after a successful handshake, the code immediately switches from the handshake wrapper to the direct connection, potentially leaving the Finished message unflushed in the buffer.

Solution:

Added a check after the TLS handshake completes to flush any pending packet before switching the transport. This ensures the Finished message is always sent regardless of the TLS library's read behavior.