### PR TITLE
Check if channel receive will succeed using len instead of a select statement.

### DIFF
--- a/token.go
+++ b/token.go
@@ -1192,18 +1192,16 @@ func (t *tokenProcessor) iterateResponse() error {
 func (t tokenProcessor) nextToken() (tokenStruct, error) {
 	// we do this separate non-blocking check on token channel to
 	// prioritize it over cancellation channel
-	select {
-	case tok, more := <-t.tokChan:
-		err, more := tok.(error)
-		if more {
+	if len(t.tokChan) > 0 {
+		tok := <-t.tokChan
+		err, ok := tok.(error)
+		if ok {
 			t.sess.LogF(t.ctx, msdsn.LogDebug, "nextToken returned an error:"+err.Error())
 			// this is an error and not a token
 			return nil, err
 		} else {
 			return tok, nil
 		}
-	default:
-		// there are no tokens on the channel, will need to wait
 	}
 
 	select {


### PR DESCRIPTION
I noticed that the existing code probably didn't do quite what was intended. In its current state, it immediately overwrites the "more" variable received from the tokChan with the result of the type assertion. That seems like a bug. Additionally, the entire pattern that it uses is unnecessary and error prone: select statements are non-deterministic, so the default statement block might execute even if the channel is closed or not empty. I changed the code so that it checks the length of the channel before receiving. This way, the receive is guaranteed not to block and it will always execute whenever the channel is not empty.