### PR TITLE
Skip Attention packet when in rollback

### DIFF
--- a/queries_test.go
+++ b/queries_test.go
@@ -1240,7 +1240,7 @@ func TestCommitTranError(t *testing.T) {
 
 	// close connection to cause processBeginResponse to fail
 	conn.sess.buf.transport.Close()
-	err = conn.simpleProcessResp(ctx)
+	err = conn.simpleProcessResp(ctx, false)
 	switch err {
 	case nil:
 		t.Error("simpleProcessResp should fail but it succeeded")
@@ -1300,7 +1300,7 @@ func TestRollbackTranError(t *testing.T) {
 
 	// close connection to cause processBeginResponse to fail
 	conn.sess.buf.transport.Close()
-	err = conn.simpleProcessResp(ctx)
+	err = conn.simpleProcessResp(ctx, false)
 	switch err {
 	case nil:
 		t.Error("simpleProcessResp should fail but it succeeded")


### PR DESCRIPTION
We have noticed an issue when the context is cancelled during an open transaction.  In this case, the driver would be requested to rollback (via code in database/sql)...

```
func (tx *Tx) awaitDone() {
	// Wait for either the transaction to be committed or rolled
	// back, or for the associated context to be closed.
	<-tx.ctx.Done()

	// Discard and close the connection used to ensure the
	// transaction is closed and the resources are released.  This
	// rollback does nothing if the transaction has already been
	// committed or rolled back.
	// Do not discard the connection if the connection knows
	// how to reset the session.
	discardConnection := !tx.keepConnOnRollback
	tx.rollback(discardConnection)
}
```

The driver will request the rollback and during the processing of the rollback response, it will currently send an Attention packet.  If the rollback request is not yet complete (maybe the server is slow), then this may lead to the rollback being cancelled.

```
func (t tokenProcessor) nextToken() (tokenStruct, error) {
	...
	select {
	...
	case <-t.ctx.Done():
		if t.noAttn {
			return nil, t.ctx.Err()
		}
		t.sess.LogF(t.ctx, msdsn.LogDebug, "Sending attention to the server")
		if err := sendAttention(t.sess.buf); err != nil {
			// unable to send attention, current connection is bad
			// notify caller and close channel
			return nil, err
		}
```

This leads to an error from SQL...

`The request failed to run because the batch is aborted, this can be caused by abort signal sent from client, or another request is running in the same session, which makes the session busy.`

This means the transaction is left open in SQL leading to blocked queries etc.
If the transaction is subsequently requested to rollback, this will result in ErrTxDone as the transaction has already been marked as complete.