### PR TITLE
feat: add SQL Server 2025 VECTOR type support

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -161,8 +161,6 @@ jobs:
           export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}&trustServerCertificate=true"
           BENCH_PATTERN='Benchmark(BulkMakeParam|ConvertAssign|Decode|Encode|ManglePassword|Parse|Read|RoundTrip|Send|Str2ucs2|TdsBuffer|Ucs22str|Write)'
           git worktree add ../main-bench origin/main
-          cp -v *_benchmark_test.go ../main-bench/ 2>/dev/null || true
-          cp -v msdsn/*_benchmark_test.go ../main-bench/msdsn/ 2>/dev/null || true
           cd ../main-bench
           go test -run='^$' -bench="$BENCH_PATTERN" \
             -benchtime=1s -count=10 -benchmem -timeout=25m . ./msdsn 2>&1 | \

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -161,6 +161,8 @@ jobs:
           export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}&trustServerCertificate=true"
           BENCH_PATTERN='Benchmark(BulkMakeParam|ConvertAssign|Decode|Encode|ManglePassword|Parse|Read|RoundTrip|Send|Str2ucs2|TdsBuffer|Ucs22str|Write)'
           git worktree add ../main-bench origin/main
+          # Copy only shared benchmark files. PR-only benchmarks may depend on APIs absent from main;
+          # benchstat reports those benchmarks without a baseline measurement.
           for benchmark in *_benchmark_test.go msdsn/*_benchmark_test.go; do
             if [ -f "../main-bench/$benchmark" ]; then
               cp -v "$benchmark" "../main-bench/$benchmark"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -161,6 +161,11 @@ jobs:
           export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}&trustServerCertificate=true"
           BENCH_PATTERN='Benchmark(BulkMakeParam|ConvertAssign|Decode|Encode|ManglePassword|Parse|Read|RoundTrip|Send|Str2ucs2|TdsBuffer|Ucs22str|Write)'
           git worktree add ../main-bench origin/main
+          for benchmark in *_benchmark_test.go msdsn/*_benchmark_test.go; do
+            if [ -f "../main-bench/$benchmark" ]; then
+              cp -v "$benchmark" "../main-bench/$benchmark"
+            fi
+          done
           cd ../main-bench
           go test -run='^$' -bench="$BENCH_PATTERN" \
             -benchtime=1s -count=10 -benchmem -timeout=25m . ./msdsn 2>&1 | \

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -141,21 +141,7 @@ jobs:
             echo "Waiting for SQL Server... (attempt $i/30)"
             sleep 2
           done
-      - name: Warmup run (stabilize CPU/caches)
-        shell: bash
-        run: |
-          export SQLUSER=sa
-          export SQLPASSWORD=$SQLCMDPASSWORD
-          export DATABASE=master
-          export HOST=localhost
-          export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}&trustServerCertificate=true"
-          BENCH_PATTERN='Benchmark(BulkMakeParam|ConvertAssign|Decode|Encode|ManglePassword|Parse|Read|RoundTrip|Send|Str2ucs2|TdsBuffer|Ucs22str|Write)'
-          # Throwaway run to warm CPU caches, prime the Go runtime, and settle
-          # the OS scheduler. Results are discarded — ensures both measurement
-          # runs start from the same steady-state conditions.
-          go test -run='^$' -bench="$BENCH_PATTERN" \
-            -benchtime=100ms -count=1 -timeout=10m . ./msdsn > /dev/null 2>&1
-      - name: Run baseline benchmarks (main)
+      - name: Run interleaved benchmarks
         shell: bash
         run: |
           export SQLUSER=sa
@@ -165,6 +151,7 @@ jobs:
           export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}&trustServerCertificate=true"
           BENCH_PATTERN='Benchmark(BulkMakeParam|ConvertAssign|Decode|Encode|ManglePassword|Parse|Read|RoundTrip|Send|Str2ucs2|TdsBuffer|Ucs22str|Write)'
           git worktree add ../main-bench origin/main
+          trap 'git worktree remove ../main-bench --force || true' EXIT
           # Copy only shared benchmark files. PR-only benchmarks may depend on APIs absent from main;
           # benchstat reports those benchmarks without a baseline measurement.
           for benchmark in *_benchmark_test.go msdsn/*_benchmark_test.go; do
@@ -172,25 +159,44 @@ jobs:
               cp -v "$benchmark" "../main-bench/$benchmark"
             fi
           done
-          cd ../main-bench
+          # Warm both binaries before collecting measurements.
           go test -run='^$' -bench="$BENCH_PATTERN" \
-            -benchtime=1s -count=10 -benchmem -timeout=25m . ./msdsn 2>&1 | \
-            tee "$GITHUB_WORKSPACE/bench_old_full.log"
-          grep -E '^(Benchmark|goos:|goarch:|pkg:|cpu:)' "$GITHUB_WORKSPACE/bench_old_full.log" > "$GITHUB_WORKSPACE/bench_old.txt"
-          cd "$GITHUB_WORKSPACE"
-          git worktree remove ../main-bench --force
-      - name: Run PR benchmarks
-        shell: bash
-        run: |
-          export SQLUSER=sa
-          export SQLPASSWORD=$SQLCMDPASSWORD
-          export DATABASE=master
-          export HOST=localhost
-          export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}&trustServerCertificate=true"
-          BENCH_PATTERN='Benchmark(BulkMakeParam|ConvertAssign|Decode|Encode|ManglePassword|Parse|Read|RoundTrip|Send|Str2ucs2|TdsBuffer|Ucs22str|Write)'
-          go test -run='^$' -bench="$BENCH_PATTERN" \
-            -benchtime=1s -count=10 -benchmem -timeout=25m . ./msdsn 2>&1 | \
-            tee bench_new_full.log
+            -benchtime=100ms -count=1 -timeout=10m . ./msdsn > /dev/null
+          (
+            cd ../main-bench
+            go test -run='^$' -bench="$BENCH_PATTERN" \
+              -benchtime=100ms -count=1 -timeout=10m . ./msdsn > /dev/null
+          )
+
+          : > bench_old_full.log
+          : > bench_new_full.log
+          for iteration in {1..10}; do
+            if ((iteration % 2)); then
+              first=main
+              second=pr
+            else
+              first=pr
+              second=main
+            fi
+
+            for revision in "$first" "$second"; do
+              if [ "$revision" = main ]; then
+                (
+                  cd ../main-bench
+                  go test -run='^$' -bench="$BENCH_PATTERN" \
+                    -benchtime=1s -count=1 -benchmem -timeout=10m \
+                    -ldflags="-randlayout=$iteration" . ./msdsn
+                ) 2>&1 | tee -a "$GITHUB_WORKSPACE/bench_old_full.log"
+              else
+                go test -run='^$' -bench="$BENCH_PATTERN" \
+                  -benchtime=1s -count=1 -benchmem -timeout=10m \
+                  -ldflags="-randlayout=$iteration" . ./msdsn 2>&1 | \
+                  tee -a bench_new_full.log
+              fi
+            done
+          done
+
+          grep -E '^(Benchmark|goos:|goarch:|pkg:|cpu:)' bench_old_full.log > bench_old.txt
           grep -E '^(Benchmark|goos:|goarch:|pkg:|cpu:)' bench_new_full.log > bench_new.txt
       - name: Compare benchmarks
         shell: bash
@@ -214,8 +220,9 @@ jobs:
             echo "::notice::Performance improvements detected (see above)"
           fi
           # Fail on statistically significant regressions exceeding 15%
-          # Sequential CI runs produce systematic drift up to ~12%, so we require
-          # both statistical significance (no ~ marker) AND >15% magnitude.
+          # Interleaved samples and randomized function layouts reduce runner and
+          # binary-layout variance. Require both statistical significance (no ~
+          # marker) AND >15% magnitude.
           # Exclude TdsBuffer_Write_Large: ~120ns operation with multi-flush path
           # shows 30-46% swings between sequential CI runs due to cache sensitivity.
           REGRESSED=$(grep -v '~' bench_diff.txt | grep -v 'TdsBuffer_Write_Large' | grep -E '^\S+\s+.+\s+\+[0-9]+\.[0-9]+%' | awk -F'+' '{split($2,a,"%"); if (a[1]+0 >= 15) print}')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+## 1.9.7
+
+### Features
+
+* Add SQL Server 2025 Vector data type support with `Vector` and `NullVector` types for AI/ML workloads (#306)
+  - Supports float32 vectors up to 1998 dimensions
+  - Supports float16 vectors up to 3996 dimensions (preview feature)
+  - Compatible with `VECTOR_DISTANCE` similarity search functions
+  - See [doc/how-to-use-vectors.md](doc/how-to-use-vectors.md) for usage guide
+* Add `vectortypesupport` connection string parameter to control native vector format
+  - `off` (default): Vectors sent as JSON for backward compatibility
+  - `v1`: Enable optimized binary TDS protocol for vectors (SQL Server 2025+)
+
 ## 1.9.6
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Other supported formats are listed below.
   * `true` (Default) Client attempt to connect to all IPs simultaneously. 
   * `false` Client attempts to connect to IPs in serial.
 * `guid conversion` - Enables the conversion of GUIDs, so that byte order is preserved. UniqueIdentifier isn't supported for nullable fields, NullUniqueIdentifier must be used instead.
+* `vectortypesupport` - Controls native vector type support for SQL Server 2025+. See [How to use Vectors](doc/how-to-use-vectors.md).
+  * `off` (Default) Vectors are sent as JSON strings for backward compatibility.
+  * `v1` Enables optimized binary TDS protocol for vector data.
 
 ### Connection parameters for namedpipe package
 * `pipe`  - If set, no Browser query is made and named pipe used will be `\\<host>\pipe\<pipe>`
@@ -601,6 +604,7 @@ Constrain the provider to an allowed list of key vaults by appending vault host 
 * Supports query notifications
 * Supports Kerberos Authentication
 * Supports handling the `uniqueidentifier` data type with the `UniqueIdentifier` and `NullUniqueIdentifier` go types
+* Supports SQL Server 2025 Vector data type for AI/ML workloads with `Vector` and `NullVector` go types. See [How to use Vectors](doc/how-to-use-vectors.md)
 * Pluggable Dialer implementations through `msdsn.ProtocolParsers` and `msdsn.ProtocolDialers`
 * A `namedpipe` package to support connections using named pipes (np:) on Windows
 * A `sharedmemory` package to support connections using shared memory (lpc:) on Windows

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ All connection string parameters are case-insensitive. Providing the same parame
   * `true` (Default) Client attempt to connect to all IPs simultaneously. 
   * `false` Client attempts to connect to IPs in serial.
 * `guid conversion` - Enables the conversion of GUIDs, so that byte order is preserved. UniqueIdentifier isn't supported for nullable fields, NullUniqueIdentifier must be used instead.
+* `vectortypesupport` - Controls native vector type support for SQL Server 2025+. See [How to use Vectors](doc/how-to-use-vectors.md).
+  * `off` (Default) Vectors are sent as JSON strings for backward compatibility.
+  * `v1` Enables optimized binary TDS protocol for vector data.
 
 ### Connection parameters for namedpipe package
 * `pipe`  - If set, no Browser query is made and named pipe used will be `\\<host>\pipe\<pipe>`
@@ -619,6 +622,7 @@ Constrain the provider to an allowed list of key vaults by appending vault host 
 * Supports query notifications
 * Supports Kerberos Authentication
 * Supports handling the `uniqueidentifier` data type with the `UniqueIdentifier` and `NullUniqueIdentifier` go types
+* Supports SQL Server 2025 Vector data type for AI/ML workloads with `Vector` and `NullVector` go types. See [How to use Vectors](doc/how-to-use-vectors.md)
 * Pluggable Dialer implementations through `msdsn.ProtocolParsers` and `msdsn.ProtocolDialers`
 * A `namedpipe` package to support connections using named pipes (np:) on Windows
 * A `sharedmemory` package to support connections using shared memory (lpc:) on Windows

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -373,29 +373,41 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 		return b.makeParam(valuer.Decimal, col)
 	case Money[shopspring.NullDecimal]:
 		return b.makeParam(valuer.Decimal, col)
+	case []float32:
+		vector, e := NewVector(valuer)
+		if e != nil {
+			return res, e
+		}
+		return b.makeBulkVectorParam(vector, col)
+	case []float64:
+		vector, e := NewVectorFromFloat64(valuer)
+		if e != nil {
+			return res, e
+		}
+		return b.makeBulkVectorParam(vector, col)
 	case Vector:
-		return makeBulkVectorParam(valuer, col)
+		return b.makeBulkVectorParam(valuer, col)
 	case *Vector:
 		if valuer == nil {
 			res.ti = col.ti
 			res.ti.Size = 0
 			return
 		}
-		return makeBulkVectorParam(*valuer, col)
+		return b.makeBulkVectorParam(*valuer, col)
 	case NullVector:
 		if !valuer.Valid {
 			res.ti = col.ti
 			res.ti.Size = 0
 			return
 		}
-		return makeBulkVectorParam(valuer.Vector, col)
+		return b.makeBulkVectorParam(valuer.Vector, col)
 	case *NullVector:
 		if valuer == nil || !valuer.Valid {
 			res.ti = col.ti
 			res.ti.Size = 0
 			return
 		}
-		return makeBulkVectorParam(valuer.Vector, col)
+		return b.makeBulkVectorParam(valuer.Vector, col)
 	case driver.Valuer:
 		var e error
 		val, e = driver.DefaultParameterConverter.ConvertValue(valuer)
@@ -730,10 +742,14 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 
 }
 
-func makeBulkVectorParam(vector Vector, col columnStruct) (res param, err error) {
+func (b *Bulk) makeBulkVectorParam(vector Vector, col columnStruct) (res param, err error) {
 	res.ti = col.ti
 	if col.ti.TypeId != typeVectorN {
-		return res, fmt.Errorf("mssql: cannot use Vector for column type %x", col.ti.TypeId)
+		value, valueErr := vector.Value()
+		if valueErr != nil {
+			return res, valueErr
+		}
+		return b.makeParam(value, col)
 	}
 	if vector.Data == nil {
 		res.ti.Size = 0

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -377,18 +377,21 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 		return makeBulkVectorParam(valuer, col)
 	case *Vector:
 		if valuer == nil {
+			res.ti = col.ti
 			res.ti.Size = 0
 			return
 		}
 		return makeBulkVectorParam(*valuer, col)
 	case NullVector:
 		if !valuer.Valid {
+			res.ti = col.ti
 			res.ti.Size = 0
 			return
 		}
 		return makeBulkVectorParam(valuer.Vector, col)
 	case *NullVector:
 		if valuer == nil || !valuer.Valid {
+			res.ti = col.ti
 			res.ti.Size = 0
 			return
 		}

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -373,6 +373,26 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 		return b.makeParam(valuer.Decimal, col)
 	case Money[shopspring.NullDecimal]:
 		return b.makeParam(valuer.Decimal, col)
+	case Vector:
+		return makeBulkVectorParam(valuer, col)
+	case *Vector:
+		if valuer == nil {
+			res.ti.Size = 0
+			return
+		}
+		return makeBulkVectorParam(*valuer, col)
+	case NullVector:
+		if !valuer.Valid {
+			res.ti.Size = 0
+			return
+		}
+		return makeBulkVectorParam(valuer.Vector, col)
+	case *NullVector:
+		if valuer == nil || !valuer.Valid {
+			res.ti.Size = 0
+			return
+		}
+		return makeBulkVectorParam(valuer.Vector, col)
 	case driver.Valuer:
 		var e error
 		val, e = driver.DefaultParameterConverter.ConvertValue(valuer)
@@ -705,6 +725,30 @@ func (b *Bulk) makeParam(val DataValue, col columnStruct) (res param, err error)
 	}
 	return
 
+}
+
+func makeBulkVectorParam(vector Vector, col columnStruct) (res param, err error) {
+	res.ti = col.ti
+	if col.ti.TypeId != typeVectorN {
+		return res, fmt.Errorf("mssql: cannot use Vector for column type %x", col.ti.TypeId)
+	}
+	if vector.Data == nil {
+		res.ti.Size = 0
+		return res, nil
+	}
+	if byte(vector.ElementType) != col.ti.Scale {
+		return res, fmt.Errorf("mssql: vector element type %s does not match column element type %s",
+			vector.ElementType, VectorElementType(col.ti.Scale))
+	}
+	dimensions, _, ok := vectorDimensionsFromTypeInfo(col.ti)
+	if !ok || len(vector.Data) != dimensions {
+		return res, fmt.Errorf("mssql: vector dimensions %d do not match column dimensions %d", len(vector.Data), dimensions)
+	}
+	res.buffer, err = vector.encodeToBytes()
+	if err == nil {
+		res.ti.Size = len(res.buffer)
+	}
+	return res, err
 }
 
 func (b *Bulk) dlogf(ctx context.Context, format string, v ...interface{}) {

--- a/doc/how-to-use-vectors.md
+++ b/doc/how-to-use-vectors.md
@@ -1,0 +1,381 @@
+# How to Use SQL Server 2025 Vector Types
+
+This guide explains how to work with the new Vector data type in SQL Server 2025 using the go-mssqldb driver.
+
+## Overview
+
+SQL Server 2025 introduces native vector support for AI and machine learning workloads. The `VECTOR` type stores fixed-dimensional arrays of floating-point numbers, optimized for similarity search operations.
+
+### Key Features
+- **float32 vectors**: Up to 1998 dimensions (4 bytes per element)
+- **float16 vectors** (preview): Up to 3996 dimensions (2 bytes per element) - see [float16 requirements](#element-types)
+- **Native similarity functions**: `VECTOR_DISTANCE` with cosine, euclidean, and dot product metrics
+
+## Creating Vectors
+
+Use `NewVector` to create a new vector from a slice of float32 values:
+
+```go
+import mssql "github.com/microsoft/go-mssqldb"
+
+// Create a 3-dimensional vector
+v, err := mssql.NewVector([]float32{0.1, 0.2, 0.3})
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+### Using NullVector for Nullable Columns
+
+For columns that may contain NULL values, use `NullVector`:
+
+```go
+// A valid vector
+nv := mssql.NullVector{
+    Vector: v,
+    Valid:  true,
+}
+
+// A NULL vector
+nullNv := mssql.NullVector{
+    Valid: false,
+}
+```
+
+## Inserting Vectors
+
+Vectors can be passed directly as parameters to INSERT statements. You can use `Vector` types or plain Go slices:
+
+```go
+db, err := sql.Open("sqlserver", "sqlserver://user:password@server?database=mydb")
+if err != nil {
+    log.Fatal(err)
+}
+
+// Create the table with a VECTOR column
+_, err = db.Exec(`
+    CREATE TABLE embeddings (
+        id INT IDENTITY(1,1) PRIMARY KEY,
+        name NVARCHAR(100),
+        embedding VECTOR(3) NOT NULL
+    )
+`)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Option 1: Insert using Vector type
+v, _ := mssql.NewVector([]float32{1.0, 2.0, 3.0})
+_, err = db.Exec(
+    "INSERT INTO embeddings (name, embedding) VALUES (@p1, @p2)",
+    "example1", v,
+)
+
+// Option 2: Insert using []float32 directly (convenient for frameworks)
+_, err = db.Exec(
+    "INSERT INTO embeddings (name, embedding) VALUES (@p1, @p2)",
+    "example2", []float32{4.0, 5.0, 6.0},
+)
+
+// Option 3: Insert using []float64 (converted to float32 with possible precision loss)
+// Useful when working with Go libraries that use float64 (e.g., gonum)
+_, err = db.Exec(
+    "INSERT INTO embeddings (name, embedding) VALUES (@p1, @p2)",
+    "example3", []float64{7.0, 8.0, 9.0},
+)
+```
+
+## Reading Vectors
+
+Vectors can be scanned from query results using the `Vector` type or `NullVector` type.
+The driver returns VECTOR data as binary (when native format is enabled) or JSON string,
+and the `Vector.Scan` method decodes this automatically. Note that you cannot scan directly
+into `[]float32` or `[]float64`—use `Vector` and then call `Values()` to get the slice.
+
+```go
+rows, err := db.Query("SELECT id, name, embedding FROM embeddings")
+if err != nil {
+    log.Fatal(err)
+}
+defer rows.Close()
+
+for rows.Next() {
+    var id int
+    var name string
+    // Scan to Vector type (ElementType is determined from the binary header or defaults to FLOAT32)
+    var embedding mssql.Vector
+
+    if err := rows.Scan(&id, &name, &embedding); err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("ID: %d, Name: %s, Dimensions: %d\n", id, name, embedding.Dimensions())
+    fmt.Printf("Values: %v\n", embedding.Values())
+}
+```
+
+### Scanning to Native Go Slices
+
+You can scan vectors directly to `[]float32` by using an intermediate `Vector` type:
+
+```go
+var v mssql.Vector
+err := row.Scan(&v)
+embedding := v.Values() // returns []float32
+```
+
+When scanning to `interface{}`, the driver returns `[]byte` (raw binary vector data) when native vector type support is enabled (for example, by using `vectortypesupport=v1` in the connection string).
+If native vector support is not available, the value may instead be returned as a JSON-encoded `string`.
+
+For decoded vector values, always scan to `mssql.Vector` or `mssql.NullVector`:
+
+```go
+var result interface{}
+if err := row.Scan(&result); err != nil {
+    log.Fatal(err)
+}
+
+switch v := result.(type) {
+case []byte:
+    // Native vector support: decode using Vector.Scan()
+    var vec mssql.Vector
+    if err := vec.Scan(v); err != nil {
+        log.Fatal(err)
+    }
+    floats := vec.Values()
+    _ = floats
+case string:
+    // Fallback: parse JSON string into []float32 as needed.
+    // For example: json.Unmarshal([]byte(v), &floats)
+default:
+    log.Fatalf("unexpected vector type %T", v)
+}
+```
+
+### Reading Nullable Vectors
+
+```go
+var nullableEmbedding mssql.NullVector
+err := row.Scan(&nullableEmbedding)
+if err != nil {
+    log.Fatal(err)
+}
+
+if nullableEmbedding.Valid {
+    fmt.Printf("Vector: %v\n", nullableEmbedding.Vector.Values())
+} else {
+    fmt.Println("Vector is NULL")
+}
+```
+
+## Vector Similarity Search with VECTOR_DISTANCE
+
+SQL Server 2025 provides the `VECTOR_DISTANCE` function for similarity search:
+
+```go
+// Create query vector
+queryVector, _ := mssql.NewVector([]float32{1.0, 0.0, 0.0})
+
+// Search for similar vectors using cosine distance
+rows, err := db.Query(`
+    SELECT TOP 10 name, VECTOR_DISTANCE('cosine', embedding, @p1) as distance
+    FROM embeddings
+    ORDER BY distance
+`, queryVector)
+if err != nil {
+    log.Fatal(err)
+}
+defer rows.Close()
+
+for rows.Next() {
+    var name string
+    var distance float64
+    if err := rows.Scan(&name, &distance); err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("Name: %s, Distance: %.4f\n", name, distance)
+}
+```
+
+### Distance Metrics
+
+The `VECTOR_DISTANCE` function supports three distance metrics:
+
+| Metric | Description | Range |
+|--------|-------------|-------|
+| `'cosine'` | Cosine distance (1 - cosine similarity) | 0 to 2 |
+| `'euclidean'` | Euclidean (L2) distance | 0 to ∞ |
+| `'dot'` | Negative dot product | -∞ to ∞ |
+
+## Vector Methods
+
+The `Vector` type provides several useful methods:
+
+```go
+v, _ := mssql.NewVector([]float32{1.0, 2.0, 3.0})
+
+// Get the number of dimensions
+dims := v.Dimensions() // 3
+
+// Get the values as float32 slice
+values := v.Values() // []float32{1.0, 2.0, 3.0}
+
+// Get values as float64 slice (convenient for Go libraries that use float64)
+// Note: This is a widening conversion from the stored float32 values
+float64Values := v.ToFloat64() // []float64{1.0, 2.0, 3.0}
+
+// Get element type
+elementType := v.ElementType // mssql.VectorElementFloat32
+
+// String representation
+str := v.String() // "VECTOR(FLOAT32, 3) : [1, 2, 3]"
+```
+
+## Element Types
+
+SQL Server 2025 supports two element types:
+
+| Type | Constant | Bytes | Max Dimensions | Notes |
+|------|----------|-------|----------------|-------|
+| float32 | `VectorElementFloat32` | 4 | 1998 | Default, fully supported |
+| float16 | `VectorElementFloat16` | 2 | 3996 | Preview feature (see below) |
+
+> **Precision Note:** SQL Server vectors store 32-bit or 16-bit floating-point values, not 64-bit. When inserting `[]float64` from Go, values are converted to float32 which may lose precision. For example, `0.123456789012345` becomes `0.12345679`. Most ML embedding models produce float32 values, so this is typically not an issue.
+
+### float16 Preview Feature
+
+To use float16 vectors, you must enable the preview feature in SQL Server:
+
+```sql
+ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON;
+```
+
+Then create columns with the float16 base type:
+
+```sql
+CREATE TABLE embeddings (
+    id INT PRIMARY KEY,
+    embedding VECTOR(3, float16) NOT NULL
+);
+```
+
+> **Note:** The element type is determined by the SQL Server column definition (e.g., `VECTOR(3)` for float32, `VECTOR(3, float16)` for float16), not by the Go-side `Vector` struct. When inserting float32 vectors from Go with a compatible server, they are transmitted using the native binary vector format. For float16 vectors (or when binary parameters aren't supported), vectors are sent as JSON strings and SQL Server converts them to the column's declared element type.
+>
+> **float16 TDS Limitation:** Currently, float16 vector parameters are sent as JSON over TDS because a binary parameter format for float16 is not yet available. The driver reads float16 vectors from SQL Server using the binary vector format and converts them to float32 values in Go.
+
+
+
+## Best Practices
+
+### 1. Use Appropriate Dimensions
+Choose dimensions that match your embedding model. Common sizes include 384, 768, 1024, and 1536.
+
+```sql
+-- OpenAI ada-002 embeddings (1536 dimensions)
+CREATE TABLE documents (
+    id INT PRIMARY KEY,
+    content NVARCHAR(MAX),
+    embedding VECTOR(1536) NOT NULL
+)
+```
+
+### 2. Create Vector Indexes for Large Tables
+For tables with many vectors, create a vector index to speed up similarity searches:
+
+```sql
+CREATE VECTOR INDEX idx_embedding ON documents(embedding)
+WITH (DISTANCE_METRIC = 'COSINE', QUANTIZER = 'FLAT')
+```
+
+### 3. Use Transactions for Batch Operations
+When inserting multiple vectors, use transactions for better performance:
+
+```go
+tx, err := db.Begin()
+if err != nil {
+    log.Fatal(err)
+}
+defer tx.Rollback()
+
+stmt, err := tx.Prepare("INSERT INTO embeddings (name, embedding) VALUES (@p1, @p2)")
+if err != nil {
+    log.Fatal(err)
+}
+
+for i := 0; i < 1000; i++ {
+    v, _ := mssql.NewVector(generateEmbedding(i))
+    _, err = stmt.Exec(fmt.Sprintf("item_%d", i), v)
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+
+if err := tx.Commit(); err != nil {
+    log.Fatal(err)
+}
+```
+
+## Limitations
+
+1. **Maximum dimensions**: Vectors are limited to 1998 dimensions for float32 and 3996 dimensions for float16.
+
+2. **Always Encrypted**: The Vector data type is not supported with Always Encrypted. This is a SQL Server limitation. See [Always Encrypted limitations](https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-database-engine#limitations).
+
+3. **NULL vectors and dimensions**: When inserting a NULL vector using `mssql.NullVector{Valid: false}`, the driver sends the value as an `NVARCHAR(1)` NULL so that SQL Server does not enforce any vector dimension matching for that parameter. You typically do not need to declare a specific vector dimension for NULL parameters; dimension matching still applies to non-NULL vectors and to table definitions that use the `VECTOR` type with a fixed dimension.
+
+## Precision Loss Warnings
+
+When inserting `[]float64` values, they are converted to float32, which may lose precision. You can enable warnings to detect when this occurs:
+
+```go
+// Option 1: Enable driver logging for precision loss warnings.
+// Logs via the driver logger; configure one with SetLogger or SetContextLogger to see messages.
+mssql.SetVectorPrecisionWarnings(true)
+
+// Option 2: Use a custom handler for integration with your logging framework
+mssql.SetVectorPrecisionLossHandler(func(index int, original float64, converted float32) {
+    slog.Warn("vector precision loss", 
+        "index", index,
+        "original", original, 
+        "converted", converted)
+})
+```
+
+For performance, only the first precision loss per vector is reported.
+
+## Requirements
+
+- SQL Server 2025 or later
+- go-mssqldb driver version 1.9.7 or later
+
+## Connection String Configuration
+
+The `vectortypesupport` connection string parameter controls how vector data is transmitted between the driver and SQL Server:
+
+| Value | Description |
+|-------|-------------|
+| `off` (default) | Vectors are sent as JSON strings using standard parameter types. This mode is intended for backward-compatible client behavior and works with SQL Server 2025+ even without vector feature negotiation; older SQL Server versions still cannot store `VECTOR` columns or use `VECTOR` functions. |
+| `v1` | Enables native binary TDS protocol for vectors. Requires SQL Server 2025+. |
+
+### Examples
+
+```go
+// Default: JSON format (backward compatible)
+db, _ := sql.Open("sqlserver", "sqlserver://user:pass@server?database=mydb")
+
+// Enable native binary vector format
+db, _ := sql.Open("sqlserver", "sqlserver://user:pass@server?database=mydb&vectortypesupport=v1")
+
+// ODBC format
+db, _ := sql.Open("sqlserver", "odbc:server=host;vectortypesupport=v1")
+
+// ADO format
+db, _ := sql.Open("sqlserver", "server=host;vectortypesupport=v1")
+```
+
+**Note:** The default is `off` to ensure backward compatibility. When connecting to SQL Server 2025+, setting `vectortypesupport=v1` enables the optimized binary format which may provide better performance for large vectors.
+
+## See Also
+
+- [SQL Server 2025 Vector documentation](https://learn.microsoft.com/sql/relational-databases/vectors/vectors-sql-server)
+- [Vector search best practices](https://learn.microsoft.com/sql/relational-databases/vectors/vector-search-overview)

--- a/doc/how-to-use-vectors.md
+++ b/doc/how-to-use-vectors.md
@@ -323,6 +323,8 @@ if err := tx.Commit(); err != nil {
 
 3. **NULL vectors and dimensions**: When inserting a NULL vector using `mssql.NullVector{Valid: false}`, the driver sends the value as an `NVARCHAR(1)` NULL so that SQL Server does not enforce any vector dimension matching for that parameter. You typically do not need to declare a specific vector dimension for NULL parameters; dimension matching still applies to non-NULL vectors and to table definitions that use the `VECTOR` type with a fixed dimension.
 
+4. **Element type with JSON fallback**: JSON doesn't contain vector element-type metadata. With `vectortypesupport=off`, `Vector.Scan` decodes arrays with 1 through 1998 dimensions as float32 and larger arrays as float16. A float16 vector with 1998 or fewer dimensions therefore scans as float32. Use `vectortypesupport=v1` when the application must preserve the element type returned by SQL Server.
+
 ## Precision Loss Warnings
 
 When inserting `[]float64` values, they are converted to float32, which may lose precision. You can enable warnings to detect when this occurs:

--- a/doc/how-to-use-vectors.md
+++ b/doc/how-to-use-vectors.md
@@ -259,9 +259,9 @@ CREATE TABLE embeddings (
 );
 ```
 
-> **Note:** The element type is determined by the SQL Server column definition (e.g., `VECTOR(3)` for float32, `VECTOR(3, float16)` for float16), not by the Go-side `Vector` struct. With `vectortypesupport=v1`, float32 parameters and results use the native binary vector format. Float16 parameters use JSON, and float16 results use JSON because native float16 results require protocol version 2.
+> **Note:** The element type is determined by the SQL Server column definition (e.g., `VECTOR(3)` for float32, `VECTOR(3, float16)` for float16), not by the Go-side `Vector` struct. With `vectortypesupport=v1`, float32 parameters use the native binary vector format, while float16 parameters use JSON. Native float32 and float16 results preserve the element type from the binary header.
 >
-> **float16 TDS Limitation:** Protocol version 1 does not preserve float16 result metadata. JSON results with 1998 or fewer dimensions scan as float32; larger results scan as float16.
+> **JSON fallback limitation:** JSON results don't contain element-type metadata. JSON arrays with 1 through 1998 dimensions scan as float32, while larger arrays scan as float16.
 
 
 
@@ -323,7 +323,7 @@ if err := tx.Commit(); err != nil {
 
 1. **NULL vectors and dimensions**: When inserting a NULL vector using `mssql.NullVector{Valid: false}`, the driver sends the value as an `NVARCHAR(1)` NULL so that SQL Server does not enforce any vector dimension matching for that parameter. You typically do not need to declare a specific vector dimension for NULL parameters; dimension matching still applies to non-NULL vectors and to table definitions that use the `VECTOR` type with a fixed dimension.
 
-1. **Element type with JSON fallback**: JSON doesn't contain vector element-type metadata. With `vectortypesupport=off`, `Vector.Scan` decodes arrays with 1 through 1998 dimensions as float32 and larger arrays as float16. A float16 vector with 1998 or fewer dimensions therefore scans as float32. Protocol version 1 provides native float32 results only; float16 results require protocol version 2, which this release does not negotiate.
+1. **Element type with JSON fallback**: JSON doesn't contain vector element-type metadata. With `vectortypesupport=off`, `Vector.Scan` decodes arrays with 1 through 1998 dimensions as float32 and larger arrays as float16. A float16 vector with 1998 or fewer dimensions therefore scans as float32. Native float32 and float16 results preserve the element type from the binary header.
 
 1. **Table-valued parameters**: `Vector` and `NullVector` fields aren't supported in table-valued parameters.
 

--- a/doc/how-to-use-vectors.md
+++ b/doc/how-to-use-vectors.md
@@ -178,7 +178,7 @@ queryVector, _ := mssql.NewVector([]float32{1.0, 0.0, 0.0})
 
 // Search for similar vectors using cosine distance
 rows, err := db.Query(`
-    SELECT TOP 10 name, VECTOR_DISTANCE('cosine', embedding, @p1) as distance
+    SELECT TOP 10 name, VECTOR_DISTANCE('cosine', embedding, CAST(@p1 AS VECTOR(3))) as distance
     FROM embeddings
     ORDER BY distance
 `, queryVector)
@@ -259,9 +259,9 @@ CREATE TABLE embeddings (
 );
 ```
 
-> **Note:** The element type is determined by the SQL Server column definition (e.g., `VECTOR(3)` for float32, `VECTOR(3, float16)` for float16), not by the Go-side `Vector` struct. When inserting float32 vectors from Go with a compatible server, they are transmitted using the native binary vector format. For float16 vectors (or when binary parameters aren't supported), vectors are sent as JSON strings and SQL Server converts them to the column's declared element type.
+> **Note:** The element type is determined by the SQL Server column definition (e.g., `VECTOR(3)` for float32, `VECTOR(3, float16)` for float16), not by the Go-side `Vector` struct. With `vectortypesupport=v1`, float32 parameters and results use the native binary vector format. Float16 parameters use JSON, and float16 results use JSON because native float16 results require protocol version 2.
 >
-> **float16 TDS Limitation:** Currently, float16 vector parameters are sent as JSON over TDS because a binary parameter format for float16 is not yet available. The driver reads float16 vectors from SQL Server using the binary vector format and converts them to float32 values in Go.
+> **float16 TDS Limitation:** Protocol version 1 does not preserve float16 result metadata. JSON results with 1998 or fewer dimensions scan as float32; larger results scan as float16.
 
 
 
@@ -323,7 +323,7 @@ if err := tx.Commit(); err != nil {
 
 3. **NULL vectors and dimensions**: When inserting a NULL vector using `mssql.NullVector{Valid: false}`, the driver sends the value as an `NVARCHAR(1)` NULL so that SQL Server does not enforce any vector dimension matching for that parameter. You typically do not need to declare a specific vector dimension for NULL parameters; dimension matching still applies to non-NULL vectors and to table definitions that use the `VECTOR` type with a fixed dimension.
 
-4. **Element type with JSON fallback**: JSON doesn't contain vector element-type metadata. With `vectortypesupport=off`, `Vector.Scan` decodes arrays with 1 through 1998 dimensions as float32 and larger arrays as float16. A float16 vector with 1998 or fewer dimensions therefore scans as float32. Use `vectortypesupport=v1` when the application must preserve the element type returned by SQL Server.
+4. **Element type with JSON fallback**: JSON doesn't contain vector element-type metadata. With `vectortypesupport=off`, `Vector.Scan` decodes arrays with 1 through 1998 dimensions as float32 and larger arrays as float16. A float16 vector with 1998 or fewer dimensions therefore scans as float32. Protocol version 1 provides native float32 results only; float16 results require protocol version 2, which this release does not negotiate.
 
 ## Precision Loss Warnings
 
@@ -356,8 +356,8 @@ The `vectortypesupport` connection string parameter controls how vector data is 
 
 | Value | Description |
 |-------|-------------|
-| `off` (default) | Vectors are sent as JSON strings using standard parameter types. This mode is intended for backward-compatible client behavior and works with SQL Server 2025+ even without vector feature negotiation; older SQL Server versions still cannot store `VECTOR` columns or use `VECTOR` functions. |
-| `v1` | Enables native binary TDS protocol for vectors. Requires SQL Server 2025+. |
+| `off` (default) | Vectors are sent as JSON strings using standard parameter types. This mode is intended for backward-compatible client behavior and works with SQL Server 2025 and later versions even without vector feature negotiation; older SQL Server versions still cannot store `VECTOR` columns or use `VECTOR` functions. |
+| `v1` | Enables native binary TDS protocol version 1 for float32 vectors. Float16 still uses JSON. Requires SQL Server 2025 and later versions. |
 
 ### Examples
 
@@ -375,7 +375,7 @@ db, _ := sql.Open("sqlserver", "odbc:server=host;vectortypesupport=v1")
 db, _ := sql.Open("sqlserver", "server=host;vectortypesupport=v1")
 ```
 
-**Note:** The default is `off` to ensure backward compatibility. When connecting to SQL Server 2025+, setting `vectortypesupport=v1` enables the optimized binary format which may provide better performance for large vectors.
+**Note:** The default is `off` to ensure backward compatibility. When connecting to SQL Server 2025 and later versions, setting `vectortypesupport=v1` enables the optimized binary format for float32 vectors.
 
 ## See Also
 

--- a/doc/how-to-use-vectors.md
+++ b/doc/how-to-use-vectors.md
@@ -284,7 +284,7 @@ For tables with many vectors, create a vector index to speed up similarity searc
 
 ```sql
 CREATE VECTOR INDEX idx_embedding ON documents(embedding)
-WITH (DISTANCE_METRIC = 'COSINE', QUANTIZER = 'FLAT')
+WITH (METRIC = 'COSINE', TYPE = 'DISKANN')
 ```
 
 ### 3. Use Transactions for Batch Operations
@@ -319,11 +319,13 @@ if err := tx.Commit(); err != nil {
 
 1. **Maximum dimensions**: Vectors are limited to 1998 dimensions for float32 and 3996 dimensions for float16.
 
-2. **Always Encrypted**: The Vector data type is not supported with Always Encrypted. This is a SQL Server limitation. See [Always Encrypted limitations](https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-database-engine#limitations).
+1. **Always Encrypted**: The Vector data type is not supported with Always Encrypted. This is a SQL Server limitation. See [Always Encrypted limitations](https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-database-engine#limitations).
 
-3. **NULL vectors and dimensions**: When inserting a NULL vector using `mssql.NullVector{Valid: false}`, the driver sends the value as an `NVARCHAR(1)` NULL so that SQL Server does not enforce any vector dimension matching for that parameter. You typically do not need to declare a specific vector dimension for NULL parameters; dimension matching still applies to non-NULL vectors and to table definitions that use the `VECTOR` type with a fixed dimension.
+1. **NULL vectors and dimensions**: When inserting a NULL vector using `mssql.NullVector{Valid: false}`, the driver sends the value as an `NVARCHAR(1)` NULL so that SQL Server does not enforce any vector dimension matching for that parameter. You typically do not need to declare a specific vector dimension for NULL parameters; dimension matching still applies to non-NULL vectors and to table definitions that use the `VECTOR` type with a fixed dimension.
 
-4. **Element type with JSON fallback**: JSON doesn't contain vector element-type metadata. With `vectortypesupport=off`, `Vector.Scan` decodes arrays with 1 through 1998 dimensions as float32 and larger arrays as float16. A float16 vector with 1998 or fewer dimensions therefore scans as float32. Protocol version 1 provides native float32 results only; float16 results require protocol version 2, which this release does not negotiate.
+1. **Element type with JSON fallback**: JSON doesn't contain vector element-type metadata. With `vectortypesupport=off`, `Vector.Scan` decodes arrays with 1 through 1998 dimensions as float32 and larger arrays as float16. A float16 vector with 1998 or fewer dimensions therefore scans as float32. Protocol version 1 provides native float32 results only; float16 results require protocol version 2, which this release does not negotiate.
+
+1. **Table-valued parameters**: `Vector` and `NullVector` fields aren't supported in table-valued parameters.
 
 ## Precision Loss Warnings
 
@@ -347,8 +349,7 @@ For performance, only the first precision loss per vector is reported.
 
 ## Requirements
 
-- SQL Server 2025 or later
-- go-mssqldb driver version 1.9.7 or later
+- SQL Server 2025 and later versions
 
 ## Connection String Configuration
 

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -38,6 +38,19 @@ const (
 	EncryptionStrict   = 4
 )
 
+// VectorTypeSupport controls how vector data types are handled.
+// This matches the JDBC/ODBC vectorTypeSupport connection property.
+type VectorTypeSupport int
+
+const (
+	// VectorTypeSupportOff disables native vector type support.
+	// Vector data will be returned as JSON strings for backward compatibility.
+	VectorTypeSupportOff VectorTypeSupport = 0
+	// VectorTypeSupportV1 enables native vector type support (SQL Server 2025+).
+	// This uses the optimized binary TDS protocol for vector data.
+	VectorTypeSupportV1 VectorTypeSupport = 1
+)
+
 const (
 	LogErrors      Log = 1
 	LogMessages    Log = 2
@@ -88,6 +101,7 @@ const (
 	NoTraceID              = "notraceid"
 	GuidConversion         = "guid conversion"
 	Timezone               = "timezone"
+	VectorTypeSupportParam = "vectortypesupport"
 	EpaEnabled             = "epa enabled"
 )
 
@@ -162,6 +176,10 @@ type Config struct {
 	NoTraceID bool
 	// Parameters related to type encoding
 	Encoding EncodeParameters
+	// VectorTypeSupport controls native vector type handling.
+	// Matches JDBC/ODBC vectorTypeSupport connection property.
+	// Default is VectorTypeSupportOff for backward compatibility.
+	VectorTypeSupport VectorTypeSupport
 	// EPA mode determines how the Channel Bindings are calculated.
 	EpaEnabled bool
 }
@@ -642,6 +660,20 @@ func Parse(dsn string) (Config, error) {
 		p.Encoding.GuidConversion = false
 	}
 
+	// Parse vectorTypeSupport: off, v1 (default: off for backward compatibility)
+	// Matches JDBC/ODBC vectorTypeSupport connection property
+	p.VectorTypeSupport = VectorTypeSupportOff
+	if vectorSupport, ok := params[VectorTypeSupportParam]; ok {
+		switch strings.ToLower(vectorSupport) {
+		case "off", "0":
+			p.VectorTypeSupport = VectorTypeSupportOff
+		case "v1", "1":
+			p.VectorTypeSupport = VectorTypeSupportV1
+		default:
+			return p, fmt.Errorf("invalid vectortypesupport '%s': must be 'off' or 'v1'", vectorSupport)
+		}
+	}
+
 	p.EpaEnabled = false
 	epaString, ok := params[EpaEnabled]
 	if !ok {
@@ -723,6 +755,13 @@ func (p Config) URL() *url.URL {
 
 	if tz := p.Encoding.Timezone; tz != nil && tz != time.UTC {
 		q.Add(Timezone, tz.String())
+	}
+
+	if p.VectorTypeSupport != VectorTypeSupportOff {
+		switch p.VectorTypeSupport {
+		case VectorTypeSupportV1:
+			q.Add(VectorTypeSupportParam, "v1")
+		}
 	}
 
 	if len(q) > 0 {

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -38,6 +38,19 @@ const (
 	EncryptionStrict   = 4
 )
 
+// VectorTypeSupport controls how vector data types are handled.
+// This matches the JDBC/ODBC vectorTypeSupport connection property.
+type VectorTypeSupport int
+
+const (
+	// VectorTypeSupportOff disables native vector type support.
+	// Vector data will be returned as JSON strings for backward compatibility.
+	VectorTypeSupportOff VectorTypeSupport = 0
+	// VectorTypeSupportV1 enables native vector type support (SQL Server 2025+).
+	// This uses the optimized binary TDS protocol for vector data.
+	VectorTypeSupportV1 VectorTypeSupport = 1
+)
+
 const (
 	LogErrors      Log = 1
 	LogMessages    Log = 2
@@ -89,6 +102,7 @@ const (
 	NoTraceID              = "notraceid"
 	GuidConversion         = "guid conversion"
 	Timezone               = "timezone"
+	VectorTypeSupportParam = "vectortypesupport"
 	EpaEnabled             = "epa enabled"
 )
 
@@ -167,6 +181,10 @@ type Config struct {
 	TrustServerCertificate bool
 	// Parameters related to type encoding
 	Encoding EncodeParameters
+	// VectorTypeSupport controls native vector type handling.
+	// Matches JDBC/ODBC vectorTypeSupport connection property.
+	// Default is VectorTypeSupportOff for backward compatibility.
+	VectorTypeSupport VectorTypeSupport
 	// EPA mode determines how the Channel Bindings are calculated.
 	EpaEnabled bool
 }
@@ -652,6 +670,20 @@ func Parse(dsn string) (Config, error) {
 		p.Encoding.GuidConversion = false
 	}
 
+	// Parse vectorTypeSupport: off, v1 (default: off for backward compatibility)
+	// Matches JDBC/ODBC vectorTypeSupport connection property
+	p.VectorTypeSupport = VectorTypeSupportOff
+	if vectorSupport, ok := params[VectorTypeSupportParam]; ok {
+		switch strings.ToLower(vectorSupport) {
+		case "off", "0":
+			p.VectorTypeSupport = VectorTypeSupportOff
+		case "v1", "1":
+			p.VectorTypeSupport = VectorTypeSupportV1
+		default:
+			return p, fmt.Errorf("invalid vectortypesupport '%s': must be 'off' or 'v1'", vectorSupport)
+		}
+	}
+
 	p.EpaEnabled = false
 	epaString, ok := params[EpaEnabled]
 	if !ok {
@@ -752,6 +784,13 @@ func (p Config) URL() *url.URL {
 	}
 	if p.FailOverPartnerSPN != "" {
 		q.Add(FailoverPartnerSpn, p.FailOverPartnerSPN)
+	}
+
+	if p.VectorTypeSupport != VectorTypeSupportOff {
+		switch p.VectorTypeSupport {
+		case VectorTypeSupportV1:
+			q.Add(VectorTypeSupportParam, "v1")
+		}
 	}
 
 	if len(q) > 0 {

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -181,12 +181,18 @@ type Config struct {
 	TrustServerCertificate bool
 	// Parameters related to type encoding
 	Encoding EncodeParameters
-	// VectorTypeSupport controls native vector type handling.
-	// Matches JDBC/ODBC vectorTypeSupport connection property.
-	// Default is VectorTypeSupportOff for backward compatibility.
-	VectorTypeSupport VectorTypeSupport
 	// EPA mode determines how the Channel Bindings are calculated.
 	EpaEnabled bool
+}
+
+// VectorTypeSupport returns the configured native vector protocol version.
+func (p Config) VectorTypeSupport() VectorTypeSupport {
+	switch strings.ToLower(p.Parameters[VectorTypeSupportParam]) {
+	case "v1", "1":
+		return VectorTypeSupportV1
+	default:
+		return VectorTypeSupportOff
+	}
 }
 
 func readDERFile(filename string) ([]byte, error) {
@@ -672,13 +678,10 @@ func Parse(dsn string) (Config, error) {
 
 	// Parse vectorTypeSupport: off, v1 (default: off for backward compatibility)
 	// Matches JDBC/ODBC vectorTypeSupport connection property
-	p.VectorTypeSupport = VectorTypeSupportOff
 	if vectorSupport, ok := params[VectorTypeSupportParam]; ok {
 		switch strings.ToLower(vectorSupport) {
 		case "off", "0":
-			p.VectorTypeSupport = VectorTypeSupportOff
 		case "v1", "1":
-			p.VectorTypeSupport = VectorTypeSupportV1
 		default:
 			return p, fmt.Errorf("invalid vectortypesupport '%s': must be 'off' or 'v1'", vectorSupport)
 		}
@@ -786,8 +789,8 @@ func (p Config) URL() *url.URL {
 		q.Add(FailoverPartnerSpn, p.FailOverPartnerSPN)
 	}
 
-	if p.VectorTypeSupport != VectorTypeSupportOff {
-		switch p.VectorTypeSupport {
+	if p.VectorTypeSupport() != VectorTypeSupportOff {
+		switch p.VectorTypeSupport() {
 		case VectorTypeSupportV1:
 			q.Add(VectorTypeSupportParam, "v1")
 		}

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -683,7 +683,7 @@ func Parse(dsn string) (Config, error) {
 		case "off", "0":
 		case "v1", "1":
 		default:
-			return p, fmt.Errorf("invalid vectortypesupport '%s': must be 'off' or 'v1'", vectorSupport)
+			return p, fmt.Errorf("invalid vectortypesupport '%s': must be 'off', '0', 'v1', or '1'", vectorSupport)
 		}
 	}
 

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -27,6 +27,8 @@ func TestInvalidConnectionString(t *testing.T) {
 		"disableretry=invalid",
 		"multisubnetfailover=invalid",
 		"timezone=invalid",
+		"vectortypesupport=invalid",
+		"vectortypesupport=v2", // not yet supported
 		"epa enabled=invalid",
 
 		// ODBC mode
@@ -154,6 +156,16 @@ func TestValidConnectionString(t *testing.T) {
 		{"server=test;epa enabled=true", func(p Config) bool { return p.Host == "test" && p.EpaEnabled }},
 		{"server=test;epa enabled=false", func(p Config) bool { return p.Host == "test" && !p.EpaEnabled }},
 
+		// vectortypesupport tests (matches JDBC/ODBC pattern)
+		{"vectortypesupport=off", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }},
+		{"vectortypesupport=v1", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
+		{"vectortypesupport=OFF", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }},
+		{"vectortypesupport=V1", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
+		{"vectortypesupport=0", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }},
+		{"vectortypesupport=1", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
+		{"", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }}, // default is off
+		{"server=test;vectortypesupport=v1", func(p Config) bool { return p.Host == "test" && p.VectorTypeSupport == VectorTypeSupportV1 }},
+
 		// ADO connection string tests with double-quoted values containing semicolons
 		{"server=test;password=\"pass;word\"", func(p Config) bool { return p.Host == "test" && p.Password == "pass;word" }},
 		{"password=\"[2+R2B6O:fF/[;]cJsr\"", func(p Config) bool { return p.Password == "[2+R2B6O:fF/[;]cJsr" }},
@@ -237,6 +249,9 @@ func TestValidConnectionString(t *testing.T) {
 			return p.Host == "somehost" && p.User == "someuser" && p.Password == "somepass" && p.DisableRetry
 		}},
 		{"odbc:timezone={Asia/Shanghai}", func(p Config) bool { return p.Encoding.Timezone.String() == "Asia/Shanghai" }},
+		{"odbc:vectortypesupport=v1", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
+		{"odbc:vectortypesupport=off", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }},
+		{"odbc:vectortypesupport={v1}", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
 		{"odbc:epa enabled=true", func(p Config) bool { return p.EpaEnabled }},
 		{"odbc:epa enabled=false", func(p Config) bool { return !p.EpaEnabled }},
 		{"odbc:server=somehost;epa enabled=1", func(p Config) bool { return p.Host == "somehost" && p.EpaEnabled }},
@@ -276,6 +291,8 @@ func TestValidConnectionString(t *testing.T) {
 			return p.Host == "somehost" && p.Encryption == EncryptionRequired && p.TLSConfig.MinVersion == tls.VersionTLS11 && p.ColumnEncryption && p.Encoding.GuidConversion
 		}},
 		{"sqlserver://someuser@somehost?timezone=Asia%2FShanghai", func(p Config) bool { return p.Encoding.Timezone.String() == "Asia/Shanghai" }},
+		{"sqlserver://somehost?vectortypesupport=v1", func(p Config) bool { return p.Host == "somehost" && p.VectorTypeSupport == VectorTypeSupportV1 }},
+		{"sqlserver://somehost?vectortypesupport=off", func(p Config) bool { return p.Host == "somehost" && p.VectorTypeSupport == VectorTypeSupportOff }},
 		{"sqlserver://somehost?epa+enabled=true", func(p Config) bool { return p.Host == "somehost" && p.EpaEnabled }},
 		{"sqlserver://somehost?epa+enabled=false", func(p Config) bool { return p.Host == "somehost" && !p.EpaEnabled }},
 		{"sqlserver://somehost?epa+enabled=1", func(p Config) bool { return p.Host == "somehost" && p.EpaEnabled }},

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -28,6 +28,8 @@ func TestInvalidConnectionString(t *testing.T) {
 		"disableretry=invalid",
 		"multisubnetfailover=invalid",
 		"timezone=invalid",
+		"vectortypesupport=invalid",
+		"vectortypesupport=v2", // not yet supported
 		"epa enabled=invalid",
 
 		// ODBC mode
@@ -160,6 +162,16 @@ func TestValidConnectionString(t *testing.T) {
 		{"server=test;epa enabled=true", func(p Config) bool { return p.Host == "test" && p.EpaEnabled }},
 		{"server=test;epa enabled=false", func(p Config) bool { return p.Host == "test" && !p.EpaEnabled }},
 
+		// vectortypesupport tests (matches JDBC/ODBC pattern)
+		{"vectortypesupport=off", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }},
+		{"vectortypesupport=v1", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
+		{"vectortypesupport=OFF", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }},
+		{"vectortypesupport=V1", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
+		{"vectortypesupport=0", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }},
+		{"vectortypesupport=1", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
+		{"", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }}, // default is off
+		{"server=test;vectortypesupport=v1", func(p Config) bool { return p.Host == "test" && p.VectorTypeSupport == VectorTypeSupportV1 }},
+
 		// ADO connection string tests with double-quoted values containing semicolons
 		{"server=test;password=\"pass;word\"", func(p Config) bool { return p.Host == "test" && p.Password == "pass;word" }},
 		{"password=\"[2+R2B6O:fF/[;]cJsr\"", func(p Config) bool { return p.Password == "[2+R2B6O:fF/[;]cJsr" }},
@@ -270,6 +282,9 @@ func TestValidConnectionString(t *testing.T) {
 			return p.Host == "somehost" && p.User == "someuser" && p.Password == "somepass" && p.DisableRetry
 		}},
 		{"odbc:timezone={Asia/Shanghai}", func(p Config) bool { return p.Encoding.Timezone.String() == "Asia/Shanghai" }},
+		{"odbc:vectortypesupport=v1", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
+		{"odbc:vectortypesupport=off", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }},
+		{"odbc:vectortypesupport={v1}", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
 		{"odbc:epa enabled=true", func(p Config) bool { return p.EpaEnabled }},
 		{"odbc:epa enabled=false", func(p Config) bool { return !p.EpaEnabled }},
 		{"odbc:server=somehost;epa enabled=1", func(p Config) bool { return p.Host == "somehost" && p.EpaEnabled }},
@@ -312,6 +327,8 @@ func TestValidConnectionString(t *testing.T) {
 			return p.Host == "somehost" && p.Encryption == EncryptionRequired && p.TLSConfig.MinVersion == tls.VersionTLS11 && p.ColumnEncryption && p.Encoding.GuidConversion
 		}},
 		{"sqlserver://someuser@somehost?timezone=Asia%2FShanghai", func(p Config) bool { return p.Encoding.Timezone.String() == "Asia/Shanghai" }},
+		{"sqlserver://somehost?vectortypesupport=v1", func(p Config) bool { return p.Host == "somehost" && p.VectorTypeSupport == VectorTypeSupportV1 }},
+		{"sqlserver://somehost?vectortypesupport=off", func(p Config) bool { return p.Host == "somehost" && p.VectorTypeSupport == VectorTypeSupportOff }},
 		{"sqlserver://somehost?epa+enabled=true", func(p Config) bool { return p.Host == "somehost" && p.EpaEnabled }},
 		{"sqlserver://somehost?epa+enabled=false", func(p Config) bool { return p.Host == "somehost" && !p.EpaEnabled }},
 		{"sqlserver://somehost?epa+enabled=1", func(p Config) bool { return p.Host == "somehost" && p.EpaEnabled }},

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -47,6 +47,7 @@ func TestInvalidConnectionString(t *testing.T) {
 		"sqlserver://host?key=value1&key=value2", // duplicate keys
 		"sqlserver://host?TrustServerCertificate=true&trustservercertificate=false", // case-insensitive duplicate keys
 	}
+
 	for _, connStr := range connStrings {
 		_, err := Parse(connStr)
 		if !assert.Error(t, err, "Connection expected to fail for connection string %s but it didn't", connStr) {
@@ -55,6 +56,11 @@ func TestInvalidConnectionString(t *testing.T) {
 			t.Logf("Connection failed for %s as expected with error %v", connStr, err)
 		}
 	}
+}
+
+func TestInvalidVectorTypeSupportListsAcceptedValues(t *testing.T) {
+	_, err := Parse("vectortypesupport=v2")
+	require.EqualError(t, err, "invalid vectortypesupport 'v2': must be 'off', '0', 'v1', or '1'")
 }
 
 func TestCredentialNotLeakedInError(t *testing.T) {

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -163,14 +163,14 @@ func TestValidConnectionString(t *testing.T) {
 		{"server=test;epa enabled=false", func(p Config) bool { return p.Host == "test" && !p.EpaEnabled }},
 
 		// vectortypesupport tests (matches JDBC/ODBC pattern)
-		{"vectortypesupport=off", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }},
-		{"vectortypesupport=v1", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
-		{"vectortypesupport=OFF", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }},
-		{"vectortypesupport=V1", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
-		{"vectortypesupport=0", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }},
-		{"vectortypesupport=1", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
-		{"", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }}, // default is off
-		{"server=test;vectortypesupport=v1", func(p Config) bool { return p.Host == "test" && p.VectorTypeSupport == VectorTypeSupportV1 }},
+		{"vectortypesupport=off", func(p Config) bool { return p.VectorTypeSupport() == VectorTypeSupportOff }},
+		{"vectortypesupport=v1", func(p Config) bool { return p.VectorTypeSupport() == VectorTypeSupportV1 }},
+		{"vectortypesupport=OFF", func(p Config) bool { return p.VectorTypeSupport() == VectorTypeSupportOff }},
+		{"vectortypesupport=V1", func(p Config) bool { return p.VectorTypeSupport() == VectorTypeSupportV1 }},
+		{"vectortypesupport=0", func(p Config) bool { return p.VectorTypeSupport() == VectorTypeSupportOff }},
+		{"vectortypesupport=1", func(p Config) bool { return p.VectorTypeSupport() == VectorTypeSupportV1 }},
+		{"", func(p Config) bool { return p.VectorTypeSupport() == VectorTypeSupportOff }}, // default is off
+		{"server=test;vectortypesupport=v1", func(p Config) bool { return p.Host == "test" && p.VectorTypeSupport() == VectorTypeSupportV1 }},
 
 		// ADO connection string tests with double-quoted values containing semicolons
 		{"server=test;password=\"pass;word\"", func(p Config) bool { return p.Host == "test" && p.Password == "pass;word" }},
@@ -282,9 +282,9 @@ func TestValidConnectionString(t *testing.T) {
 			return p.Host == "somehost" && p.User == "someuser" && p.Password == "somepass" && p.DisableRetry
 		}},
 		{"odbc:timezone={Asia/Shanghai}", func(p Config) bool { return p.Encoding.Timezone.String() == "Asia/Shanghai" }},
-		{"odbc:vectortypesupport=v1", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
-		{"odbc:vectortypesupport=off", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportOff }},
-		{"odbc:vectortypesupport={v1}", func(p Config) bool { return p.VectorTypeSupport == VectorTypeSupportV1 }},
+		{"odbc:vectortypesupport=v1", func(p Config) bool { return p.VectorTypeSupport() == VectorTypeSupportV1 }},
+		{"odbc:vectortypesupport=off", func(p Config) bool { return p.VectorTypeSupport() == VectorTypeSupportOff }},
+		{"odbc:vectortypesupport={v1}", func(p Config) bool { return p.VectorTypeSupport() == VectorTypeSupportV1 }},
 		{"odbc:epa enabled=true", func(p Config) bool { return p.EpaEnabled }},
 		{"odbc:epa enabled=false", func(p Config) bool { return !p.EpaEnabled }},
 		{"odbc:server=somehost;epa enabled=1", func(p Config) bool { return p.Host == "somehost" && p.EpaEnabled }},
@@ -327,8 +327,8 @@ func TestValidConnectionString(t *testing.T) {
 			return p.Host == "somehost" && p.Encryption == EncryptionRequired && p.TLSConfig.MinVersion == tls.VersionTLS11 && p.ColumnEncryption && p.Encoding.GuidConversion
 		}},
 		{"sqlserver://someuser@somehost?timezone=Asia%2FShanghai", func(p Config) bool { return p.Encoding.Timezone.String() == "Asia/Shanghai" }},
-		{"sqlserver://somehost?vectortypesupport=v1", func(p Config) bool { return p.Host == "somehost" && p.VectorTypeSupport == VectorTypeSupportV1 }},
-		{"sqlserver://somehost?vectortypesupport=off", func(p Config) bool { return p.Host == "somehost" && p.VectorTypeSupport == VectorTypeSupportOff }},
+		{"sqlserver://somehost?vectortypesupport=v1", func(p Config) bool { return p.Host == "somehost" && p.VectorTypeSupport() == VectorTypeSupportV1 }},
+		{"sqlserver://somehost?vectortypesupport=off", func(p Config) bool { return p.Host == "somehost" && p.VectorTypeSupport() == VectorTypeSupportOff }},
 		{"sqlserver://somehost?epa+enabled=true", func(p Config) bool { return p.Host == "somehost" && p.EpaEnabled }},
 		{"sqlserver://somehost?epa+enabled=false", func(p Config) bool { return p.Host == "somehost" && !p.EpaEnabled }},
 		{"sqlserver://somehost?epa+enabled=1", func(p Config) bool { return p.Host == "somehost" && p.EpaEnabled }},

--- a/mssql.go
+++ b/mssql.go
@@ -991,6 +991,51 @@ func makeStrParam(val string) (res param) {
 	return
 }
 
+// makeNullVectorParam returns a param configured as nvarchar(1) NULL.
+// SQL Server accepts this for any VECTOR(...) column regardless of dimensionality,
+// which works around the limitation that native VECTOR parameters require matching dimensions.
+func makeNullVectorParam() param {
+	return param{ti: typeInfo{TypeId: typeNVarChar, Size: 2}}
+}
+
+// makeVectorJSONParam creates a param from a Vector using JSON encoding.
+// Used when native binary format is not supported or for float16 vectors.
+func makeVectorJSONParam(v Vector) (param, error) {
+	jsonVal, err := v.Value()
+	if err != nil {
+		return param{}, err
+	}
+	if jsonVal == nil {
+		return makeNullVectorParam(), nil
+	}
+	return makeStrParam(jsonVal.(string)), nil
+}
+
+// makeVectorParam creates a parameter for native binary vector format.
+// This is used when the server supports vector feature extension (SQL Server 2025+).
+func (s *Stmt) makeVectorParam(v Vector) (res param, err error) {
+	if v.Data == nil {
+		return makeNullVectorParam(), nil
+	}
+	buf, err := v.encodeToBytes()
+	if err != nil {
+		return res, err
+	}
+	res.ti.TypeId = typeVectorN
+	res.buffer = buf
+	res.ti.Size = len(buf)
+	res.ti.Scale = byte(v.ElementType)
+	return
+}
+
+// makeVectorOrJSON returns a native binary param if supported, otherwise JSON.
+func (s *Stmt) makeVectorOrJSON(v Vector) (param, error) {
+	if s.c.sess.vectorSupported && v.ElementType == VectorElementFloat32 {
+		return s.makeVectorParam(v)
+	}
+	return makeVectorJSONParam(v)
+}
+
 func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 	if val == nil {
 		res.ti.TypeId = typeNull
@@ -1021,6 +1066,27 @@ func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 		if valuer.Decimal.Valid {
 			return s.makeParam(Money[decimal.Decimal]{valuer.Decimal.Decimal})
 		}
+	// Vector types handled before driver.Valuer for native binary format when supported.
+	case *Vector:
+		if valuer == nil || valuer.Data == nil {
+			return makeNullVectorParam(), nil
+		}
+		return s.makeParam(*valuer)
+	case *NullVector:
+		if valuer == nil || !valuer.Valid {
+			return makeNullVectorParam(), nil
+		}
+		return s.makeParam(valuer.Vector)
+	case Vector:
+		if valuer.Data == nil {
+			return makeNullVectorParam(), nil
+		}
+		return s.makeVectorOrJSON(valuer)
+	case NullVector:
+		if !valuer.Valid {
+			return makeNullVectorParam(), nil
+		}
+		return s.makeVectorOrJSON(valuer.Vector)
 	case UniqueIdentifier:
 	case NullUniqueIdentifier:
 	default:
@@ -1133,6 +1199,22 @@ func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 		res.ti.TypeId = typeFltN
 		res.ti.Size = 8
 		res.buffer = []byte{}
+
+	// Vector and NullVector are handled in the first switch before driver.Valuer
+	// to ensure native binary format is used when supported.
+
+	case []float32:
+		v, err := NewVector(val)
+		if err != nil {
+			return res, err
+		}
+		return s.makeVectorOrJSON(v)
+	case []float64:
+		v, err := NewVectorFromFloat64(val)
+		if err != nil {
+			return res, err
+		}
+		return s.makeVectorOrJSON(v)
 
 	case []byte:
 		res.ti.TypeId = typeBigVarBin

--- a/mssql.go
+++ b/mssql.go
@@ -1041,6 +1041,51 @@ func makeStrParam(val string) (res param) {
 	return
 }
 
+// makeNullVectorParam returns a param configured as nvarchar(1) NULL.
+// SQL Server accepts this for any VECTOR(...) column regardless of dimensionality,
+// which works around the limitation that native VECTOR parameters require matching dimensions.
+func makeNullVectorParam() param {
+	return param{ti: typeInfo{TypeId: typeNVarChar, Size: 2}}
+}
+
+// makeVectorJSONParam creates a param from a Vector using JSON encoding.
+// Used when native binary format is not supported or for float16 vectors.
+func makeVectorJSONParam(v Vector) (param, error) {
+	jsonVal, err := v.Value()
+	if err != nil {
+		return param{}, err
+	}
+	if jsonVal == nil {
+		return makeNullVectorParam(), nil
+	}
+	return makeStrParam(jsonVal.(string)), nil
+}
+
+// makeVectorParam creates a parameter for native binary vector format.
+// This is used when the server supports vector feature extension (SQL Server 2025+).
+func (s *Stmt) makeVectorParam(v Vector) (res param, err error) {
+	if v.Data == nil {
+		return makeNullVectorParam(), nil
+	}
+	buf, err := v.encodeToBytes()
+	if err != nil {
+		return res, err
+	}
+	res.ti.TypeId = typeVectorN
+	res.buffer = buf
+	res.ti.Size = len(buf)
+	res.ti.Scale = byte(v.ElementType)
+	return
+}
+
+// makeVectorOrJSON returns a native binary param if supported, otherwise JSON.
+func (s *Stmt) makeVectorOrJSON(v Vector) (param, error) {
+	if s.c.sess.vectorSupported && v.ElementType == VectorElementFloat32 {
+		return s.makeVectorParam(v)
+	}
+	return makeVectorJSONParam(v)
+}
+
 func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 	if val == nil {
 		res.ti.TypeId = typeNull
@@ -1071,6 +1116,27 @@ func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 		if valuer.Decimal.Valid {
 			return s.makeParam(Money[decimal.Decimal]{valuer.Decimal.Decimal})
 		}
+	// Vector types handled before driver.Valuer for native binary format when supported.
+	case *Vector:
+		if valuer == nil || valuer.Data == nil {
+			return makeNullVectorParam(), nil
+		}
+		return s.makeParam(*valuer)
+	case *NullVector:
+		if valuer == nil || !valuer.Valid {
+			return makeNullVectorParam(), nil
+		}
+		return s.makeParam(valuer.Vector)
+	case Vector:
+		if valuer.Data == nil {
+			return makeNullVectorParam(), nil
+		}
+		return s.makeVectorOrJSON(valuer)
+	case NullVector:
+		if !valuer.Valid {
+			return makeNullVectorParam(), nil
+		}
+		return s.makeVectorOrJSON(valuer.Vector)
 	case UniqueIdentifier:
 	case NullUniqueIdentifier:
 	default:
@@ -1183,6 +1249,22 @@ func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 		res.ti.TypeId = typeFltN
 		res.ti.Size = 8
 		res.buffer = []byte{}
+
+	// Vector and NullVector are handled in the first switch before driver.Valuer
+	// to ensure native binary format is used when supported.
+
+	case []float32:
+		v, err := NewVector(val)
+		if err != nil {
+			return res, err
+		}
+		return s.makeVectorOrJSON(v)
+	case []float64:
+		v, err := NewVectorFromFloat64(val)
+		if err != nil {
+			return res, err
+		}
+		return s.makeVectorOrJSON(v)
 
 	case []byte:
 		res.ti.TypeId = typeBigVarBin

--- a/mssql.go
+++ b/mssql.go
@@ -1080,6 +1080,9 @@ func (s *Stmt) makeVectorParam(v Vector) (res param, err error) {
 
 // makeVectorOrJSON returns a native binary param if supported, otherwise JSON.
 func (s *Stmt) makeVectorOrJSON(v Vector) (param, error) {
+	if v.Data != nil && len(v.Data) == 0 {
+		return param{}, errors.New("mssql: vector dimensions must be at least 1")
+	}
 	if s.c.sess.vectorSupported && v.ElementType == VectorElementFloat32 {
 		return s.makeVectorParam(v)
 	}

--- a/mssql_go19.go
+++ b/mssql_go19.go
@@ -77,6 +77,14 @@ func convertInputParameter(val interface{}) (interface{}, error) {
 	// 	return nil
 	case float32:
 		return val, nil
+	case Vector:
+		return val, nil
+	case NullVector:
+		return val, nil
+	case []float32:
+		return val, nil
+	case []float64:
+		return val, nil
 	case driver.Valuer:
 		return val, nil
 	default:

--- a/mssql_go19.go
+++ b/mssql_go19.go
@@ -92,6 +92,14 @@ func convertInputParameter(val interface{}) (interface{}, error) {
 	// 	return nil
 	case float32:
 		return val, nil
+	case Vector:
+		return val, nil
+	case NullVector:
+		return val, nil
+	case []float32:
+		return val, nil
+	case []float64:
+		return val, nil
 	case driver.Valuer:
 		return val, nil
 	default:

--- a/tds.go
+++ b/tds.go
@@ -156,6 +156,7 @@ const (
 	featExtAZURESQLSUPPORT    byte = 0x08
 	featExtDATACLASSIFICATION byte = 0x09
 	featExtUTF8SUPPORT        byte = 0x0A
+	featExtVECTORSUPPORT      byte = 0x0E
 	featExtTERMINATOR         byte = 0xFF
 )
 
@@ -175,6 +176,10 @@ type tdsSession struct {
 	connid          UniqueIdentifier
 	activityid      UniqueIdentifier
 	encoding        msdsn.EncodeParameters
+	// vectorSupported indicates if the server supports native vector binary format.
+	// TODO: Extend native binary vector parameter support to float16 vectors when server supports it.
+	// Currently, float32 vectors use binary format when vectorSupported is true, while float16 vectors are sent as JSON.
+	vectorSupported bool
 }
 
 type alwaysEncryptedSettings struct {
@@ -1062,6 +1067,11 @@ func prepareLogin(ctx context.Context, c *Connector, p msdsn.Config, logger Cont
 	if p.ColumnEncryption {
 		_ = l.FeatureExt.Add(&featureExtColumnEncryption{})
 	}
+	// Only request vector support when enabled via connection string (vectortypesupport=v1)
+	// Default is off for backward compatibility, matching ODBC behavior
+	if p.VectorTypeSupport == msdsn.VectorTypeSupportV1 {
+		_ = l.FeatureExt.Add(&featureExtVector{})
+	}
 	switch {
 	case fe.FedAuthLibrary == FedAuthLibrarySecurityToken:
 		if uint64(p.LogFlags)&logDebug != 0 {
@@ -1361,13 +1371,30 @@ initiate_connection:
 				sess.loginAck = token
 				loginAck = true
 			case featureExtAck:
-				for _, v := range token {
-					switch v := v.(type) {
-					case colAckStruct:
-						if v.Version <= 2 && v.Version > 0 {
-							sess.alwaysEncrypted = true
-							if len(v.EnclaveType) > 0 {
-								sess.aeSettings.enclaveType = string(v.EnclaveType)
+				for id, v := range token {
+					switch id {
+					case featExtCOLUMNENCRYPTION:
+						if colAck, ok := v.(colAckStruct); ok {
+							if colAck.Version <= 2 && colAck.Version > 0 {
+								sess.alwaysEncrypted = true
+								if len(colAck.EnclaveType) > 0 {
+									sess.aeSettings.enclaveType = string(colAck.EnclaveType)
+								}
+							}
+						}
+					case featExtVECTORSUPPORT:
+						// Server acknowledged vector support
+						if version, ok := v.(byte); ok {
+							if version == 1 {
+								sess.vectorSupported = true
+								if uint64(p.LogFlags)&logDebug != 0 {
+									logger.Log(ctx, msdsn.LogDebug, "Server supports native vector format (version 1)")
+								}
+							} else if version > 1 {
+								// Future protocol version: do not enable, log warning
+								if uint64(p.LogFlags)&logDebug != 0 {
+									logger.Log(ctx, msdsn.LogDebug, fmt.Sprintf("Server advertised vector support version %d (newer than supported version 1); native vector format disabled", version))
+								}
 							}
 						}
 					}
@@ -1418,6 +1445,18 @@ func (f *featureExtColumnEncryption) toBytes() []byte {
 		with the additional ability to cache column encryption keys that are to be sent to the enclave
 		and the ability to retry queries when the keys sent by the client do not match what is needed for the query to run.
 	*/
+	return []byte{0x01}
+}
+
+// featureExtVector requests vector support from the server
+type featureExtVector struct{}
+
+func (f *featureExtVector) featureID() byte {
+	return featExtVECTORSUPPORT
+}
+
+func (f *featureExtVector) toBytes() []byte {
+	// Version 1 of vector support (float32 vectors)
 	return []byte{0x01}
 }
 

--- a/tds.go
+++ b/tds.go
@@ -182,6 +182,7 @@ const (
 	featExtAZURESQLSUPPORT    byte = 0x08
 	featExtDATACLASSIFICATION byte = 0x09
 	featExtUTF8SUPPORT        byte = 0x0A
+	featExtVECTORSUPPORT      byte = 0x0E
 	featExtTERMINATOR         byte = 0xFF
 )
 
@@ -204,6 +205,10 @@ type tdsSession struct {
 	// readDone is closed when the current processSingleResponse goroutine
 	// completes. startResponseReader waits on this to prevent concurrent buffer reads.
 	readDone chan struct{}
+	// vectorSupported indicates if the server supports native vector binary format.
+	// TODO: Extend native binary vector parameter support to float16 vectors when server supports it.
+	// Currently, float32 vectors use binary format when vectorSupported is true, while float16 vectors are sent as JSON.
+	vectorSupported bool
 }
 
 type alwaysEncryptedSettings struct {
@@ -1098,6 +1103,11 @@ func prepareLogin(ctx context.Context, c *Connector, p msdsn.Config, logger Cont
 	if p.ColumnEncryption {
 		_ = l.FeatureExt.Add(&featureExtColumnEncryption{})
 	}
+	// Only request vector support when enabled via connection string (vectortypesupport=v1)
+	// Default is off for backward compatibility, matching ODBC behavior
+	if p.VectorTypeSupport == msdsn.VectorTypeSupportV1 {
+		_ = l.FeatureExt.Add(&featureExtVector{})
+	}
 	switch {
 	case fe.FedAuthLibrary == FedAuthLibrarySecurityToken:
 		if uint64(p.LogFlags)&logDebug != 0 {
@@ -1404,13 +1414,30 @@ initiate_connection:
 				sess.loginAck = token
 				loginAck = true
 			case featureExtAck:
-				for _, v := range token {
-					switch v := v.(type) {
-					case colAckStruct:
-						if v.Version <= 2 && v.Version > 0 {
-							sess.alwaysEncrypted = true
-							if len(v.EnclaveType) > 0 {
-								sess.aeSettings.enclaveType = string(v.EnclaveType)
+				for id, v := range token {
+					switch id {
+					case featExtCOLUMNENCRYPTION:
+						if colAck, ok := v.(colAckStruct); ok {
+							if colAck.Version <= 2 && colAck.Version > 0 {
+								sess.alwaysEncrypted = true
+								if len(colAck.EnclaveType) > 0 {
+									sess.aeSettings.enclaveType = string(colAck.EnclaveType)
+								}
+							}
+						}
+					case featExtVECTORSUPPORT:
+						// Server acknowledged vector support
+						if version, ok := v.(byte); ok {
+							if version == 1 {
+								sess.vectorSupported = true
+								if uint64(p.LogFlags)&logDebug != 0 {
+									logger.Log(ctx, msdsn.LogDebug, "Server supports native vector format (version 1)")
+								}
+							} else if version > 1 {
+								// Future protocol version: do not enable, log warning
+								if uint64(p.LogFlags)&logDebug != 0 {
+									logger.Log(ctx, msdsn.LogDebug, fmt.Sprintf("Server advertised vector support version %d (newer than supported version 1); native vector format disabled", version))
+								}
 							}
 						}
 					}
@@ -1461,6 +1488,18 @@ func (f *featureExtColumnEncryption) toBytes() []byte {
 		with the additional ability to cache column encryption keys that are to be sent to the enclave
 		and the ability to retry queries when the keys sent by the client do not match what is needed for the query to run.
 	*/
+	return []byte{0x01}
+}
+
+// featureExtVector requests vector support from the server
+type featureExtVector struct{}
+
+func (f *featureExtVector) featureID() byte {
+	return featExtVECTORSUPPORT
+}
+
+func (f *featureExtVector) toBytes() []byte {
+	// Version 1 of vector support (float32 vectors)
 	return []byte{0x01}
 }
 

--- a/tds.go
+++ b/tds.go
@@ -1105,7 +1105,7 @@ func prepareLogin(ctx context.Context, c *Connector, p msdsn.Config, logger Cont
 	}
 	// Only request vector support when enabled via connection string (vectortypesupport=v1)
 	// Default is off for backward compatibility, matching ODBC behavior
-	if p.VectorTypeSupport == msdsn.VectorTypeSupportV1 {
+	if p.VectorTypeSupport() == msdsn.VectorTypeSupportV1 {
 		_ = l.FeatureExt.Add(&featureExtVector{})
 	}
 	switch {

--- a/token.go
+++ b/token.go
@@ -605,6 +605,14 @@ func parseFeatureExtAck(r *tdsBuffer) featureExtAck {
 
 			}
 			ack[feature] = colAck
+		case featExtVECTORSUPPORT:
+			// Vector support ack contains a single byte indicating the version
+			if length < 1 {
+				badStreamPanicf("invalid featExtVECTORSUPPORT feature ack: length < 1")
+			}
+			version := r.byte()
+			length--
+			ack[feature] = version
 		}
 
 		// Skip unprocessed bytes

--- a/token.go
+++ b/token.go
@@ -635,6 +635,14 @@ func parseFeatureExtAck(r *tdsBuffer) featureExtAck {
 
 			}
 			ack[feature] = colAck
+		case featExtVECTORSUPPORT:
+			// Vector support ack contains a single byte indicating the version
+			if length < 1 {
+				badStreamPanicf("invalid featExtVECTORSUPPORT feature ack: length < 1")
+			}
+			version := r.byte()
+			length--
+			ack[feature] = version
 		}
 
 		// Skip unprocessed bytes

--- a/token.go
+++ b/token.go
@@ -637,11 +637,11 @@ func parseFeatureExtAck(r *tdsBuffer) featureExtAck {
 			ack[feature] = colAck
 		case featExtVECTORSUPPORT:
 			// Vector support ack contains a single byte indicating the version
-			if length < 1 {
-				badStreamPanicf("invalid featExtVECTORSUPPORT feature ack: length < 1")
+			if length != 1 {
+				badStreamPanicf("invalid featExtVECTORSUPPORT feature ack length %d", length)
 			}
 			version := r.byte()
-			length--
+			length = 0
 			ack[feature] = version
 		}
 

--- a/token_test.go
+++ b/token_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"regexp"
+	"strings"
 	"sync"
 	"testing"
 
@@ -152,6 +154,33 @@ func TestParseFeatureExtAck(t *testing.T) {
 		}
 
 		parseFeatureExtAck(r)
+	}
+}
+
+func TestParseFeatureExtAckVector(t *testing.T) {
+	t.Run("version 1", func(t *testing.T) {
+		ack := parseFeatureExtAck(makeFinalBuf([]byte{
+			featExtVECTORSUPPORT, 1, 0, 0, 0, 1, featExtTERMINATOR,
+		}))
+		if got := ack[featExtVECTORSUPPORT]; got != byte(1) {
+			t.Fatalf("vector version = %v, want 1", got)
+		}
+	})
+
+	for _, length := range []uint32{0, 2} {
+		t.Run(fmt.Sprintf("length %d", length), func(t *testing.T) {
+			data := []byte{featExtVECTORSUPPORT, byte(length), 0, 0, 0}
+			data = append(data, make([]byte, length)...)
+			data = append(data, featExtTERMINATOR)
+
+			defer func() {
+				err, ok := recover().(error)
+				if !ok || !strings.Contains(err.Error(), fmt.Sprintf("feature ack length %d", length)) {
+					t.Fatalf("unexpected panic: %v", err)
+				}
+			}()
+			parseFeatureExtAck(makeFinalBuf(data))
+		})
 	}
 }
 

--- a/tvp_go19.go
+++ b/tvp_go19.go
@@ -167,6 +167,13 @@ func (tvp TVP) columnTypes() ([]columnStruct, []int, error) {
 		if IsSkipField(tvpTagValue, isTvpTag, jsonTagValue, isJsonTag) {
 			continue
 		}
+		fieldType := field.Type
+		if fieldType.Kind() == reflect.Ptr {
+			fieldType = fieldType.Elem()
+		}
+		if fieldType == reflect.TypeOf(Vector{}) || fieldType == reflect.TypeOf(NullVector{}) {
+			return nil, nil, fmt.Errorf("mssql: Vector fields are not supported in table-valued parameters")
+		}
 		tvpFieldIndexes = append(tvpFieldIndexes, i)
 		isIdentity := tvpTagValue == tvpIdentity
 		if field.Type.Kind() == reflect.Ptr {

--- a/tvp_go19.go
+++ b/tvp_go19.go
@@ -171,7 +171,8 @@ func (tvp TVP) columnTypes() ([]columnStruct, []int, error) {
 		if fieldType.Kind() == reflect.Ptr {
 			fieldType = fieldType.Elem()
 		}
-		if fieldType == reflect.TypeOf(Vector{}) || fieldType == reflect.TypeOf(NullVector{}) {
+		if fieldType == reflect.TypeOf(Vector{}) || fieldType == reflect.TypeOf(NullVector{}) ||
+			fieldType == reflect.TypeOf([]float32{}) || fieldType == reflect.TypeOf([]float64{}) {
 			return nil, nil, fmt.Errorf("mssql: Vector fields are not supported in table-valued parameters")
 		}
 		tvpFieldIndexes = append(tvpFieldIndexes, i)

--- a/tvp_go19_test.go
+++ b/tvp_go19_test.go
@@ -132,8 +132,10 @@ func TestTVPType_columnTypes(t *testing.T) {
 
 func TestTVPTypeRejectsVectorFields(t *testing.T) {
 	for name, value := range map[string]interface{}{
-		"Vector":     []struct{ Vector Vector }{{Vector: Vector{ElementType: VectorElementFloat32, Data: []float32{1}}}},
-		"NullVector": []struct{ Vector *NullVector }{{Vector: &NullVector{Valid: true}}},
+		"Vector":        []struct{ Vector Vector }{{Vector: Vector{ElementType: VectorElementFloat32, Data: []float32{1}}}},
+		"NullVector":    []struct{ Vector *NullVector }{{Vector: &NullVector{Valid: true}}},
+		"float32 slice": []struct{ Vector []float32 }{{Vector: []float32{1}}},
+		"float64 slice": []struct{ Vector []float64 }{{Vector: []float64{1}}},
 	} {
 		t.Run(name, func(t *testing.T) {
 			tvp := TVP{TypeName: "VectorTableType", Value: value}

--- a/tvp_go19_test.go
+++ b/tvp_go19_test.go
@@ -5,6 +5,7 @@ package mssql
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ func TestTVPType_columnTypes(t *testing.T) {
 	type customTypeAllFieldsSkipOne struct {
 		SkipTest int `tvp:"-"`
 	}
+
 	type customTypeAllFieldsSkipMoreOne struct {
 		SkipTest  int `tvp:"-"`
 		SkipTest1 int `json:"-"`
@@ -123,6 +125,21 @@ func TestTVPType_columnTypes(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("TVP.columnTypes() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+		})
+	}
+}
+
+func TestTVPTypeRejectsVectorFields(t *testing.T) {
+	for name, value := range map[string]interface{}{
+		"Vector":     []struct{ Vector Vector }{{Vector: Vector{ElementType: VectorElementFloat32, Data: []float32{1}}}},
+		"NullVector": []struct{ Vector *NullVector }{{Vector: &NullVector{Valid: true}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tvp := TVP{TypeName: "VectorTableType", Value: value}
+			_, _, err := tvp.columnTypes()
+			if err == nil || !strings.Contains(err.Error(), "Vector fields are not supported in table-valued parameters") {
+				t.Fatalf("TVP.columnTypes() error = %v", err)
 			}
 		})
 	}

--- a/types.go
+++ b/types.go
@@ -66,6 +66,7 @@ const (
 	typeXml        = 0xf1
 	typeUdt        = 0xf0
 	typeTvp        = 0xf3
+	typeVectorN    = 0xf5 // SQL Server 2025+ Vector type
 
 	// long length types
 	typeText    = 0x23
@@ -262,6 +263,28 @@ func writeVarLen(w io.Writer, ti *typeInfo, out bool, encoding msdsn.EncodeParam
 			}
 		}
 		ti.Writer = writeLongLenType
+	case typeVectorN:
+		// Vector type (SQL Server 2025+)
+		// Format: maxLength (USHORT) + scaleByte (BYTE for element type)
+		if ti.Size > 8000 || ti.Size == 0 || out {
+			if err = binary.Write(w, binary.LittleEndian, uint16(0xffff)); err != nil {
+				return
+			}
+			// Write scale byte (element type: 0=FLOAT32, 1=FLOAT16)
+			if err = binary.Write(w, binary.LittleEndian, ti.Scale); err != nil {
+				return
+			}
+			ti.Writer = writePLPType
+		} else {
+			if err = binary.Write(w, binary.LittleEndian, uint16(ti.Size)); err != nil {
+				return
+			}
+			// Write scale byte (element type: 0=FLOAT32, 1=FLOAT16)
+			if err = binary.Write(w, binary.LittleEndian, ti.Scale); err != nil {
+				return
+			}
+			ti.Writer = writeVectorType
+		}
 	default:
 		panic("Invalid type")
 	}
@@ -552,6 +575,53 @@ func writeShortLenType(w io.Writer, ti typeInfo, buf []byte, encoding msdsn.Enco
 	return
 }
 
+// readVectorType reads a Vector value from the TDS stream.
+// Vectors are stored as binary data with an 8-byte header followed by element values.
+// The payload element width (for example, float16 or float32) depends on the vector element type.
+//
+// This function returns []byte (the raw binary vector payload), which is a standard
+// database/sql/driver.Value type. Types such as Vector and NullVector, which implement
+// sql.Scanner, are responsible for decoding this binary representation.
+func readVectorType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn.EncodeParameters) interface{} {
+	var size uint16
+	if c != nil {
+		size = uint16(r.rsize)
+	} else {
+		size = r.uint16()
+	}
+	if size == 0xffff {
+		return nil
+	}
+	// Reuse ti.Buffer if available and large enough for reading, otherwise allocate new buffer.
+	// Always return a copy that does not alias ti.Buffer to avoid data corruption when
+	// rows are buffered and processed after subsequent reads overwrite ti.Buffer.
+	var readBuf []byte
+	if ti != nil && len(ti.Buffer) >= int(size) {
+		readBuf = ti.Buffer[:size]
+	} else {
+		readBuf = make([]byte, size)
+	}
+	r.ReadFull(readBuf)
+
+	// Return a copy - Vector.Scan() handles decoding
+	out := make([]byte, size)
+	copy(out, readBuf)
+	return out
+}
+
+// writeVectorType writes a Vector value to the TDS stream.
+func writeVectorType(w io.Writer, ti typeInfo, buf []byte, encoding msdsn.EncodeParameters) (err error) {
+	if buf == nil {
+		err = binary.Write(w, binary.LittleEndian, uint16(0xffff))
+		return
+	}
+	if err = binary.Write(w, binary.LittleEndian, uint16(len(buf))); err != nil {
+		return
+	}
+	_, err = w.Write(buf)
+	return
+}
+
 func readLongLenType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn.EncodeParameters) interface{} {
 	// information about this format can be found here:
 	// http://msdn.microsoft.com/en-us/library/dd304783.aspx
@@ -774,6 +844,11 @@ func readPLPType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn.E
 		return decodeNChar(bytesToDecode)
 	case typeUdt:
 		return decodeUdt(*ti, bytesToDecode)
+	case typeVectorN:
+		// Vector type in PLP format - return raw bytes.
+		// Types such as Vector and NullVector, which implement sql.Scanner,
+		// are responsible for decoding this binary representation.
+		return bytesToDecode
 	}
 	panic("shouldn't get here")
 }
@@ -896,6 +971,22 @@ func readVarLen(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn.En
 			ti.Reader = readLongLenType
 		case typeVariant:
 			ti.Reader = readVariantTypeWithEncoding
+		}
+	case typeVectorN:
+		// Vector type (SQL Server 2025+)
+		// Format: maxLength (USHORT) + scaleByte (BYTE)
+		// When vector feature extension is negotiated, server sends binary format
+		ti.Size = int(r.uint16())
+		scaleByte := r.byte() // element type: 0=FLOAT32, 1=FLOAT16
+		ti.Scale = scaleByte
+		// Note: We do not store dimension count in ti.Prec (uint8) to avoid overflow.
+		// Vector dimensions can be up to 1998 (float32) or 3996 (float16).
+		// Dimension count can be derived as: (ti.Size - 8) / bytesPerDim when needed.
+		if ti.Size == 0xffff {
+			ti.Reader = readPLPType
+		} else {
+			ti.Buffer = make([]byte, ti.Size)
+			ti.Reader = readVectorType
 		}
 	default:
 		badStreamPanicf("Invalid type %d", ti.TypeId)
@@ -1111,6 +1202,25 @@ func decodeUdt(ti typeInfo, buf []byte) []byte {
 	return buf
 }
 
+// vectorDimensionsFromTypeInfo calculates the number of vector dimensions from typeInfo.
+// Returns (dimensions, isFloat16, ok). ok is false if the type info is invalid.
+func vectorDimensionsFromTypeInfo(ti typeInfo) (dims int, isFloat16, ok bool) {
+	elementType := VectorElementType(ti.Scale)
+	if !elementType.IsValid() {
+		return 0, false, false
+	}
+	isFloat16 = elementType == VectorElementFloat16
+	if ti.Size == 0xffff || ti.Size < vectorHeaderSize {
+		return 0, isFloat16, false
+	}
+	payloadSize := ti.Size - vectorHeaderSize
+	bytesPerElement := elementType.BytesPerElement()
+	if payloadSize == 0 || payloadSize%bytesPerElement != 0 {
+		return 0, isFloat16, false
+	}
+	return payloadSize / bytesPerElement, isFloat16, true
+}
+
 // makes go/sql type instance as described below
 // It should return
 // the value type that can be used to scan types into. For example, the database
@@ -1212,6 +1322,10 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 	case typeVariant:
 		return reflect.TypeOf((*interface{})(nil)).Elem()
 	case typeUdt:
+		return reflect.TypeOf([]byte{})
+	case typeVectorN:
+		// readVectorType returns []byte (raw binary vector payload).
+		// Applications should scan to Vector or NullVector types for decoding.
 		return reflect.TypeOf([]byte{})
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangScanType for type %d", ti.TypeId))
@@ -1340,6 +1454,15 @@ func makeDecl(ti typeInfo) string {
 			return fmt.Sprintf("%s.%s READONLY", ti.UdtInfo.SchemaName, ti.UdtInfo.TypeName)
 		}
 		return fmt.Sprintf("%s READONLY", ti.UdtInfo.TypeName)
+	case typeVectorN:
+		dims, isFloat16, ok := vectorDimensionsFromTypeInfo(ti)
+		if !ok {
+			return "vector"
+		}
+		if isFloat16 {
+			return fmt.Sprintf("vector(%d, float16)", dims)
+		}
+		return fmt.Sprintf("vector(%d)", dims)
 	default:
 		panic(fmt.Sprintf("not implemented makeDecl for type %#x", ti.TypeId))
 	}
@@ -1449,6 +1572,8 @@ func makeGoLangTypeName(ti typeInfo) string {
 		return "BINARY"
 	case typeUdt:
 		return strings.ToUpper(ti.UdtInfo.TypeName)
+	case typeVectorN:
+		return "VECTOR"
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangTypeName for type %d", ti.TypeId))
 	}
@@ -1584,6 +1709,12 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 		default:
 			panic(fmt.Sprintf("not implemented makeGoLangTypeLength for user defined type %s", ti.UdtInfo.TypeName))
 		}
+	case typeVectorN:
+		dims, _, ok := vectorDimensionsFromTypeInfo(ti)
+		if !ok {
+			return 0, false
+		}
+		return int64(dims), true
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangTypeLength for type %d", ti.TypeId))
 	}
@@ -1699,6 +1830,8 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 	case typeBigBinary:
 		return 0, 0, false
 	case typeUdt:
+		return 0, 0, false
+	case typeVectorN:
 		return 0, 0, false
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangTypePrecisionScale for type %d", ti.TypeId))

--- a/types.go
+++ b/types.go
@@ -597,6 +597,9 @@ func readVectorType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msds
 	if size == 0xffff {
 		return nil
 	}
+	if c == nil && int(size) > ti.Size {
+		badStreamPanicf("vector length %d exceeds column maximum %d", size, ti.Size)
+	}
 	out := make([]byte, size)
 	r.ReadFull(out)
 	return out
@@ -983,7 +986,6 @@ func readVarLen(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn.En
 		if ti.Size == 0xffff {
 			ti.Reader = readPLPType
 		} else {
-			ti.Buffer = make([]byte, ti.Size)
 			ti.Reader = readVectorType
 		}
 	default:

--- a/types.go
+++ b/types.go
@@ -597,20 +597,8 @@ func readVectorType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msds
 	if size == 0xffff {
 		return nil
 	}
-	// Reuse ti.Buffer if available and large enough for reading, otherwise allocate new buffer.
-	// Always return a copy that does not alias ti.Buffer to avoid data corruption when
-	// rows are buffered and processed after subsequent reads overwrite ti.Buffer.
-	var readBuf []byte
-	if ti != nil && len(ti.Buffer) >= int(size) {
-		readBuf = ti.Buffer[:size]
-	} else {
-		readBuf = make([]byte, size)
-	}
-	r.ReadFull(readBuf)
-
-	// Return a copy - Vector.Scan() handles decoding
 	out := make([]byte, size)
-	copy(out, readBuf)
+	r.ReadFull(out)
 	return out
 }
 

--- a/types.go
+++ b/types.go
@@ -66,6 +66,7 @@ const (
 	typeXml        = 0xf1
 	typeUdt        = 0xf0
 	typeTvp        = 0xf3
+	typeVectorN    = 0xf5 // SQL Server 2025+ Vector type
 
 	// long length types
 	typeText    = 0x23
@@ -267,6 +268,28 @@ func writeVarLen(w io.Writer, ti *typeInfo, out bool, encoding msdsn.EncodeParam
 			}
 		}
 		ti.Writer = writeLongLenType
+	case typeVectorN:
+		// Vector type (SQL Server 2025+)
+		// Format: maxLength (USHORT) + scaleByte (BYTE for element type)
+		if ti.Size > 8000 || ti.Size == 0 || out {
+			if err = binary.Write(w, binary.LittleEndian, uint16(0xffff)); err != nil {
+				return
+			}
+			// Write scale byte (element type: 0=FLOAT32, 1=FLOAT16)
+			if err = binary.Write(w, binary.LittleEndian, ti.Scale); err != nil {
+				return
+			}
+			ti.Writer = writePLPType
+		} else {
+			if err = binary.Write(w, binary.LittleEndian, uint16(ti.Size)); err != nil {
+				return
+			}
+			// Write scale byte (element type: 0=FLOAT32, 1=FLOAT16)
+			if err = binary.Write(w, binary.LittleEndian, ti.Scale); err != nil {
+				return
+			}
+			ti.Writer = writeVectorType
+		}
 	default:
 		panic("Invalid type")
 	}
@@ -557,6 +580,53 @@ func writeShortLenType(w io.Writer, ti typeInfo, buf []byte, encoding msdsn.Enco
 	return
 }
 
+// readVectorType reads a Vector value from the TDS stream.
+// Vectors are stored as binary data with an 8-byte header followed by element values.
+// The payload element width (for example, float16 or float32) depends on the vector element type.
+//
+// This function returns []byte (the raw binary vector payload), which is a standard
+// database/sql/driver.Value type. Types such as Vector and NullVector, which implement
+// sql.Scanner, are responsible for decoding this binary representation.
+func readVectorType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn.EncodeParameters) interface{} {
+	var size uint16
+	if c != nil {
+		size = uint16(r.rsize)
+	} else {
+		size = r.uint16()
+	}
+	if size == 0xffff {
+		return nil
+	}
+	// Reuse ti.Buffer if available and large enough for reading, otherwise allocate new buffer.
+	// Always return a copy that does not alias ti.Buffer to avoid data corruption when
+	// rows are buffered and processed after subsequent reads overwrite ti.Buffer.
+	var readBuf []byte
+	if ti != nil && len(ti.Buffer) >= int(size) {
+		readBuf = ti.Buffer[:size]
+	} else {
+		readBuf = make([]byte, size)
+	}
+	r.ReadFull(readBuf)
+
+	// Return a copy - Vector.Scan() handles decoding
+	out := make([]byte, size)
+	copy(out, readBuf)
+	return out
+}
+
+// writeVectorType writes a Vector value to the TDS stream.
+func writeVectorType(w io.Writer, ti typeInfo, buf []byte, encoding msdsn.EncodeParameters) (err error) {
+	if buf == nil {
+		err = binary.Write(w, binary.LittleEndian, uint16(0xffff))
+		return
+	}
+	if err = binary.Write(w, binary.LittleEndian, uint16(len(buf))); err != nil {
+		return
+	}
+	_, err = w.Write(buf)
+	return
+}
+
 func readLongLenType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn.EncodeParameters) interface{} {
 	// information about this format can be found here:
 	// http://msdn.microsoft.com/en-us/library/dd304783.aspx
@@ -784,6 +854,11 @@ func readPLPType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn.E
 		return decodeNChar(bytesToDecode)
 	case typeUdt:
 		return decodeUdt(*ti, bytesToDecode)
+	case typeVectorN:
+		// Vector type in PLP format - return raw bytes.
+		// Types such as Vector and NullVector, which implement sql.Scanner,
+		// are responsible for decoding this binary representation.
+		return bytesToDecode
 	}
 	panic("shouldn't get here")
 }
@@ -906,6 +981,22 @@ func readVarLen(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn.En
 			ti.Reader = readLongLenType
 		case typeVariant:
 			ti.Reader = readVariantTypeWithEncoding
+		}
+	case typeVectorN:
+		// Vector type (SQL Server 2025+)
+		// Format: maxLength (USHORT) + scaleByte (BYTE)
+		// When vector feature extension is negotiated, server sends binary format
+		ti.Size = int(r.uint16())
+		scaleByte := r.byte() // element type: 0=FLOAT32, 1=FLOAT16
+		ti.Scale = scaleByte
+		// Note: We do not store dimension count in ti.Prec (uint8) to avoid overflow.
+		// Vector dimensions can be up to 1998 (float32) or 3996 (float16).
+		// Dimension count can be derived as: (ti.Size - 8) / bytesPerDim when needed.
+		if ti.Size == 0xffff {
+			ti.Reader = readPLPType
+		} else {
+			ti.Buffer = make([]byte, ti.Size)
+			ti.Reader = readVectorType
 		}
 	default:
 		badStreamPanicf("Invalid type %d", ti.TypeId)
@@ -1121,6 +1212,25 @@ func decodeUdt(ti typeInfo, buf []byte) []byte {
 	return buf
 }
 
+// vectorDimensionsFromTypeInfo calculates the number of vector dimensions from typeInfo.
+// Returns (dimensions, isFloat16, ok). ok is false if the type info is invalid.
+func vectorDimensionsFromTypeInfo(ti typeInfo) (dims int, isFloat16, ok bool) {
+	elementType := VectorElementType(ti.Scale)
+	if !elementType.IsValid() {
+		return 0, false, false
+	}
+	isFloat16 = elementType == VectorElementFloat16
+	if ti.Size == 0xffff || ti.Size < vectorHeaderSize {
+		return 0, isFloat16, false
+	}
+	payloadSize := ti.Size - vectorHeaderSize
+	bytesPerElement := elementType.BytesPerElement()
+	if payloadSize == 0 || payloadSize%bytesPerElement != 0 {
+		return 0, isFloat16, false
+	}
+	return payloadSize / bytesPerElement, isFloat16, true
+}
+
 // makes go/sql type instance as described below
 // It should return
 // the value type that can be used to scan types into. For example, the database
@@ -1222,6 +1332,10 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 	case typeVariant:
 		return reflect.TypeOf((*interface{})(nil)).Elem()
 	case typeUdt:
+		return reflect.TypeOf([]byte{})
+	case typeVectorN:
+		// readVectorType returns []byte (raw binary vector payload).
+		// Applications should scan to Vector or NullVector types for decoding.
 		return reflect.TypeOf([]byte{})
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangScanType for type %d", ti.TypeId))
@@ -1350,6 +1464,15 @@ func makeDecl(ti typeInfo) string {
 			return fmt.Sprintf("%s.%s READONLY", ti.UdtInfo.SchemaName, ti.UdtInfo.TypeName)
 		}
 		return fmt.Sprintf("%s READONLY", ti.UdtInfo.TypeName)
+	case typeVectorN:
+		dims, isFloat16, ok := vectorDimensionsFromTypeInfo(ti)
+		if !ok {
+			return "vector"
+		}
+		if isFloat16 {
+			return fmt.Sprintf("vector(%d, float16)", dims)
+		}
+		return fmt.Sprintf("vector(%d)", dims)
 	default:
 		panic(fmt.Sprintf("not implemented makeDecl for type %#x", ti.TypeId))
 	}
@@ -1459,6 +1582,8 @@ func makeGoLangTypeName(ti typeInfo) string {
 		return "BINARY"
 	case typeUdt:
 		return strings.ToUpper(ti.UdtInfo.TypeName)
+	case typeVectorN:
+		return "VECTOR"
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangTypeName for type %d", ti.TypeId))
 	}
@@ -1594,6 +1719,12 @@ func makeGoLangTypeLength(ti typeInfo) (int64, bool) {
 		default:
 			panic(fmt.Sprintf("not implemented makeGoLangTypeLength for user defined type %s", ti.UdtInfo.TypeName))
 		}
+	case typeVectorN:
+		dims, _, ok := vectorDimensionsFromTypeInfo(ti)
+		if !ok {
+			return 0, false
+		}
+		return int64(dims), true
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangTypeLength for type %d", ti.TypeId))
 	}
@@ -1709,6 +1840,8 @@ func makeGoLangTypePrecisionScale(ti typeInfo) (int64, int64, bool) {
 	case typeBigBinary:
 		return 0, 0, false
 	case typeUdt:
+		return 0, 0, false
+	case typeVectorN:
 		return 0, 0, false
 	default:
 		panic(fmt.Sprintf("not implemented makeGoLangTypePrecisionScale for type %d", ti.TypeId))

--- a/types.go
+++ b/types.go
@@ -854,6 +854,47 @@ func readPLPType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn.E
 	panic("shouldn't get here")
 }
 
+func readVectorPLPType(_ *typeInfo, r *tdsBuffer, c *cryptoMetadata, _ msdsn.EncodeParameters) interface{} {
+	if c != nil {
+		size := r.rsize - r.rpos
+		if size > vectorMaxWireSize {
+			badStreamPanicf("vector PLP length %d exceeds maximum %d", size, vectorMaxWireSize)
+		}
+		out := make([]byte, size)
+		r.ReadFull(out)
+		return out
+	}
+
+	size := r.uint64()
+	switch size {
+	case _PLP_NULL:
+		return nil
+	case _UNKNOWN_PLP_LEN:
+	default:
+		if size > vectorMaxWireSize {
+			badStreamPanicf("vector PLP length %d exceeds maximum %d", size, vectorMaxWireSize)
+		}
+	}
+
+	capacity := 1000
+	if size != _UNKNOWN_PLP_LEN {
+		capacity = int(size)
+	}
+	out := make([]byte, 0, capacity)
+	for {
+		chunkSize := r.uint32()
+		if chunkSize == _PLP_TERMINATOR {
+			return out
+		}
+		if uint64(len(out))+uint64(chunkSize) > vectorMaxWireSize {
+			badStreamPanicf("vector PLP accumulated length exceeds maximum %d", vectorMaxWireSize)
+		}
+		offset := len(out)
+		out = append(out, make([]byte, int(chunkSize))...)
+		r.ReadFull(out[offset:])
+	}
+}
+
 func writePLPType(w io.Writer, ti typeInfo, buf []byte, encoding msdsn.EncodeParameters) (err error) {
 	if buf == nil {
 		err = binary.Write(w, binary.LittleEndian, uint64(_PLP_NULL))
@@ -984,7 +1025,7 @@ func readVarLen(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn.En
 		// Vector dimensions can be up to 1998 (float32) or 3996 (float16).
 		// Dimension count can be derived as: (ti.Size - 8) / bytesPerDim when needed.
 		if ti.Size == 0xffff {
-			ti.Reader = readPLPType
+			ti.Reader = readVectorPLPType
 		} else {
 			ti.Reader = readVectorType
 		}

--- a/types.go
+++ b/types.go
@@ -597,6 +597,9 @@ func readVectorType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msds
 	if size == 0xffff {
 		return nil
 	}
+	if int(size) > vectorMaxWireSize {
+		badStreamPanicf("vector length %d exceeds wire maximum %d", size, vectorMaxWireSize)
+	}
 	if c == nil && int(size) > ti.Size {
 		badStreamPanicf("vector length %d exceeds column maximum %d", size, ti.Size)
 	}
@@ -884,6 +887,9 @@ func readVectorPLPType(_ *typeInfo, r *tdsBuffer, c *cryptoMetadata, _ msdsn.Enc
 	for {
 		chunkSize := r.uint32()
 		if chunkSize == _PLP_TERMINATOR {
+			if size != _UNKNOWN_PLP_LEN && uint64(len(out)) != size {
+				badStreamPanicf("vector PLP length %d does not match advertised length %d", len(out), size)
+			}
 			return out
 		}
 		if uint64(len(out))+uint64(chunkSize) > vectorMaxWireSize {

--- a/types.go
+++ b/types.go
@@ -891,6 +891,9 @@ func readVectorPLPType(_ *typeInfo, r *tdsBuffer, c *cryptoMetadata, _ msdsn.Enc
 		if uint64(len(out))+uint64(chunkSize) > vectorMaxWireSize {
 			badStreamPanicf("vector PLP accumulated length exceeds maximum %d", vectorMaxWireSize)
 		}
+		if size != _UNKNOWN_PLP_LEN && uint64(len(out))+uint64(chunkSize) > size {
+			badStreamPanicf("vector PLP chunk exceeds advertised length %d", size)
+		}
 		offset := len(out)
 		out = append(out, make([]byte, int(chunkSize))...)
 		r.ReadFull(out[offset:])

--- a/types.go
+++ b/types.go
@@ -848,11 +848,6 @@ func readPLPType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn.E
 		return decodeNChar(bytesToDecode)
 	case typeUdt:
 		return decodeUdt(*ti, bytesToDecode)
-	case typeVectorN:
-		// Vector type in PLP format - return raw bytes.
-		// Types such as Vector and NullVector, which implement sql.Scanner,
-		// are responsible for decoding this binary representation.
-		return bytesToDecode
 	}
 	panic("shouldn't get here")
 }

--- a/types.go
+++ b/types.go
@@ -588,19 +588,20 @@ func writeShortLenType(w io.Writer, ti typeInfo, buf []byte, encoding msdsn.Enco
 // database/sql/driver.Value type. Types such as Vector and NullVector, which implement
 // sql.Scanner, are responsible for decoding this binary representation.
 func readVectorType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn.EncodeParameters) interface{} {
-	var size uint16
+	var size int
 	if c != nil {
-		size = uint16(r.rsize)
+		size = r.rsize - r.rpos
 	} else {
-		size = r.uint16()
+		encodedSize := r.uint16()
+		if encodedSize == 0xffff {
+			return nil
+		}
+		size = int(encodedSize)
 	}
-	if size == 0xffff {
-		return nil
-	}
-	if int(size) > vectorMaxWireSize {
+	if size > vectorMaxWireSize {
 		badStreamPanicf("vector length %d exceeds wire maximum %d", size, vectorMaxWireSize)
 	}
-	if c == nil && int(size) > ti.Size {
+	if c == nil && size > ti.Size {
 		badStreamPanicf("vector length %d exceeds column maximum %d", size, ti.Size)
 	}
 	out := make([]byte, size)

--- a/vector.go
+++ b/vector.go
@@ -1,0 +1,710 @@
+package mssql
+
+import (
+	"context"
+	"database/sql/driver"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/microsoft/go-mssqldb/msdsn"
+)
+
+// vectorPrecisionLossHandler is a callback function that is invoked when float64 to float32
+// conversion results in precision loss. The callback receives the index of the value,
+// the original float64 value, and the converted float32 value.
+// Use SetVectorPrecisionLossHandler to set this in a thread-safe way.
+// By default, no handler is set (warnings are silent).
+var vectorPrecisionLossHandler func(index int, original float64, converted float32)
+var vectorPrecisionMu sync.Mutex
+
+// SetVectorPrecisionLossHandler sets the global precision loss handler in a thread-safe way.
+// Passing nil disables precision loss callbacks.
+func SetVectorPrecisionLossHandler(handler func(index int, original float64, converted float32)) {
+	vectorPrecisionMu.Lock()
+	defer vectorPrecisionMu.Unlock()
+	vectorPrecisionLossHandler = handler
+}
+
+// SetVectorPrecisionWarnings enables or disables precision loss warnings when converting
+// float64 values to float32 for vector operations. When enabled, a warning is logged via
+// the driver's logging infrastructure (SetLogger/SetContextLogger) when precision loss is
+// detected (at most one warning per vector operation). If no driver logger is configured,
+// the warning is silently discarded.
+func SetVectorPrecisionWarnings(enabled bool) {
+	if enabled {
+		SetVectorPrecisionLossHandler(defaultPrecisionLossHandler)
+	} else {
+		SetVectorPrecisionLossHandler(nil)
+	}
+}
+
+// defaultPrecisionLossHandler is the default handler that logs precision loss warnings.
+// It routes warnings through the driver's logging infrastructure (SetLogger/SetContextLogger)
+// so that applications can capture them alongside other driver messages. If no driver logger
+// is configured, the message is silently discarded. Applications that want custom handling
+// should use SetVectorPrecisionLossHandler to set their own function.
+func defaultPrecisionLossHandler(index int, original float64, converted float32) {
+	msg := fmt.Sprintf("vector precision loss at index %d: float64(%v) -> float32(%v)", index, original, converted)
+	driverInstance.logger.Log(context.Background(), msdsn.LogMessages, msg)
+}
+
+// checkFloat64PrecisionLoss checks if converting float64 to float32 loses precision
+// and invokes the precision loss handler on the first value that loses precision.
+// Only reports the first loss for performance with large vectors.
+func checkFloat64PrecisionLoss(values []float64, converted []float32) {
+	vectorPrecisionMu.Lock()
+	handler := vectorPrecisionLossHandler
+	vectorPrecisionMu.Unlock()
+	if handler == nil {
+		return
+	}
+	for i, orig := range values {
+		// Check if round-trip conversion loses precision
+		if float64(converted[i]) != orig && !math.IsNaN(orig) {
+			handler(i, orig, converted[i])
+			return // Only report first precision loss
+		}
+	}
+}
+
+// VectorElementType represents the element type of a SQL Server Vector.
+// SQL Server 2025 supports float32 (default) and float16.
+type VectorElementType byte
+
+const (
+	// VectorElementFloat32 represents 32-bit single-precision floating point (4 bytes per element).
+	// This is the default element type for SQL Server vectors.
+	VectorElementFloat32 VectorElementType = 0x00
+
+	// VectorElementFloat16 represents 16-bit half-precision floating point (2 bytes per element).
+	// Note: float16 is a preview feature in SQL Server requiring PREVIEW_FEATURES = ON.
+	// Currently, float16 vector *parameters* are transmitted as JSON payloads over TDS rather than as
+	// binary vector values. This does not affect how server-to-client results are encoded on the wire.
+	// The element type is determined by the SQL column definition, not the Go-side struct.
+	VectorElementFloat16 VectorElementType = 0x01
+)
+
+// Vector type constants for SQL Server 2025+ Vector data type
+const (
+	// Vector header constants
+	vectorMagic      = 0xA9 // Magic byte identifying vector data
+	vectorVersion    = 0x01 // Current vector format version
+	vectorHeaderSize = 8    // Size of vector header in bytes
+
+	// Maximum dimensions for a vector
+	// For float32: (8000 - 8) / 4 = 1998 dimensions
+	// For float16: (8000 - 8) / 2 = 3996 dimensions
+	vectorMaxDimensionsFloat32 = 1998
+	vectorMaxDimensionsFloat16 = 3996
+)
+
+// String returns the string representation of the element type.
+// Uses uppercase names (FLOAT32, FLOAT16) for consistency with JDBC and SqlClient drivers.
+func (t VectorElementType) String() string {
+	switch t {
+	case VectorElementFloat32:
+		return "FLOAT32"
+	case VectorElementFloat16:
+		return "FLOAT16"
+	default:
+		return fmt.Sprintf("UNKNOWN(0x%02X)", byte(t))
+	}
+}
+
+// IsValid returns true if the element type is a supported vector element type.
+func (t VectorElementType) IsValid() bool {
+	return t == VectorElementFloat32 || t == VectorElementFloat16
+}
+
+// BytesPerElement returns the number of bytes per element for this type.
+func (t VectorElementType) BytesPerElement() int {
+	switch t {
+	case VectorElementFloat32:
+		return 4
+	case VectorElementFloat16:
+		return 2
+	default:
+		return 4 // Default to float32
+	}
+}
+
+// MaxDimensions returns the maximum number of dimensions for this element type.
+func (t VectorElementType) MaxDimensions() int {
+	switch t {
+	case VectorElementFloat32:
+		return vectorMaxDimensionsFloat32
+	case VectorElementFloat16:
+		return vectorMaxDimensionsFloat16
+	default:
+		return vectorMaxDimensionsFloat32
+	}
+}
+
+// Vector represents the SQL Server Vector data type introduced in SQL Server 2025.
+// It stores an array of floating-point values, commonly used for AI/ML embedding scenarios.
+//
+// SQL Server supports two element types:
+//   - float32 (default): 32-bit single-precision, up to 1998 dimensions
+//   - float16: 16-bit half-precision, up to 3996 dimensions
+//
+// The Vector struct exposes its fields for direct access; however, callers should avoid
+// modifying Data after the Vector has been passed to a database operation, as concurrent
+// mutation may lead to unpredictable results.
+//
+// Example usage:
+//
+//	// Creating a vector with float32 values (default)
+//	v, err := mssql.NewVector([]float32{1.0, 2.0, 3.0})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Using in a query
+//	_, err = db.Exec("INSERT INTO embeddings (embedding) VALUES (@p1)", v)
+//
+//	// Reading from a query
+//	var result mssql.Vector
+//	err = db.QueryRow("SELECT embedding FROM embeddings WHERE id = 1").Scan(&result)
+type Vector struct {
+	// ElementType specifies the precision of vector elements (float32 or float16).
+	ElementType VectorElementType
+
+	// Data contains the vector elements as float32 values.
+	// For float16 vectors, values are converted to/from float32 during encoding/decoding.
+	Data []float32
+}
+
+// NullVector represents a Vector that may be null.
+// NullVector implements the Scanner interface so it can be used as a scan destination.
+type NullVector struct {
+	Vector Vector
+	Valid  bool // Valid is true if Vector is not NULL
+}
+
+// IsNull reports whether the vector represents a SQL NULL value.
+// It returns true when Data is nil; an empty but non-nil slice is not considered NULL.
+func (v Vector) IsNull() bool {
+	return v.Data == nil
+}
+
+// Scan implements the sql.Scanner interface for Vector.
+func (v *Vector) Scan(src interface{}) error {
+	if src == nil {
+		v.Data = nil
+		v.ElementType = VectorElementFloat32
+		return nil
+	}
+
+	switch val := src.(type) {
+	case []byte:
+		return v.decodeFromBytes(val)
+	case Vector:
+		*v = val
+		return nil
+	case []float32:
+		v.ElementType = VectorElementFloat32
+		v.Data = copyFloat32Slice(val)
+		return nil
+	case []float64:
+		// Convert float64 to float32 (may lose precision)
+		v.ElementType = VectorElementFloat32
+		v.Data = make([]float32, len(val))
+		for i, f := range val {
+			v.Data[i] = float32(f)
+		}
+		checkFloat64PrecisionLoss(val, v.Data)
+		return nil
+	case string:
+		// Handle JSON array format: "[1.0, 2.0, 3.0]"
+		return v.decodeFromJSON(val)
+	default:
+		return fmt.Errorf("mssql: cannot convert %T to Vector", src)
+	}
+}
+
+// Value implements the driver.Valuer interface for Vector.
+// Returns the vector as a JSON array string for SQL Server parameter binding.
+// Returns an error if the vector contains Infinity values (which cannot be represented in JSON).
+func (v Vector) Value() (driver.Value, error) {
+	if v.Data == nil {
+		return nil, nil
+	}
+	// Check for Inf values which cannot be round-tripped through JSON
+	for _, val := range v.Data {
+		if math.IsInf(float64(val), 0) {
+			return nil, errors.New("mssql: vector contains Infinity values which cannot be encoded as JSON parameter")
+		}
+	}
+	return v.ToJSON(), nil
+}
+
+// Scan implements the sql.Scanner interface for NullVector.
+func (nv *NullVector) Scan(src interface{}) error {
+	if src == nil {
+		nv.Valid = false
+		nv.Vector = Vector{}
+		return nil
+	}
+
+	if err := nv.Vector.Scan(src); err != nil {
+		// Ensure the NullVector remains invalid on scan failure.
+		nv.Valid = false
+		return err
+	}
+
+	nv.Valid = true
+	return nil
+}
+
+// Value implements the driver.Valuer interface for NullVector.
+func (nv NullVector) Value() (driver.Value, error) {
+	if !nv.Valid {
+		return nil, nil
+	}
+	return nv.Vector.Value()
+}
+
+// String returns a string representation of the Vector.
+// Format: "VECTOR(FLOAT32, 3) : [1, 2, 3]"
+// The format uses uppercase type names for consistency with JDBC and SqlClient drivers.
+func (v Vector) String() string {
+	if v.Data == nil {
+		return "NULL"
+	}
+
+	// Use strings.Builder for better performance with large vectors.
+	// Capacity estimate: ~12 chars per float for typical values.
+	var sb strings.Builder
+	sb.Grow(len(v.Data)*12 + 30) // ~12 chars/float + prefix overhead
+	sb.WriteString("VECTOR(")
+	sb.WriteString(v.ElementType.String())
+	sb.WriteString(", ")
+	sb.WriteString(strconv.Itoa(len(v.Data)))
+	sb.WriteString(") : [")
+	for i, val := range v.Data {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(strconv.FormatFloat(float64(val), 'g', -1, 32))
+	}
+	sb.WriteByte(']')
+	return sb.String()
+}
+
+// ToJSON returns the Vector as a JSON array string suitable for SQL Server parameter binding.
+// Format: "[1.0, 2.0, 3.0]"
+// Returns an empty string for nil/NULL vectors or if the vector contains Infinity values.
+// This format is used when sending vectors as parameters via RPC calls,
+// following the backward compatibility approach used by SqlClient.
+// Note: NaN values are encoded as JSON null; Infinity values return empty string
+// since they cannot be losslessly round-tripped through JSON.
+func (v Vector) ToJSON() string {
+	if v.Data == nil {
+		return ""
+	}
+
+	// Use strings.Builder for better performance with large vectors
+	var sb strings.Builder
+	sb.Grow(len(v.Data)*12 + 2) // Estimate: ~12 chars per float + brackets
+	sb.WriteByte('[')
+	for i, val := range v.Data {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		f := float64(val)
+		if math.IsInf(f, 0) {
+			// Infinity cannot be represented in JSON and would round-trip as NaN.
+			// Return empty string to avoid silently encoding Infinity; callers should
+			// treat this as a serialization failure when v.Data is non-nil.
+			return ""
+		}
+		if math.IsNaN(f) {
+			// JSON does not support NaN as a numeric literal.
+			// Encode as null; decodeFromJSON will convert back to NaN.
+			sb.WriteString("null")
+		} else {
+			sb.WriteString(strconv.FormatFloat(f, 'g', -1, 32))
+		}
+	}
+	sb.WriteByte(']')
+	return sb.String()
+}
+
+// Dimensions returns the number of dimensions (elements) in the vector.
+func (v Vector) Dimensions() int {
+	return len(v.Data)
+}
+
+// Values returns a copy of the vector data as a float32 slice.
+func (v Vector) Values() []float32 {
+	if v.Data == nil {
+		return nil
+	}
+	return copyFloat32Slice(v.Data)
+}
+
+// encodeToBytes encodes the Vector to the TDS wire format.
+// Wire format:
+//   - Magic (1 byte): 0xA9
+//   - Version (1 byte): 0x01
+//   - Dimensions (2 bytes, little-endian): number of elements
+//   - Type (1 byte): 0x00 for float32, 0x01 for float16
+//   - Reserved (3 bytes): 0x00, 0x00, 0x00
+//   - Data: float32 (4 bytes per element) or float16 (2 bytes per element), little-endian
+func (v Vector) encodeToBytes() ([]byte, error) {
+	if v.Data == nil {
+		return nil, nil
+	}
+
+	dimensions := len(v.Data)
+	maxDimensions := v.ElementType.MaxDimensions()
+	if dimensions > maxDimensions {
+		return nil, fmt.Errorf("mssql: vector dimensions %d exceeds maximum %d for %s",
+			dimensions, maxDimensions, v.ElementType)
+	}
+
+	bytesPerElement := v.ElementType.BytesPerElement()
+	totalSize := vectorHeaderSize + dimensions*bytesPerElement
+	buf := make([]byte, totalSize)
+
+	// Write header
+	buf[0] = vectorMagic
+	buf[1] = vectorVersion
+	binary.LittleEndian.PutUint16(buf[2:4], uint16(dimensions))
+	buf[4] = byte(v.ElementType)
+	buf[5] = 0x00 // Reserved
+	buf[6] = 0x00 // Reserved
+	buf[7] = 0x00 // Reserved
+
+	// Write data based on element type
+	switch v.ElementType {
+	case VectorElementFloat32:
+		for i, val := range v.Data {
+			offset := vectorHeaderSize + i*4
+			binary.LittleEndian.PutUint32(buf[offset:offset+4], math.Float32bits(val))
+		}
+	case VectorElementFloat16:
+		for i, val := range v.Data {
+			offset := vectorHeaderSize + i*2
+			binary.LittleEndian.PutUint16(buf[offset:offset+2], float32ToFloat16(val))
+		}
+	default:
+		return nil, fmt.Errorf("mssql: unsupported vector element type: %s", v.ElementType)
+	}
+
+	return buf, nil
+}
+
+// decodeFromBytes decodes the Vector from the TDS wire format.
+func (v *Vector) decodeFromBytes(buf []byte) error {
+	// Treat nil buffer as SQL NULL vector.
+	if buf == nil {
+		v.Data = nil
+		v.ElementType = VectorElementFloat32
+		return nil
+	}
+
+	// A non-nil but empty buffer is considered invalid/truncated data.
+	if len(buf) == 0 {
+		return errors.New("mssql: vector data too short")
+	}
+
+	if len(buf) < vectorHeaderSize {
+		return errors.New("mssql: vector data too short for header")
+	}
+
+	// Validate header
+	if buf[0] != vectorMagic {
+		return fmt.Errorf("mssql: invalid vector magic byte: got 0x%02X, expected 0x%02X", buf[0], vectorMagic)
+	}
+
+	if buf[1] != vectorVersion {
+		return fmt.Errorf("mssql: unsupported vector version: got 0x%02X, expected 0x%02X", buf[1], vectorVersion)
+	}
+
+	dimensions := int(binary.LittleEndian.Uint16(buf[2:4]))
+	elementType := VectorElementType(buf[4])
+
+	// Validate element type
+	if !elementType.IsValid() {
+		return fmt.Errorf("mssql: unsupported vector element type: 0x%02X", elementType)
+	}
+
+	bytesPerElement := elementType.BytesPerElement()
+	expectedDataSize := vectorHeaderSize + dimensions*bytesPerElement
+	if len(buf) != expectedDataSize {
+		return fmt.Errorf("mssql: vector data size mismatch: got %d bytes, expected %d bytes for %d %s dimensions",
+			len(buf), expectedDataSize, dimensions, elementType)
+	}
+
+	// Decode values based on element type
+	result := make([]float32, dimensions)
+	switch elementType {
+	case VectorElementFloat32:
+		for i := 0; i < dimensions; i++ {
+			offset := vectorHeaderSize + i*4
+			result[i] = math.Float32frombits(binary.LittleEndian.Uint32(buf[offset : offset+4]))
+		}
+	case VectorElementFloat16:
+		for i := 0; i < dimensions; i++ {
+			offset := vectorHeaderSize + i*2
+			result[i] = float16ToFloat32(binary.LittleEndian.Uint16(buf[offset : offset+2]))
+		}
+	}
+
+	v.ElementType = elementType
+	v.Data = result
+	return nil
+}
+
+// decodeFromJSON decodes a Vector from a JSON array string.
+// Format: "[1.0, 2.0, 3.0]"
+// Note: JSON null values are decoded as NaN since JSON does not support
+// special floating-point values (NaN, Inf) as numeric literals.
+// This allows round-tripping of NaN values through ToJSON()/decodeFromJSON().
+func (v *Vector) decodeFromJSON(jsonStr string) error {
+	// Trim whitespace
+	jsonStr = strings.TrimSpace(jsonStr)
+
+	// Check for empty array - return empty slice (not nil) to distinguish from NULL
+	if jsonStr == "[]" {
+		v.Data = make([]float32, 0)
+		v.ElementType = VectorElementFloat32
+		return nil
+	}
+
+	// Check for JSON null - represents SQL NULL (Data == nil)
+	if jsonStr == "null" {
+		v.Data = nil
+		v.ElementType = VectorElementFloat32
+		return nil
+	}
+
+	// Parse JSON array using []*float64 to handle null values
+	// (null is used to represent NaN/Inf since JSON doesn't support them)
+	var values []*float64
+	if err := json.Unmarshal([]byte(jsonStr), &values); err != nil {
+		return fmt.Errorf("mssql: failed to parse vector JSON: %w", err)
+	}
+
+	// Convert to float32, mapping null to NaN
+	data := make([]float32, len(values))
+	for i, val := range values {
+		if val == nil {
+			// null represents NaN (JSON doesn't support NaN/Inf literals)
+			data[i] = float32(math.NaN())
+		} else {
+			data[i] = float32(*val)
+		}
+	}
+
+	v.ElementType = VectorElementFloat32
+	v.Data = data
+	return nil
+}
+
+// float32ToFloat16 converts a float32 value to float16 (IEEE 754 half-precision).
+// This follows the same algorithm used by JDBC's VectorUtils.floatToFloat16().
+//
+// IEEE 754 half-precision format (16 bits):
+//   - Sign: 1 bit (bit 15)
+//   - Exponent: 5 bits (bits 10-14), bias = 15
+//   - Mantissa: 10 bits (bits 0-9)
+//
+// Constants used:
+//   - float16ExpMax (31): Maximum exponent value (all 1s = infinity/NaN)
+//   - float16InfBits (0x7C00): Positive infinity bit pattern
+//   - float16NaNBits (0x7E00): Quiet NaN bit pattern (canonical form)
+//   - float16MantissaMask (0x03FF): Mask for 10-bit mantissa
+const (
+	float16ExpMax       = 31     // Maximum exponent value (5 bits all 1s)
+	float16InfBits      = 0x7C00 // Positive infinity: sign=0, exp=11111, mant=0
+	float16NaNBits      = 0x7E00 // Quiet NaN: sign=0, exp=11111, mant=1000000000
+	float16MantissaMask = 0x03FF // 10-bit mantissa mask
+)
+
+func float32ToFloat16(value float32) uint16 {
+	bits := math.Float32bits(value)
+
+	sign := (bits >> 31) & 0x1
+	exponent := int((bits >> 23) & 0xFF)
+	mantissa := bits & 0x7FFFFF
+
+	// NaN or Infinity
+	if exponent == 0xFF {
+		if mantissa != 0 {
+			return uint16((sign << 15) | float16NaNBits) // NaN
+		}
+		return uint16((sign << 15) | float16InfBits) // Infinity
+	}
+
+	// Zero (preserve signed zero)
+	if (bits & 0x7FFFFFFF) == 0 {
+		return uint16(sign << 15)
+	}
+
+	// Convert exponent (bias 127 -> bias 15)
+	halfExponent := exponent - 127 + 15
+
+	// Overflow → Infinity
+	if halfExponent >= float16ExpMax {
+		return uint16((sign << 15) | float16InfBits)
+	}
+
+	// Underflow → Subnormal or Zero
+	if halfExponent <= 0 {
+		if halfExponent < -10 {
+			return uint16(sign << 15) // Too small → zero
+		}
+
+		// Convert to subnormal
+		mantissa |= 0x800000
+		shift := uint(1 - halfExponent)
+
+		mant := mantissa >> (shift + 13)
+
+		// Round to nearest-even
+		roundBit := (mantissa >> (shift + 12)) & 1
+		lostBits := mantissa & ((1 << (shift + 12)) - 1)
+
+		if roundBit == 1 && (lostBits != 0 || (mant&1) == 1) {
+			mant++
+		}
+
+		return uint16((sign << 15) | mant)
+	}
+
+	// Normal number
+	mant := mantissa >> 13
+
+	// Rounding: check bit 12 (first discarded bit) and lower 12 bits (0xFFF mask).
+	// The 0xFFF mask captures the 12 bits that are lost when truncating from
+	// float32's 23-bit mantissa to float16's 10-bit mantissa.
+	roundBit := (mantissa >> 12) & 1
+	lostBits := mantissa & 0xFFF
+
+	if roundBit == 1 && (lostBits != 0 || (mant&1) == 1) {
+		mant++
+		if mant == 0x400 { // Mantissa overflow
+			mant = 0
+			halfExponent++
+			if halfExponent >= float16ExpMax {
+				return uint16((sign << 15) | float16InfBits)
+			}
+		}
+	}
+
+	return uint16((uint32(sign) << 15) | (uint32(halfExponent) << 10) | uint32(mant))
+}
+
+// float16ToFloat32 converts a float16 (IEEE 754 half-precision) value to float32.
+// This follows the same algorithm used by JDBC's VectorUtils.float16ToFloat().
+func float16ToFloat32(value uint16) float32 {
+	sign := (value >> 15) & 0x1
+	exponent := int((value >> 10) & 0x1F)
+	mantissa := uint32(value & 0x3FF)
+
+	// Infinity or NaN
+	if exponent == 31 {
+		if mantissa != 0 {
+			return float32(math.NaN())
+		}
+		if sign == 1 {
+			return float32(math.Inf(-1))
+		}
+		return float32(math.Inf(1))
+	}
+
+	// Zero or subnormal
+	if exponent == 0 {
+		if mantissa == 0 {
+			// Preserve signed zero
+			if sign == 1 {
+				return float32(math.Copysign(0, -1))
+			}
+			return 0
+		}
+		// Subnormal: normalize
+		for (mantissa & 0x400) == 0 {
+			mantissa <<= 1
+			exponent--
+		}
+		mantissa &= 0x3FF
+		exponent++
+	}
+
+	// Convert exponent bias (15 -> 127)
+	exponent = exponent + (127 - 15)
+
+	result := (uint32(sign) << 31) | (uint32(exponent) << 23) | (mantissa << 13)
+	return math.Float32frombits(result)
+}
+
+// copyFloat32Slice returns a copy of the input slice.
+func copyFloat32Slice(src []float32) []float32 {
+	dst := make([]float32, len(src))
+	copy(dst, src)
+	return dst
+}
+
+// newVectorFromFloat32 creates a Vector from float32 slice with dimension validation.
+func newVectorFromFloat32(elementType VectorElementType, values []float32) (Vector, error) {
+	max := elementType.MaxDimensions()
+	if len(values) > max {
+		return Vector{}, fmt.Errorf("mssql: vector dimensions %d exceeds maximum %d for %s", len(values), max, elementType)
+	}
+	return Vector{ElementType: elementType, Data: copyFloat32Slice(values)}, nil
+}
+
+// NewVector creates a new Vector with float32 element type from a slice of float32 values.
+// Returns an error if the number of dimensions exceeds the maximum allowed.
+func NewVector(values []float32) (Vector, error) {
+	return newVectorFromFloat32(VectorElementFloat32, values)
+}
+
+// NewVectorWithType creates a new Vector with the specified element type from a slice of float32 values.
+// Returns an error if the element type is unsupported or the number of dimensions exceeds the maximum allowed.
+func NewVectorWithType(elementType VectorElementType, values []float32) (Vector, error) {
+	if !elementType.IsValid() {
+		return Vector{}, fmt.Errorf("mssql: unsupported vector element type %d", elementType)
+	}
+	return newVectorFromFloat32(elementType, values)
+}
+
+// NewVectorFromFloat64 creates a new Vector with float32 element type from a slice of float64 values.
+// The values are converted to float32, which may result in precision loss.
+// If SetVectorPrecisionLossHandler has been called or SetVectorPrecisionWarnings(true) was called,
+// a warning will be generated for the first value that loses precision.
+// Returns an error if the number of dimensions exceeds the maximum allowed.
+func NewVectorFromFloat64(values []float64) (Vector, error) {
+	max := VectorElementFloat32.MaxDimensions()
+	if len(values) > max {
+		return Vector{}, fmt.Errorf("mssql: vector dimensions %d exceeds maximum %d for %s", len(values), max, VectorElementFloat32)
+	}
+	data := make([]float32, len(values))
+	for i, val := range values {
+		data[i] = float32(val)
+	}
+	checkFloat64PrecisionLoss(values, data)
+	return Vector{ElementType: VectorElementFloat32, Data: data}, nil
+}
+
+// ToFloat64 returns the vector values as a slice of float64.
+// This is a widening conversion from the stored float32 values.
+// Useful for interfacing with Go libraries that use float64 (e.g., gonum).
+func (v Vector) ToFloat64() []float64 {
+	if v.Data == nil {
+		return nil
+	}
+	result := make([]float64, len(v.Data))
+	for i, val := range v.Data {
+		result[i] = float64(val)
+	}
+	return result
+}

--- a/vector.go
+++ b/vector.go
@@ -437,6 +437,12 @@ func (v *Vector) decodeFromBytes(buf []byte) error {
 		return fmt.Errorf("mssql: unsupported vector element type: 0x%02X", elementType)
 	}
 
+	maxDimensions := elementType.MaxDimensions()
+	if dimensions > maxDimensions {
+		return fmt.Errorf("mssql: vector dimensions %d exceeds maximum %d for %s",
+			dimensions, maxDimensions, elementType)
+	}
+
 	bytesPerElement := elementType.BytesPerElement()
 	expectedDataSize := vectorHeaderSize + dimensions*bytesPerElement
 	if len(buf) != expectedDataSize {

--- a/vector.go
+++ b/vector.go
@@ -649,6 +649,9 @@ func float16ToFloat32(value uint16) float32 {
 
 // copyFloat32Slice returns a copy of the input slice.
 func copyFloat32Slice(src []float32) []float32 {
+	if src == nil {
+		return nil
+	}
 	dst := make([]float32, len(src))
 	copy(dst, src)
 	return dst
@@ -687,6 +690,9 @@ func NewVectorFromFloat64(values []float64) (Vector, error) {
 	max := VectorElementFloat32.MaxDimensions()
 	if len(values) > max {
 		return Vector{}, fmt.Errorf("mssql: vector dimensions %d exceeds maximum %d for %s", len(values), max, VectorElementFloat32)
+	}
+	if values == nil {
+		return Vector{ElementType: VectorElementFloat32}, nil
 	}
 	data := make([]float32, len(values))
 	for i, val := range values {

--- a/vector.go
+++ b/vector.go
@@ -208,17 +208,18 @@ func (v *Vector) Scan(src interface{}) error {
 		*v = val
 		return nil
 	case []float32:
-		v.ElementType = VectorElementFloat32
-		v.Data = copyFloat32Slice(val)
+		vector, err := NewVector(val)
+		if err != nil {
+			return err
+		}
+		*v = vector
 		return nil
 	case []float64:
-		// Convert float64 to float32 (may lose precision)
-		v.ElementType = VectorElementFloat32
-		v.Data = make([]float32, len(val))
-		for i, f := range val {
-			v.Data[i] = float32(f)
+		vector, err := NewVectorFromFloat64(val)
+		if err != nil {
+			return err
 		}
-		checkFloat64PrecisionLoss(val, v.Data)
+		*v = vector
 		return nil
 	case string:
 		// Handle JSON array format: "[1.0, 2.0, 3.0]"
@@ -486,8 +487,8 @@ func (v *Vector) decodeFromJSON(jsonStr string) error {
 		return nil
 	}
 
-	// Parse JSON array using []*float64 to handle null values
-	// (null is used to represent NaN/Inf since JSON doesn't support them)
+	// Parse JSON array using []*float64 to handle null values.
+	// null is used to represent NaN since JSON does not support it.
 	var values []*float64
 	if err := json.Unmarshal([]byte(jsonStr), &values); err != nil {
 		return fmt.Errorf("mssql: failed to parse vector JSON: %w", err)

--- a/vector.go
+++ b/vector.go
@@ -195,7 +195,8 @@ func (v Vector) IsNull() bool {
 	return v.Data == nil
 }
 
-// Scan implements the sql.Scanner interface for Vector.
+// Scan implements the sql.Scanner interface for Vector. JSON input does not carry
+// element metadata, so dimensions above the float32 limit are inferred as float16.
 func (v *Vector) Scan(src interface{}) error {
 	if src == nil {
 		v.Data = nil
@@ -507,9 +508,9 @@ func (v *Vector) decodeFromJSON(jsonStr string) error {
 
 	data := make([]float32, 0)
 	for decoder.More() {
-		if len(data) >= vectorMaxDimensionsFloat32 {
-			return fmt.Errorf("mssql: vector dimensions %d exceeds maximum %d for %s",
-				len(data)+1, vectorMaxDimensionsFloat32, VectorElementFloat32)
+		if len(data) >= vectorMaxDimensionsFloat16 {
+			return fmt.Errorf("mssql: vector dimensions %d exceeds maximum %d",
+				len(data)+1, vectorMaxDimensionsFloat16)
 		}
 		var val *float64
 		if err := decoder.Decode(&val); err != nil {
@@ -533,6 +534,9 @@ func (v *Vector) decodeFromJSON(jsonStr string) error {
 	}
 
 	v.ElementType = VectorElementFloat32
+	if len(data) > vectorMaxDimensionsFloat32 {
+		v.ElementType = VectorElementFloat16
+	}
 	v.Data = data
 	return nil
 }

--- a/vector.go
+++ b/vector.go
@@ -265,7 +265,7 @@ func (nv *NullVector) Scan(src interface{}) error {
 		return err
 	}
 
-	nv.Valid = true
+	nv.Valid = !nv.Vector.IsNull()
 	return nil
 }
 
@@ -511,7 +511,11 @@ func (v *Vector) decodeFromJSON(jsonStr string) error {
 		if val == nil {
 			return errors.New("mssql: vector JSON elements must be numbers")
 		}
-		data = append(data, float32(*val))
+		converted := float32(*val)
+		if math.IsInf(float64(converted), 0) {
+			return errors.New("mssql: vector JSON element exceeds float32 range")
+		}
+		data = append(data, converted)
 	}
 	if _, err := decoder.Token(); err != nil {
 		return fmt.Errorf("mssql: failed to parse vector JSON: %w", err)

--- a/vector.go
+++ b/vector.go
@@ -235,15 +235,17 @@ func (v *Vector) Scan(src interface{}) error {
 
 // Value implements the driver.Valuer interface for Vector.
 // Returns the vector as a JSON array string for SQL Server parameter binding.
-// Returns an error if the vector contains Infinity values (which cannot be represented in JSON).
+// Returns an error if the vector is empty or contains non-finite values.
 func (v Vector) Value() (driver.Value, error) {
 	if v.Data == nil {
 		return nil, nil
 	}
-	// Check for Inf values which cannot be round-tripped through JSON
+	if len(v.Data) == 0 {
+		return nil, errors.New("mssql: vector dimensions must be at least 1")
+	}
 	for _, val := range v.Data {
-		if math.IsInf(float64(val), 0) {
-			return nil, errors.New("mssql: vector contains Infinity values which cannot be encoded as JSON parameter")
+		if math.IsNaN(float64(val)) || math.IsInf(float64(val), 0) {
+			return nil, errors.New("mssql: vector contains non-finite values which cannot be encoded as JSON parameter")
 		}
 	}
 	return v.ToJSON(), nil
@@ -304,13 +306,11 @@ func (v Vector) String() string {
 
 // ToJSON returns the Vector as a JSON array string suitable for SQL Server parameter binding.
 // Format: "[1.0, 2.0, 3.0]"
-// Returns an empty string for nil/NULL vectors or if the vector contains Infinity values.
+// Returns an empty string for nil/NULL vectors or vectors containing non-finite values.
 // This format is used when sending vectors as parameters via RPC calls,
 // following the backward compatibility approach used by SqlClient.
-// Note: NaN values are encoded as JSON null; Infinity values return empty string
-// since they cannot be losslessly round-tripped through JSON.
 func (v Vector) ToJSON() string {
-	if v.Data == nil {
+	if len(v.Data) == 0 {
 		return ""
 	}
 
@@ -323,19 +323,10 @@ func (v Vector) ToJSON() string {
 			sb.WriteString(", ")
 		}
 		f := float64(val)
-		if math.IsInf(f, 0) {
-			// Infinity cannot be represented in JSON and would round-trip as NaN.
-			// Return empty string to avoid silently encoding Infinity; callers should
-			// treat this as a serialization failure when v.Data is non-nil.
+		if math.IsNaN(f) || math.IsInf(f, 0) {
 			return ""
 		}
-		if math.IsNaN(f) {
-			// JSON does not support NaN as a numeric literal.
-			// Encode as null; decodeFromJSON will convert back to NaN.
-			sb.WriteString("null")
-		} else {
-			sb.WriteString(strconv.FormatFloat(f, 'g', -1, 32))
-		}
+		sb.WriteString(strconv.FormatFloat(f, 'g', -1, 32))
 	}
 	sb.WriteByte(']')
 	return sb.String()
@@ -368,6 +359,9 @@ func (v Vector) encodeToBytes() ([]byte, error) {
 	}
 
 	dimensions := len(v.Data)
+	if dimensions == 0 {
+		return nil, errors.New("mssql: vector dimensions must be at least 1")
+	}
 	maxDimensions := v.ElementType.MaxDimensions()
 	if dimensions > maxDimensions {
 		return nil, fmt.Errorf("mssql: vector dimensions %d exceeds maximum %d for %s",
@@ -434,6 +428,9 @@ func (v *Vector) decodeFromBytes(buf []byte) error {
 	}
 
 	dimensions := int(binary.LittleEndian.Uint16(buf[2:4]))
+	if dimensions == 0 {
+		return errors.New("mssql: vector dimensions must be at least 1")
+	}
 	elementType := VectorElementType(buf[4])
 
 	// Validate element type
@@ -476,18 +473,12 @@ func (v *Vector) decodeFromBytes(buf []byte) error {
 
 // decodeFromJSON decodes a Vector from a JSON array string.
 // Format: "[1.0, 2.0, 3.0]"
-// Note: JSON null values are decoded as NaN since JSON does not support
-// special floating-point values (NaN, Inf) as numeric literals.
-// This allows round-tripping of NaN values through ToJSON()/decodeFromJSON().
 func (v *Vector) decodeFromJSON(jsonStr string) error {
 	// Trim whitespace
 	jsonStr = strings.TrimSpace(jsonStr)
 
-	// Check for empty array - return empty slice (not nil) to distinguish from NULL
 	if jsonStr == "[]" {
-		v.Data = make([]float32, 0)
-		v.ElementType = VectorElementFloat32
-		return nil
+		return errors.New("mssql: vector dimensions must be at least 1")
 	}
 
 	// Check for JSON null - represents SQL NULL (Data == nil)
@@ -518,11 +509,9 @@ func (v *Vector) decodeFromJSON(jsonStr string) error {
 			return fmt.Errorf("mssql: failed to parse vector JSON: %w", err)
 		}
 		if val == nil {
-			// null represents NaN (JSON doesn't support NaN/Inf literals)
-			data = append(data, float32(math.NaN()))
-		} else {
-			data = append(data, float32(*val))
+			return errors.New("mssql: vector JSON elements must be numbers")
 		}
+		data = append(data, float32(*val))
 	}
 	if _, err := decoder.Token(); err != nil {
 		return fmt.Errorf("mssql: failed to parse vector JSON: %w", err)
@@ -691,6 +680,9 @@ func copyFloat32Slice(src []float32) []float32 {
 
 // newVectorFromFloat32 creates a Vector from float32 slice with dimension validation.
 func newVectorFromFloat32(elementType VectorElementType, values []float32) (Vector, error) {
+	if values != nil && len(values) == 0 {
+		return Vector{}, errors.New("mssql: vector dimensions must be at least 1")
+	}
 	max := elementType.MaxDimensions()
 	if len(values) > max {
 		return Vector{}, fmt.Errorf("mssql: vector dimensions %d exceeds maximum %d for %s", len(values), max, elementType)
@@ -719,6 +711,9 @@ func NewVectorWithType(elementType VectorElementType, values []float32) (Vector,
 // a warning will be generated for the first value that loses precision.
 // Returns an error if the number of dimensions exceeds the maximum allowed.
 func NewVectorFromFloat64(values []float64) (Vector, error) {
+	if values != nil && len(values) == 0 {
+		return Vector{}, errors.New("mssql: vector dimensions must be at least 1")
+	}
 	max := VectorElementFloat32.MaxDimensions()
 	if len(values) > max {
 		return Vector{}, fmt.Errorf("mssql: vector dimensions %d exceeds maximum %d for %s", len(values), max, VectorElementFloat32)

--- a/vector.go
+++ b/vector.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"strconv"
 	"strings"
@@ -102,6 +103,7 @@ const (
 	// For float16: (8000 - 8) / 2 = 3996 dimensions
 	vectorMaxDimensionsFloat32 = 1998
 	vectorMaxDimensionsFloat16 = 3996
+	vectorMaxWireSize          = 8000
 )
 
 // String returns the string representation of the element type.
@@ -493,22 +495,41 @@ func (v *Vector) decodeFromJSON(jsonStr string) error {
 		return nil
 	}
 
-	// Parse JSON array using []*float64 to handle null values.
-	// null is used to represent NaN since JSON does not support it.
-	var values []*float64
-	if err := json.Unmarshal([]byte(jsonStr), &values); err != nil {
+	decoder := json.NewDecoder(strings.NewReader(jsonStr))
+	token, err := decoder.Token()
+	if err != nil {
 		return fmt.Errorf("mssql: failed to parse vector JSON: %w", err)
 	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '[' {
+		return errors.New("mssql: failed to parse vector JSON: expected array")
+	}
 
-	// Convert to float32, mapping null to NaN
-	data := make([]float32, len(values))
-	for i, val := range values {
+	data := make([]float32, 0)
+	for decoder.More() {
+		if len(data) >= vectorMaxDimensionsFloat32 {
+			return fmt.Errorf("mssql: vector dimensions %d exceeds maximum %d for %s",
+				len(data)+1, vectorMaxDimensionsFloat32, VectorElementFloat32)
+		}
+		var val *float64
+		if err := decoder.Decode(&val); err != nil {
+			return fmt.Errorf("mssql: failed to parse vector JSON: %w", err)
+		}
 		if val == nil {
 			// null represents NaN (JSON doesn't support NaN/Inf literals)
-			data[i] = float32(math.NaN())
+			data = append(data, float32(math.NaN()))
 		} else {
-			data[i] = float32(*val)
+			data = append(data, float32(*val))
 		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return fmt.Errorf("mssql: failed to parse vector JSON: %w", err)
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		if err == nil {
+			return errors.New("mssql: failed to parse vector JSON: unexpected trailing data")
+		}
+		return fmt.Errorf("mssql: failed to parse vector JSON: %w", err)
 	}
 
 	v.ElementType = VectorElementFloat32

--- a/vector.go
+++ b/vector.go
@@ -240,8 +240,15 @@ func (v Vector) Value() (driver.Value, error) {
 	if v.Data == nil {
 		return nil, nil
 	}
+	if !v.ElementType.IsValid() {
+		return nil, fmt.Errorf("mssql: unsupported vector element type %d", v.ElementType)
+	}
 	if len(v.Data) == 0 {
 		return nil, errors.New("mssql: vector dimensions must be at least 1")
+	}
+	if len(v.Data) > v.ElementType.MaxDimensions() {
+		return nil, fmt.Errorf("mssql: vector dimensions %d exceeds maximum %d for %s",
+			len(v.Data), v.ElementType.MaxDimensions(), v.ElementType)
 	}
 	for _, val := range v.Data {
 		if math.IsNaN(float64(val)) || math.IsInf(float64(val), 0) {
@@ -525,6 +532,9 @@ func (v *Vector) decodeFromJSON(jsonStr string) error {
 			return errors.New("mssql: failed to parse vector JSON: unexpected trailing data")
 		}
 		return fmt.Errorf("mssql: failed to parse vector JSON: %w", err)
+	}
+	if len(data) == 0 {
+		return errors.New("mssql: vector dimensions must be at least 1")
 	}
 
 	v.ElementType = VectorElementFloat32

--- a/vector.go
+++ b/vector.go
@@ -195,8 +195,9 @@ func (v Vector) IsNull() bool {
 	return v.Data == nil
 }
 
-// Scan implements the sql.Scanner interface for Vector. JSON input does not carry
-// element metadata, so dimensions above the float32 limit are inferred as float16.
+// Scan implements the sql.Scanner interface for Vector. JSON input doesn't carry
+// element metadata, so dimensions through 1998 decode as float32 and larger
+// dimensions decode as float16.
 func (v *Vector) Scan(src interface{}) error {
 	if src == nil {
 		v.Data = nil

--- a/vector_benchmark_test.go
+++ b/vector_benchmark_test.go
@@ -1,0 +1,104 @@
+package mssql
+
+import "testing"
+
+// Benchmarks for the VECTOR codecs.
+//
+// Only the paths makeVectorOrJSON can actually reach are covered. It sends
+// native binary for float32 when the server negotiated vector support, and JSON
+// otherwise — including for every float16 parameter, since TDS has no binary
+// float16 parameter format yet. So encodeToBytes is benchmarked for float32
+// only, while decodeFromBytes is benchmarked for both, because the server does
+// return float16 columns in binary.
+//
+// 384 and 1536 are representative embedding widths (all-MiniLM and OpenAI
+// ada-002), both within the 1998-dimension float32 limit.
+
+func benchVector(elementType VectorElementType, dims int) Vector {
+	data := make([]float32, dims)
+	for i := range data {
+		data[i] = float32(i) * 0.001
+	}
+	return Vector{ElementType: elementType, Data: data}
+}
+
+func benchmarkEncodeVector(b *testing.B, elementType VectorElementType, dims int) {
+	v := benchVector(elementType, dims)
+	wire, err := v.encodeToBytes()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.SetBytes(int64(len(wire)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := v.encodeToBytes(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func benchmarkDecodeVector(b *testing.B, elementType VectorElementType, dims int) {
+	wire, err := benchVector(elementType, dims).encodeToBytes()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	var v Vector
+	b.SetBytes(int64(len(wire)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := v.decodeFromBytes(wire); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncodeVector_Float32_384(b *testing.B) {
+	benchmarkEncodeVector(b, VectorElementFloat32, 384)
+}
+
+func BenchmarkEncodeVector_Float32_1536(b *testing.B) {
+	benchmarkEncodeVector(b, VectorElementFloat32, 1536)
+}
+
+func BenchmarkDecodeVector_Float32_384(b *testing.B) {
+	benchmarkDecodeVector(b, VectorElementFloat32, 384)
+}
+
+func BenchmarkDecodeVector_Float32_1536(b *testing.B) {
+	benchmarkDecodeVector(b, VectorElementFloat32, 1536)
+}
+
+func BenchmarkDecodeVector_Float16_384(b *testing.B) {
+	benchmarkDecodeVector(b, VectorElementFloat16, 384)
+}
+
+func BenchmarkDecodeVector_Float16_1536(b *testing.B) {
+	benchmarkDecodeVector(b, VectorElementFloat16, 1536)
+}
+
+// Value() serialises through ToJSON on every parameter bind.
+func BenchmarkEncodeVector_JSON_1536(b *testing.B) {
+	v := benchVector(VectorElementFloat32, 1536)
+
+	b.SetBytes(int64(len(v.ToJSON())))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = v.ToJSON()
+	}
+}
+
+// Scan takes this path when a vector column comes back as a JSON string.
+func BenchmarkDecodeVector_JSON_1536(b *testing.B) {
+	js := benchVector(VectorElementFloat32, 1536).ToJSON()
+
+	var v Vector
+	b.SetBytes(int64(len(js)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := v.decodeFromJSON(js); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/vector_db_test.go
+++ b/vector_db_test.go
@@ -1,0 +1,835 @@
+package mssql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/microsoft/go-mssqldb/msdsn"
+)
+
+// vectorTestDB holds the shared test database state for vector tests.
+// If we're connected to a system database, we create a user database for testing.
+var (
+	vectorTestDBOnce    sync.Once
+	vectorTestDBName    string
+	vectorTestDBCreated bool
+)
+
+// setupVectorTestDB ensures we're using a user database for vector tests.
+// System databases (master, tempdb, msdb, model) don't support PREVIEW_FEATURES.
+// Database cleanup is handled by drop-before-create logic at the start of each test run.
+func setupVectorTestDB(t *testing.T, conn *sql.DB) {
+	t.Helper()
+
+	vectorTestDBOnce.Do(func() {
+		// Check current database
+		var currentDB string
+		err := conn.QueryRow("SELECT DB_NAME()").Scan(&currentDB)
+		if err != nil {
+			t.Logf("Warning: Could not get current database: %v", err)
+			return
+		}
+
+		// Check if it's a system database
+		systemDBs := []string{"master", "tempdb", "msdb", "model"}
+		isSystemDB := false
+		for _, sysDB := range systemDBs {
+			if strings.EqualFold(currentDB, sysDB) {
+				isSystemDB = true
+				break
+			}
+		}
+
+		if !isSystemDB {
+			// Already in a user database, no need to create one
+			t.Logf("Using existing user database: %s", currentDB)
+			return
+		}
+
+		// We need to use a test database
+		// Use a fixed, clearly prefixed name to avoid accumulating test databases
+		// The prefix makes it obviously a test database
+		vectorTestDBName = "go_mssqldb_vector_test"
+		t.Logf("Connected to system database '%s', will use test database '%s'", currentDB, vectorTestDBName)
+
+		// Drop any existing test database from previous runs, then create fresh.
+		// This is best-effort: if the test login lacks permissions, we skip database
+		// creation and float16 tests will be skipped when they need PREVIEW_FEATURES.
+		if _, err := conn.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS [%s]", vectorTestDBName)); err != nil {
+			t.Logf("Warning: Could not drop test database (may lack permissions): %v", err)
+			return
+		}
+
+		// Create the test database
+		_, err = conn.Exec(fmt.Sprintf("CREATE DATABASE [%s]", vectorTestDBName))
+		if err != nil {
+			t.Logf("Warning: Could not create test database (may lack permissions): %v", err)
+			return
+		}
+		t.Logf("Created test database '%s'", vectorTestDBName)
+		vectorTestDBCreated = true
+		// Note: We don't use t.Cleanup() here because sync.Once ties it to the first
+		// test that runs, which would try to drop the database while other tests are
+		// still using it. Instead, we rely on drop-before-create at the start of each
+		// test run to clean up any leftover databases from previous runs.
+	})
+
+	// Note: We don't attempt to USE the test database here because USE is session-scoped
+	// and *sql.DB may pick different connections per call. The tests create their own
+	// tables in the current database context, which is sufficient for isolation.
+	// The test database creation above is primarily for cleanup between test runs.
+}
+
+// skipIfVectorNotSupported checks if the SQL Server instance supports VECTOR type.
+// VECTOR is only supported in SQL Server 2025+. If not supported, the test is skipped.
+// This function checks VECTOR support FIRST before any database setup to ensure
+// clean skips on pre-2025 servers without risking permission errors.
+func skipIfVectorNotSupported(t *testing.T, conn *sql.DB) {
+	t.Helper()
+
+	// Use a dedicated connection to ensure the temp table CREATE and DROP
+	// happen on the same session. Temp tables are session-scoped, so using
+	// *sql.DB directly could cause the DROP to execute on a different
+	// pooled connection where the temp table doesn't exist.
+	ctx := context.Background()
+	singleConn, err := conn.Conn(ctx)
+	if err != nil {
+		t.Skipf("Skipping: unable to connect to database: %v", err)
+	}
+	defer singleConn.Close()
+
+	// Check VECTOR support FIRST, before any database setup.
+	// This ensures pre-2025 servers skip cleanly without running into
+	// potential permission errors from DROP/CREATE DATABASE operations.
+	_, err = singleConn.ExecContext(ctx, "CREATE TABLE #vector_check (v VECTOR(1))")
+	if err != nil {
+		errStr := err.Error()
+		// Error 2715: "Cannot find data type VECTOR"
+		// This occurs on SQL Server versions before 2025
+		if strings.Contains(errStr, "Cannot find data type VECTOR") ||
+			strings.Contains(errStr, "2715") {
+			// Log the server version for debugging
+			var version string
+			if verr := singleConn.QueryRowContext(ctx, "SELECT @@VERSION").Scan(&version); verr == nil {
+				if len(version) > 80 {
+					version = version[:80] + "..."
+				}
+				t.Logf("Server: %s", version)
+			}
+			t.Skip("VECTOR type not supported - requires SQL Server 2025+")
+		}
+		// For other errors, fail the test
+		t.Fatalf("Failed to check VECTOR support: %v", err)
+	}
+	// Clean up the check table on the same connection where it was created
+	singleConn.ExecContext(ctx, "DROP TABLE #vector_check")
+
+	// Now that we know VECTOR is supported, ensure we're in a user database
+	// for tests that need PREVIEW_FEATURES (float16 tests).
+	setupVectorTestDB(t, conn)
+}
+
+// mustNewVector is a test helper that creates a Vector and panics on error.
+func mustNewVector(values []float32) Vector {
+	v, err := NewVector(values)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// openWithVectorSupport opens a database connection with vectortypesupport=v1 enabled.
+// This enables native binary vector format when the server supports it (SQL Server 2025+).
+func openWithVectorSupport(t testing.TB) (*sql.DB, *testLogger) {
+	tl := testLogger{t: t}
+	SetLogger(&tl)
+	t.Cleanup(func() {
+		tl.StopLogging()
+	})
+
+	config := testConnParams(t)
+	config.VectorTypeSupport = msdsn.VectorTypeSupportV1
+	connectionString := config.URL().String()
+
+	connector, err := NewConnector(connectionString)
+	if err != nil {
+		t.Fatal("Failed to create connector:", err)
+	}
+	conn := sql.OpenDB(connector)
+	return conn, &tl
+}
+
+// vectorTestContext holds common test infrastructure for vector database tests.
+type vectorTestContext struct {
+	t         *testing.T
+	conn      *sql.DB
+	tx        *sql.Tx
+	tableName string
+}
+
+// setupVectorTest creates a test context with connection, transaction, and table.
+// The table has a single VECTOR column with the specified dimensions.
+// Use nullable=true for columns that should allow NULL values.
+func setupVectorTest(t *testing.T, dims int, nullable bool) *vectorTestContext {
+	t.Helper()
+	conn, _ := openWithVectorSupport(t)
+	t.Cleanup(func() { conn.Close() })
+	skipIfVectorNotSupported(t, conn)
+
+	tx, err := conn.Begin()
+	if err != nil {
+		t.Fatal("Begin transaction failed:", err)
+	}
+	t.Cleanup(func() { tx.Rollback() })
+
+	tableName := fmt.Sprintf("#test_vector_%s", t.Name())
+	nullSpec := "NOT NULL"
+	if nullable {
+		nullSpec = "NULL"
+	}
+	_, err = tx.Exec(fmt.Sprintf("CREATE TABLE %s (id INT IDENTITY(1,1) PRIMARY KEY, embedding VECTOR(%d) %s)", tableName, dims, nullSpec))
+	if err != nil {
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	return &vectorTestContext{t: t, conn: conn, tx: tx, tableName: tableName}
+}
+
+// setupVectorTestCustom creates a test context with a custom table schema.
+func setupVectorTestCustom(t *testing.T, createSQL string) *vectorTestContext {
+	t.Helper()
+	conn, _ := openWithVectorSupport(t)
+	t.Cleanup(func() { conn.Close() })
+	skipIfVectorNotSupported(t, conn)
+
+	tx, err := conn.Begin()
+	if err != nil {
+		t.Fatal("Begin transaction failed:", err)
+	}
+	t.Cleanup(func() { tx.Rollback() })
+
+	tableName := fmt.Sprintf("#test_vector_%s", t.Name())
+	_, err = tx.Exec(fmt.Sprintf(createSQL, tableName))
+	if err != nil {
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	return &vectorTestContext{t: t, conn: conn, tx: tx, tableName: tableName}
+}
+
+// insert inserts a vector and returns the generated ID.
+func (ctx *vectorTestContext) insert(v interface{}) int64 {
+	ctx.t.Helper()
+	result, err := ctx.tx.Exec(fmt.Sprintf("INSERT INTO %s (embedding) VALUES (@p1)", ctx.tableName), v)
+	if err != nil {
+		ctx.t.Fatalf("Failed to insert: %v", err)
+	}
+	id, _ := result.LastInsertId()
+	return id
+}
+
+// selectVector reads a vector by ID.
+func (ctx *vectorTestContext) selectVector(id int) Vector {
+	ctx.t.Helper()
+	var v Vector
+	err := ctx.tx.QueryRow(fmt.Sprintf("SELECT embedding FROM %s WHERE id = @p1", ctx.tableName), id).Scan(&v)
+	if err != nil {
+		ctx.t.Fatalf("Failed to scan vector: %v", err)
+	}
+	return v
+}
+
+// selectNullVector reads a nullable vector by ID.
+func (ctx *vectorTestContext) selectNullVector(id int) NullVector {
+	ctx.t.Helper()
+	var nv NullVector
+	err := ctx.tx.QueryRow(fmt.Sprintf("SELECT embedding FROM %s WHERE id = @p1", ctx.tableName), id).Scan(&nv)
+	if err != nil {
+		ctx.t.Fatalf("Failed to scan NullVector: %v", err)
+	}
+	return nv
+}
+
+// assertVectorEquals checks that two vectors have the same values.
+func assertVectorEquals(t *testing.T, got, want Vector) {
+	t.Helper()
+	if got.Dimensions() != want.Dimensions() {
+		t.Fatalf("Dimensions: got %d, want %d", got.Dimensions(), want.Dimensions())
+	}
+	for i := range want.Data {
+		if !floatsEqualVector(got.Data[i], want.Data[i]) {
+			t.Errorf("Data[%d]: got %f, want %f", i, got.Data[i], want.Data[i])
+		}
+	}
+}
+
+// TestVectorInsertAndSelect tests inserting and reading Vector values.
+// This test requires a SQL Server 2025+ instance.
+func TestVectorInsertAndSelect(t *testing.T) {
+	ctx := setupVectorTest(t, 3, false)
+
+	v := mustNewVector([]float32{1.0, 2.0, 3.0})
+	ctx.insert(v)
+
+	got := ctx.selectVector(1)
+	assertVectorEquals(t, got, v)
+	t.Logf("Read vector: %v", got)
+}
+
+// TestVectorNullInsertAndSelect tests inserting and reading NULL Vector values.
+func TestVectorNullInsertAndSelect(t *testing.T) {
+	ctx := setupVectorTest(t, 3, true)
+
+	// Insert NULL
+	ctx.insert(NullVector{Valid: false})
+
+	// Insert valid
+	validVec := mustNewVector([]float32{4.0, 5.0, 6.0})
+	ctx.insert(NullVector{Vector: validVec, Valid: true})
+
+	// Verify NULL
+	readNull := ctx.selectNullVector(1)
+	if readNull.Valid {
+		t.Errorf("Expected NULL, got valid: %v", readNull.Vector)
+	}
+
+	// Verify valid
+	readValid := ctx.selectNullVector(2)
+	if !readValid.Valid {
+		t.Fatal("Expected valid vector, got NULL")
+	}
+	assertVectorEquals(t, readValid.Vector, validVec)
+	t.Logf("Read valid NullVector: %v", readValid.Vector)
+}
+
+// TestVectorDifferentDimensions tests vectors with different dimension counts.
+func TestVectorDifferentDimensions(t *testing.T) {
+	conn, _ := openWithVectorSupport(t)
+	defer conn.Close()
+	skipIfVectorNotSupported(t, conn)
+
+	testCases := []struct {
+		dims   int
+		values []float32
+	}{
+		{1, []float32{42.0}},
+		{5, []float32{1.0, 2.0, 3.0, 4.0, 5.0}},
+		{10, make([]float32, 10)},
+		{100, make([]float32, 100)},
+	}
+
+	// Initialize test vectors with values
+	for i := range testCases {
+		for j := range testCases[i].values {
+			testCases[i].values[j] = float32(j + 1)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%dD", tc.dims), func(t *testing.T) {
+			tx, err := conn.Begin()
+			if err != nil {
+				t.Fatal("Begin transaction failed:", err)
+			}
+			defer tx.Rollback()
+
+			tableName := fmt.Sprintf("#test_vector_%d", tc.dims)
+			_, err = tx.Exec(fmt.Sprintf("CREATE TABLE %s (id INT IDENTITY(1,1) PRIMARY KEY, embedding VECTOR(%d) NOT NULL)", tableName, tc.dims))
+			if err != nil {
+				t.Fatalf("Failed to create table: %v", err)
+			}
+
+			v := mustNewVector(tc.values)
+			_, err = tx.Exec(fmt.Sprintf("INSERT INTO %s (embedding) VALUES (@p1)", tableName), v)
+			if err != nil {
+				t.Fatalf("Failed to insert: %v", err)
+			}
+
+			var got Vector
+			err = tx.QueryRow(fmt.Sprintf("SELECT embedding FROM %s WHERE id = 1", tableName)).Scan(&got)
+			if err != nil {
+				t.Fatalf("Failed to scan: %v", err)
+			}
+
+			if got.Dimensions() != tc.dims {
+				t.Errorf("Expected %d dimensions, got %d", tc.dims, got.Dimensions())
+			}
+		})
+	}
+}
+
+// TestVectorSpecialValues tests vectors with special floating-point values.
+func TestVectorSpecialValues(t *testing.T) {
+	ctx := setupVectorTest(t, 5, false)
+	defer ctx.tx.Rollback()
+
+	// Test special values: zero, negative, small, large
+	v := mustNewVector([]float32{0.0, -1.0, 1e-30, 1e30, -0.0})
+	ctx.insert(v)
+
+	got := ctx.selectVector(1)
+
+	// Verify values (-0.0 should read as 0.0)
+	expected := []float32{0.0, -1.0, 1e-30, 1e30, 0.0}
+	for i, val := range got.Data {
+		if !floatsEqualVector(val, expected[i]) {
+			t.Errorf("Value %d: expected %e, got %e", i, expected[i], val)
+		}
+	}
+	t.Logf("Special values vector: %v", got)
+}
+
+// TestVectorDistance tests using vectors in SQL Server VECTOR_DISTANCE function.
+func TestVectorDistance(t *testing.T) {
+	ctx := setupVectorTestCustom(t, "CREATE TABLE %s (id INT IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(50), embedding VECTOR(3) NOT NULL)")
+	defer ctx.tx.Rollback()
+
+	// Insert test vectors
+	vectors := []struct {
+		name   string
+		values []float32
+	}{
+		{"vec_a", []float32{1.0, 0.0, 0.0}},
+		{"vec_b", []float32{0.0, 1.0, 0.0}},
+		{"vec_c", []float32{0.0, 0.0, 1.0}},
+		{"vec_d", []float32{1.0, 1.0, 1.0}},
+	}
+	for _, v := range vectors {
+		_, err := ctx.tx.Exec(fmt.Sprintf("INSERT INTO %s (name, embedding) VALUES (@p1, @p2)", ctx.tableName), v.name, mustNewVector(v.values))
+		if err != nil {
+			t.Fatalf("Failed to insert %s: %v", v.name, err)
+		}
+	}
+
+	// Query using VECTOR_DISTANCE with native binary vector parameter
+	queryVector := mustNewVector([]float32{1.0, 0.0, 0.0})
+	rows, err := ctx.tx.Query(fmt.Sprintf("SELECT name, VECTOR_DISTANCE('cosine', embedding, @p1) as distance FROM %s ORDER BY distance", ctx.tableName), queryVector)
+	if err != nil {
+		t.Fatalf("Failed to query with VECTOR_DISTANCE: %v", err)
+	}
+	defer rows.Close()
+
+	var results []struct {
+		name     string
+		distance float64
+	}
+	for rows.Next() {
+		var r struct {
+			name     string
+			distance float64
+		}
+		if err := rows.Scan(&r.name, &r.distance); err != nil {
+			t.Fatalf("Failed to scan result: %v", err)
+		}
+		results = append(results, r)
+		t.Logf("Name: %s, Distance: %f", r.name, r.distance)
+	}
+
+	if len(results) != 4 {
+		t.Errorf("Expected 4 results, got %d", len(results))
+	}
+	if results[0].name != "vec_a" || results[0].distance != 0.0 {
+		t.Errorf("Expected vec_a with distance 0, got %s with distance %f", results[0].name, results[0].distance)
+	}
+}
+
+// TestVectorColumnMetadata tests that Vector column metadata is reported correctly.
+func TestVectorColumnMetadata(t *testing.T) {
+	const dimensions = 128
+	ctx := setupVectorTest(t, dimensions, false)
+	defer ctx.tx.Rollback()
+
+	// Insert a vector
+	testData := make([]float32, dimensions)
+	for i := range testData {
+		testData[i] = float32(i)
+	}
+	ctx.insert(mustNewVector(testData))
+
+	// Query and check column types
+	rows, err := ctx.tx.Query(fmt.Sprintf("SELECT id, embedding FROM %s", ctx.tableName))
+	if err != nil {
+		t.Fatalf("Failed to query: %v", err)
+	}
+	defer rows.Close()
+
+	colTypes, err := rows.ColumnTypes()
+	if err != nil {
+		t.Fatalf("Failed to get column types: %v", err)
+	}
+
+	// Check embedding column type
+	embeddingCol := colTypes[1]
+	typeName := embeddingCol.DatabaseTypeName()
+
+	// Verify the column type is correctly reported as VECTOR
+	if typeName != "VECTOR" {
+		t.Errorf("Expected column type VECTOR, got %s", typeName)
+	}
+	t.Logf("Column type: %s", typeName)
+
+	// Verify length is reported correctly (dimensions)
+	if length, ok := embeddingCol.Length(); ok {
+		t.Logf("Column length: %d", length)
+	}
+
+	// Verify we can actually scan the vector data correctly
+	if rows.Next() {
+		var id int
+		var v Vector
+		if err := rows.Scan(&id, &v); err != nil {
+			t.Fatalf("Failed to scan vector: %v", err)
+		}
+		if v.Dimensions() != dimensions {
+			t.Errorf("Expected %d dimensions, got %d", dimensions, v.Dimensions())
+		}
+		t.Logf("Successfully scanned vector with %d dimensions", v.Dimensions())
+	}
+}
+
+// TestVectorLargeDimensions tests vectors near the maximum allowed dimensions.
+func TestVectorLargeDimensions(t *testing.T) {
+	const dimensions = 500
+	ctx := setupVectorTest(t, dimensions, false)
+	defer ctx.tx.Rollback()
+
+	// Create test data
+	testData := make([]float32, dimensions)
+	for i := range testData {
+		testData[i] = float32(i) * 0.001
+	}
+	ctx.insert(mustNewVector(testData))
+
+	got := ctx.selectVector(1)
+	if got.Dimensions() != dimensions {
+		t.Errorf("Expected %d dimensions, got %d", dimensions, got.Dimensions())
+	}
+
+	// Spot check some values
+	for _, i := range []int{0, 100, 250, 499} {
+		if !floatsEqualVector(got.Data[i], testData[i]) {
+			t.Errorf("Value at index %d: expected %f, got %f", i, testData[i], got.Data[i])
+		}
+	}
+	t.Logf("Successfully round-tripped %d-dimensional vector", dimensions)
+}
+
+// TestVectorBatchInsert tests inserting multiple vectors in a transaction.
+func TestVectorBatchInsert(t *testing.T) {
+	ctx := setupVectorTest(t, 3, false)
+	defer ctx.tx.Rollback()
+
+	// Insert multiple vectors
+	const count = 100
+	for i := 0; i < count; i++ {
+		ctx.insert(mustNewVector([]float32{float32(i), float32(i * 2), float32(i * 3)}))
+	}
+
+	// Verify count
+	var actualCount int
+	err := ctx.tx.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", ctx.tableName)).Scan(&actualCount)
+	if err != nil {
+		t.Fatalf("Failed to count rows: %v", err)
+	}
+	if actualCount != count {
+		t.Errorf("Expected %d rows, got %d", count, actualCount)
+	}
+	t.Logf("Batch inserted %d vectors successfully", count)
+}
+
+// TestVectorSliceFloat32Insert tests inserting []float32 directly without wrapping in Vector.
+// This provides better framework compatibility (e.g., GORM) per shueybubbles' feedback.
+func TestVectorSliceFloat32Insert(t *testing.T) {
+	ctx := setupVectorTest(t, 3, false)
+	defer ctx.tx.Rollback()
+
+	// Insert using []float32 directly (not wrapped in Vector type)
+	values := []float32{1.0, 2.0, 3.0}
+	_, err := ctx.tx.Exec(fmt.Sprintf("INSERT INTO %s (embedding) VALUES (@p1)", ctx.tableName), values)
+	if err != nil {
+		t.Fatalf("Failed to insert []float32: %v", err)
+	}
+
+	// Read back using Vector type
+	got := ctx.selectVector(1)
+	for i, val := range values {
+		if got.Data[i] != val {
+			t.Errorf("Value %d: expected %f, got %f", i, val, got.Data[i])
+		}
+	}
+	t.Logf("Successfully round-tripped []float32 -> Vector: %v", got.Data)
+}
+
+// TestVectorSliceFloat64Insert tests inserting []float64 directly.
+// float64 is the default float type in Go, so this is important for convenience.
+func TestVectorSliceFloat64Insert(t *testing.T) {
+	ctx := setupVectorTest(t, 3, false)
+	defer ctx.tx.Rollback()
+
+	// Insert using []float64 directly (Go's default float type)
+	values := []float64{1.5, 2.5, 3.5}
+	_, err := ctx.tx.Exec(fmt.Sprintf("INSERT INTO %s (embedding) VALUES (@p1)", ctx.tableName), values)
+	if err != nil {
+		t.Fatalf("Failed to insert []float64: %v", err)
+	}
+
+	got := ctx.selectVector(1)
+	if got.Dimensions() != len(values) {
+		t.Fatalf("Expected %d dimensions, got %d", len(values), got.Dimensions())
+	}
+
+	for i, val := range values {
+		if !floatsEqualVector(got.Data[i], float32(val)) {
+			t.Errorf("Value %d: expected %f, got %f", i, val, got.Data[i])
+		}
+	}
+	t.Logf("Successfully round-tripped []float64 -> Vector: %v", got.Data)
+}
+
+// TestVectorScanToInterface tests that scanning to interface{} returns []byte.
+// The driver returns raw binary vector data; applications should scan to Vector
+// or NullVector types for decoded values.
+func TestVectorScanToInterface(t *testing.T) {
+	ctx := setupVectorTest(t, 3, false)
+	defer ctx.tx.Rollback()
+
+	ctx.insert(mustNewVector([]float32{1.0, 2.0, 3.0}))
+
+	// Scan to interface{} - returns []byte (raw binary) when native vector format is supported
+	var result interface{}
+	err := ctx.tx.QueryRow(fmt.Sprintf("SELECT embedding FROM %s WHERE id = 1", ctx.tableName)).Scan(&result)
+	if err != nil {
+		t.Fatalf("Failed to scan to interface{}: %v", err)
+	}
+
+	// Verify we got []byte (native binary format) or string (JSON fallback)
+	switch v := result.(type) {
+	case []byte:
+		// Native binary format - verify we can decode it
+		var decoded Vector
+		if err := decoded.Scan(v); err != nil {
+			t.Fatalf("Failed to decode []byte to Vector: %v", err)
+		}
+		if decoded.Dimensions() != 3 {
+			t.Fatalf("Expected 3 dimensions, got %d", decoded.Dimensions())
+		}
+		expected := []float32{1.0, 2.0, 3.0}
+		for i, val := range expected {
+			if decoded.Data[i] != val {
+				t.Errorf("Value %d: expected %f, got %f", i, val, decoded.Data[i])
+			}
+		}
+		t.Logf("Scan to interface{} returned []byte (native binary), decoded: %v", decoded.Data)
+	case string:
+		// JSON fallback - server doesn't support native vector binary format
+		// This happens when the TDS vector feature extension is not negotiated
+		t.Logf("Scan to interface{} returned string (JSON fallback): %s", v)
+		// Parse JSON to verify it's valid vector data
+		if !strings.HasPrefix(v, "[") || !strings.HasSuffix(v, "]") {
+			t.Fatalf("Expected JSON array, got: %s", v)
+		}
+		t.Skip("Server does not support native vector binary format - JSON fallback used")
+	default:
+		t.Fatalf("Expected []byte or string, got %T", result)
+	}
+}
+
+// TestVectorFloat16 tests float16 vector support (preview feature).
+// This test requires SQL Server 2025+ with PREVIEW_FEATURES enabled.
+func TestVectorFloat16(t *testing.T) {
+	conn, _ := openWithVectorSupport(t)
+	defer conn.Close()
+	skipIfVectorNotSupported(t, conn)
+
+	// Determine which database to use for PREVIEW_FEATURES
+	// If we created a test database, use that; otherwise use the current database
+	var targetDB string
+	if vectorTestDBCreated && vectorTestDBName != "" {
+		targetDB = vectorTestDBName
+	} else {
+		// Get the current database name from the connection string config
+		err := conn.QueryRow("SELECT DB_NAME()").Scan(&targetDB)
+		if err != nil {
+			t.Fatalf("Failed to get current database: %v", err)
+		}
+	}
+
+	// Check if it's a system database - we can't enable PREVIEW_FEATURES on system databases
+	systemDBs := []string{"master", "tempdb", "msdb", "model"}
+	for _, sysDB := range systemDBs {
+		if strings.EqualFold(targetDB, sysDB) {
+			t.Skipf("Cannot enable PREVIEW_FEATURES on system database '%s'. Connect to a user database to test float16.", targetDB)
+		}
+	}
+
+	// Use a dedicated connection to ensure consistent database context
+	ctx := context.Background()
+	singleConn, err := conn.Conn(ctx)
+	if err != nil {
+		t.Skipf("Skipping: unable to connect to database: %v", err)
+	}
+	defer singleConn.Close()
+
+	// Switch to the target database on this specific connection
+	_, err = singleConn.ExecContext(ctx, fmt.Sprintf("USE [%s]", targetDB))
+	if err != nil {
+		t.Fatalf("Could not switch to database %s: %v", targetDB, err)
+	}
+
+	// Track original PREVIEW_FEATURES state so we can restore it later.
+	var previewWasOn bool
+	var previewToggled bool
+
+	// Query the current PREVIEW_FEATURES configuration.
+	// value is stored as sql_variant, we query its string representation.
+	var configValue string
+	err = singleConn.QueryRowContext(ctx,
+		"SELECT CAST(value AS NVARCHAR(10)) FROM sys.database_scoped_configurations WHERE name = 'PREVIEW_FEATURES'").Scan(&configValue)
+	if err != nil {
+		// PREVIEW_FEATURES config may not exist on older servers
+		t.Skipf("Could not query PREVIEW_FEATURES state (may not be supported): %v", err)
+	}
+	previewWasOn = configValue == "1"
+
+	// Enable preview features for float16 support if not already enabled.
+	// This must be run while in the target database context.
+	if !previewWasOn {
+		_, err = singleConn.ExecContext(ctx, "ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON")
+		if err != nil {
+			t.Skipf("Could not enable PREVIEW_FEATURES (may not be supported): %v", err)
+		}
+		previewToggled = true
+	}
+
+	// Ensure we restore PREVIEW_FEATURES to its original state when done.
+	defer func() {
+		if !previewToggled {
+			// We did not change the configuration; nothing to restore.
+			return
+		}
+		_, err := singleConn.ExecContext(ctx, "ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = OFF")
+		if err != nil {
+			t.Logf("Warning: Could not restore PREVIEW_FEATURES to OFF: %v", err)
+		}
+	}()
+
+	// Begin transaction on this connection to keep temp table visible
+	tx, err := singleConn.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal("Begin transaction failed:", err)
+	}
+	defer tx.Rollback()
+
+	// Create test table with float16 vector column
+	tableName := "#test_vector_float16"
+	_, err = tx.Exec(fmt.Sprintf(`
+		CREATE TABLE %s (
+			id INT IDENTITY(1,1) PRIMARY KEY,
+			embedding VECTOR(3, float16) NOT NULL
+		)
+	`, tableName))
+	if err != nil {
+		// VECTOR type requires SQL Server 2025+, float16 requires PREVIEW_FEATURES
+		t.Skipf("Could not create float16 VECTOR column (requires SQL Server 2025+ with PREVIEW_FEATURES): %v", err)
+	}
+
+	// Insert a float16 vector using NewVectorWithType
+	v, err := NewVectorWithType(VectorElementFloat16, []float32{1.0, 2.0, 3.0})
+	if err != nil {
+		t.Fatalf("Failed to create float16 vector: %v", err)
+	}
+	_, err = tx.Exec(
+		fmt.Sprintf("INSERT INTO %s (embedding) VALUES (@p1)", tableName),
+		v,
+	)
+	if err != nil {
+		// Float16 native binary parameters may not be supported yet in current SQL Server build
+		// SQL Server 2025 RTM supports float16 columns but native float16 parameters require additional support
+		if strings.Contains(err.Error(), "invalid precision or scale") ||
+			strings.Contains(err.Error(), "Conversion of vector") {
+			t.Skipf("Float16 native binary parameters not supported in this SQL Server build: %v", err)
+		}
+		t.Fatalf("Failed to insert float16 vector: %v", err)
+	}
+
+	// Read back the vector
+	var readVector Vector
+	err = tx.QueryRow(
+		fmt.Sprintf("SELECT embedding FROM %s WHERE id = 1", tableName),
+	).Scan(&readVector)
+	if err != nil {
+		t.Fatalf("Failed to scan float16 vector: %v", err)
+	}
+
+	// Verify dimensions
+	if readVector.Dimensions() != 3 {
+		t.Errorf("Expected 3 dimensions, got %d", readVector.Dimensions())
+	}
+
+	// Verify values (float16 has less precision, so use tolerance)
+	expected := []float32{1.0, 2.0, 3.0}
+	for i, val := range readVector.Data {
+		if !floatsEqualVector(val, expected[i]) {
+			t.Errorf("Dimension %d: expected %f, got %f", i, expected[i], val)
+		}
+	}
+
+	t.Logf("Successfully round-tripped float16 vector: %v", readVector)
+
+	// Test with values that show float16 precision loss
+	// Must use NewVectorWithType to create a float16 vector - SQL Server won't convert float32 to float16
+	precisionTestValues := []float32{1.001, 2.002, 3.003}
+	v2, err := NewVectorWithType(VectorElementFloat16, precisionTestValues)
+	if err != nil {
+		t.Fatalf("Failed to create float16 precision test vector: %v", err)
+	}
+	_, err = tx.Exec(
+		fmt.Sprintf("INSERT INTO %s (embedding) VALUES (@p1)", tableName),
+		v2,
+	)
+	if err != nil {
+		t.Fatalf("Failed to insert precision test vector: %v", err)
+	}
+
+	var readVector2 Vector
+	err = tx.QueryRow(
+		fmt.Sprintf("SELECT embedding FROM %s WHERE id = 2", tableName),
+	).Scan(&readVector2)
+	if err != nil {
+		t.Fatalf("Failed to scan precision test vector: %v", err)
+	}
+
+	// IEEE 754 float16 has a 10-bit significand (~3 decimal digits of precision).
+	// The ULP near 1.0 is 2^-10 ≈ 9.8e-4, so for values in the 1–3 range we expect
+	// absolute conversion error to be on the order of a few 1e-3. We therefore use
+	// a conservative 0.01 absolute tolerance here to allow for implementation-
+	// specific details while still catching excessive precision loss.
+	t.Logf("Precision test - input: %v, output: %v", precisionTestValues, readVector2.Data)
+	for i, val := range readVector2.Data {
+		diff := math.Abs(float64(val - precisionTestValues[i]))
+		if diff > 0.01 {
+			t.Errorf("Dimension %d: precision loss too high, expected ~%f, got %f (diff: %f)",
+				i, precisionTestValues[i], val, diff)
+		}
+	}
+}
+
+// floatsEqualVector compares two float32 values with tolerance for vector tests.
+func floatsEqualVector(a, b float32) bool {
+	if math.IsNaN(float64(a)) && math.IsNaN(float64(b)) {
+		return true
+	}
+	if math.IsInf(float64(a), 1) && math.IsInf(float64(b), 1) {
+		return true
+	}
+	if math.IsInf(float64(a), -1) && math.IsInf(float64(b), -1) {
+		return true
+	}
+	diff := math.Abs(float64(a - b))
+	return diff < 1e-6 || diff < math.Abs(float64(a))*1e-6
+}

--- a/vector_db_test.go
+++ b/vector_db_test.go
@@ -222,15 +222,13 @@ func setupVectorTestCustom(t *testing.T, createSQL string) *vectorTestContext {
 	return &vectorTestContext{t: t, conn: conn, tx: tx, tableName: tableName}
 }
 
-// insert inserts a vector and returns the generated ID.
-func (ctx *vectorTestContext) insert(v interface{}) int64 {
+// insert inserts a vector.
+func (ctx *vectorTestContext) insert(v interface{}) {
 	ctx.t.Helper()
-	result, err := ctx.tx.Exec(fmt.Sprintf("INSERT INTO %s (embedding) VALUES (@p1)", ctx.tableName), v)
+	_, err := ctx.tx.Exec(fmt.Sprintf("INSERT INTO %s (embedding) VALUES (@p1)", ctx.tableName), v)
 	if err != nil {
 		ctx.t.Fatalf("Failed to insert: %v", err)
 	}
-	id, _ := result.LastInsertId()
-	return id
 }
 
 // selectVector reads a vector by ID.

--- a/vector_db_test.go
+++ b/vector_db_test.go
@@ -540,6 +540,29 @@ func TestVectorBulkCopy(t *testing.T) {
 	}
 }
 
+func TestVectorBulkCopyJSONFallback(t *testing.T) {
+	ctx := setupVectorTestWithSupport(t, 3, false, msdsn.VectorTypeSupportOff)
+
+	stmt, err := ctx.tx.Prepare(CopyIn(ctx.tableName, BulkOptions{}, "embedding"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+
+	if _, err := stmt.Exec([]float32{1, 2, 3}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stmt.Exec(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := ctx.selectVector(1)
+	assertVectorEquals(t, got, Vector{
+		ElementType: VectorElementFloat32,
+		Data:        []float32{1, 2, 3},
+	})
+}
+
 // TestVectorSliceFloat32Insert tests inserting []float32 directly without wrapping in Vector.
 // This provides better framework compatibility (e.g., GORM) per shueybubbles' feedback.
 func TestVectorSliceFloat32Insert(t *testing.T) {

--- a/vector_db_test.go
+++ b/vector_db_test.go
@@ -143,9 +143,7 @@ func mustNewVector(values []float32) Vector {
 	return v
 }
 
-// openWithVectorSupport opens a database connection with vectortypesupport=v1 enabled.
-// This enables native binary vector format when the server supports it (SQL Server 2025+).
-func openWithVectorSupport(t testing.TB) (*sql.DB, *testLogger) {
+func openWithVectorTypeSupport(t testing.TB, vectorTypeSupport msdsn.VectorTypeSupport) (*sql.DB, *testLogger) {
 	tl := testLogger{t: t}
 	SetLogger(&tl)
 	t.Cleanup(func() {
@@ -153,7 +151,7 @@ func openWithVectorSupport(t testing.TB) (*sql.DB, *testLogger) {
 	})
 
 	config := testConnParams(t)
-	config.VectorTypeSupport = msdsn.VectorTypeSupportV1
+	config.VectorTypeSupport = vectorTypeSupport
 	connectionString := config.URL().String()
 
 	connector, err := NewConnector(connectionString)
@@ -162,6 +160,12 @@ func openWithVectorSupport(t testing.TB) (*sql.DB, *testLogger) {
 	}
 	conn := sql.OpenDB(connector)
 	return conn, &tl
+}
+
+// openWithVectorSupport opens a database connection with vectortypesupport=v1 enabled.
+// This enables native binary vector format when the server supports it (SQL Server 2025+).
+func openWithVectorSupport(t testing.TB) (*sql.DB, *testLogger) {
+	return openWithVectorTypeSupport(t, msdsn.VectorTypeSupportV1)
 }
 
 // vectorTestContext holds common test infrastructure for vector database tests.
@@ -176,8 +180,12 @@ type vectorTestContext struct {
 // The table has a single VECTOR column with the specified dimensions.
 // Use nullable=true for columns that should allow NULL values.
 func setupVectorTest(t *testing.T, dims int, nullable bool) *vectorTestContext {
+	return setupVectorTestWithSupport(t, dims, nullable, msdsn.VectorTypeSupportV1)
+}
+
+func setupVectorTestWithSupport(t *testing.T, dims int, nullable bool, vectorTypeSupport msdsn.VectorTypeSupport) *vectorTestContext {
 	t.Helper()
-	conn, _ := openWithVectorSupport(t)
+	conn, _ := openWithVectorTypeSupport(t, vectorTypeSupport)
 	t.Cleanup(func() { conn.Close() })
 	skipIfVectorNotSupported(t, conn)
 
@@ -587,6 +595,37 @@ func TestVectorSliceFloat64Insert(t *testing.T) {
 		}
 	}
 	t.Logf("Successfully round-tripped []float64 -> Vector: %v", got.Data)
+}
+
+func TestVectorJSONFallbackRoundTrip(t *testing.T) {
+	ctx := setupVectorTestWithSupport(t, 3, false, msdsn.VectorTypeSupportOff)
+
+	inputs := []struct {
+		value interface{}
+		want  []float32
+	}{
+		{mustNewVector([]float32{1, 2, 3}), []float32{1, 2, 3}},
+		{[]float32{4, 5, 6}, []float32{4, 5, 6}},
+		{[]float64{7.5, 8.5, 9.5}, []float32{7.5, 8.5, 9.5}},
+	}
+
+	for _, input := range inputs {
+		ctx.insert(input.value)
+	}
+
+	var raw interface{}
+	err := ctx.tx.QueryRow(fmt.Sprintf("SELECT embedding FROM %s WHERE id = 1", ctx.tableName)).Scan(&raw)
+	if err != nil {
+		t.Fatal("Failed to scan JSON fallback value:", err)
+	}
+	if _, ok := raw.(string); !ok {
+		t.Fatalf("Expected JSON fallback string, got %T", raw)
+	}
+
+	for i, input := range inputs {
+		got := ctx.selectVector(i + 1)
+		assertVectorEquals(t, got, Vector{ElementType: VectorElementFloat32, Data: input.want})
+	}
 }
 
 // TestVectorScanToInterface tests that scanning to interface{} returns []byte.

--- a/vector_db_test.go
+++ b/vector_db_test.go
@@ -6,84 +6,10 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/microsoft/go-mssqldb/msdsn"
 )
-
-// vectorTestDB holds the shared test database state for vector tests.
-// If we're connected to a system database, we create a user database for testing.
-var (
-	vectorTestDBOnce    sync.Once
-	vectorTestDBName    string
-	vectorTestDBCreated bool
-)
-
-// setupVectorTestDB ensures we're using a user database for vector tests.
-// System databases (master, tempdb, msdb, model) don't support PREVIEW_FEATURES.
-// Database cleanup is handled by drop-before-create logic at the start of each test run.
-func setupVectorTestDB(t *testing.T, conn *sql.DB) {
-	t.Helper()
-
-	vectorTestDBOnce.Do(func() {
-		// Check current database
-		var currentDB string
-		err := conn.QueryRow("SELECT DB_NAME()").Scan(&currentDB)
-		if err != nil {
-			t.Logf("Warning: Could not get current database: %v", err)
-			return
-		}
-
-		// Check if it's a system database
-		systemDBs := []string{"master", "tempdb", "msdb", "model"}
-		isSystemDB := false
-		for _, sysDB := range systemDBs {
-			if strings.EqualFold(currentDB, sysDB) {
-				isSystemDB = true
-				break
-			}
-		}
-
-		if !isSystemDB {
-			// Already in a user database, no need to create one
-			t.Logf("Using existing user database: %s", currentDB)
-			return
-		}
-
-		// We need to use a test database
-		// Use a fixed, clearly prefixed name to avoid accumulating test databases
-		// The prefix makes it obviously a test database
-		vectorTestDBName = "go_mssqldb_vector_test"
-		t.Logf("Connected to system database '%s', will use test database '%s'", currentDB, vectorTestDBName)
-
-		// Drop any existing test database from previous runs, then create fresh.
-		// This is best-effort: if the test login lacks permissions, we skip database
-		// creation and float16 tests will be skipped when they need PREVIEW_FEATURES.
-		if _, err := conn.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS [%s]", vectorTestDBName)); err != nil {
-			t.Logf("Warning: Could not drop test database (may lack permissions): %v", err)
-			return
-		}
-
-		// Create the test database
-		_, err = conn.Exec(fmt.Sprintf("CREATE DATABASE [%s]", vectorTestDBName))
-		if err != nil {
-			t.Logf("Warning: Could not create test database (may lack permissions): %v", err)
-			return
-		}
-		t.Logf("Created test database '%s'", vectorTestDBName)
-		vectorTestDBCreated = true
-		// Note: We don't use t.Cleanup() here because sync.Once ties it to the first
-		// test that runs, which would try to drop the database while other tests are
-		// still using it. Instead, we rely on drop-before-create at the start of each
-		// test run to clean up any leftover databases from previous runs.
-	})
-
-	// Note: We don't attempt to USE the test database here because USE is session-scoped
-	// and *sql.DB may pick different connections per call. The tests create their own
-	// tables in the current database context, which is sufficient for isolation.
-	// The test database creation above is primarily for cleanup between test runs.
-}
 
 // skipIfVectorNotSupported checks if the SQL Server instance supports VECTOR type.
 // VECTOR is only supported in SQL Server 2025+. If not supported, the test is skipped.
@@ -129,9 +55,6 @@ func skipIfVectorNotSupported(t *testing.T, conn *sql.DB) {
 	// Clean up the check table on the same connection where it was created
 	singleConn.ExecContext(ctx, "DROP TABLE #vector_check")
 
-	// Now that we know VECTOR is supported, ensure we're in a user database
-	// for tests that need PREVIEW_FEATURES (float16 tests).
-	setupVectorTestDB(t, conn)
 }
 
 // mustNewVector is a test helper that creates a Vector and panics on error.
@@ -151,7 +74,15 @@ func openWithVectorTypeSupport(t testing.TB, vectorTypeSupport msdsn.VectorTypeS
 	})
 
 	config := testConnParams(t)
-	config.VectorTypeSupport = vectorTypeSupport
+	if config.Parameters == nil {
+		config.Parameters = make(map[string]string)
+	}
+	switch vectorTypeSupport {
+	case msdsn.VectorTypeSupportV1:
+		config.Parameters[msdsn.VectorTypeSupportParam] = "v1"
+	default:
+		config.Parameters[msdsn.VectorTypeSupportParam] = "off"
+	}
 	connectionString := config.URL().String()
 
 	connector, err := NewConnector(connectionString)
@@ -437,7 +368,7 @@ func TestVectorDistance(t *testing.T) {
 	}
 
 	if len(results) != 4 {
-		t.Errorf("Expected 4 results, got %d", len(results))
+		t.Fatalf("Expected 4 results, got %d", len(results))
 	}
 	if results[0].name != "vec_a" || results[0].distance != 0.0 {
 		t.Errorf("Expected vec_a with distance 0, got %s with distance %f", results[0].name, results[0].distance)
@@ -480,8 +411,8 @@ func TestVectorColumnMetadata(t *testing.T) {
 	t.Logf("Column type: %s", typeName)
 
 	// Verify length is reported correctly (dimensions)
-	if length, ok := embeddingCol.Length(); ok {
-		t.Logf("Column length: %d", length)
+	if length, ok := embeddingCol.Length(); !ok || length != dimensions {
+		t.Errorf("Column length = %d, %t; want %d, true", length, ok, dimensions)
 	}
 
 	// Verify we can actually scan the vector data correctly
@@ -546,6 +477,67 @@ func TestVectorBatchInsert(t *testing.T) {
 		t.Errorf("Expected %d rows, got %d", count, actualCount)
 	}
 	t.Logf("Batch inserted %d vectors successfully", count)
+}
+
+func TestVectorBulkCopy(t *testing.T) {
+	ctx := setupVectorTest(t, 3, true)
+
+	stmt, err := ctx.tx.Prepare(CopyIn(ctx.tableName, BulkOptions{}, "embedding"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+
+	for _, value := range []interface{}{
+		mustNewVector([]float32{1, 2, 3}),
+		NullVector{Valid: false},
+	} {
+		if _, err := stmt.Exec(value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := stmt.Exec(); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := ctx.tx.Query(fmt.Sprintf("SELECT embedding FROM %s ORDER BY id", ctx.tableName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		t.Fatal("missing vector row")
+	}
+	var vector Vector
+	if err := rows.Scan(&vector); err != nil {
+		t.Fatal(err)
+	}
+	if len(vector.Data) != 3 {
+		t.Fatalf("bulk vector dimensions = %d; want 3", len(vector.Data))
+	}
+	if !floatsEqualVector(vector.Data[0], 1) ||
+		!floatsEqualVector(vector.Data[1], 2) ||
+		!floatsEqualVector(vector.Data[2], 3) {
+		t.Fatalf("bulk vector = %v; want [1 2 3]", vector.Data)
+	}
+
+	if !rows.Next() {
+		t.Fatal("missing NULL row")
+	}
+	var nullVector NullVector
+	if err := rows.Scan(&nullVector); err != nil {
+		t.Fatal(err)
+	}
+	if nullVector.Valid {
+		t.Fatal("bulk NULL vector scanned as valid")
+	}
+	if rows.Next() {
+		t.Fatal("unexpected extra row")
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestVectorSliceFloat32Insert tests inserting []float32 directly without wrapping in Vector.
@@ -683,17 +675,10 @@ func TestVectorFloat16(t *testing.T) {
 	defer conn.Close()
 	skipIfVectorNotSupported(t, conn)
 
-	// Determine which database to use for PREVIEW_FEATURES
-	// If we created a test database, use that; otherwise use the current database
 	var targetDB string
-	if vectorTestDBCreated && vectorTestDBName != "" {
-		targetDB = vectorTestDBName
-	} else {
-		// Get the current database name from the connection string config
-		err := conn.QueryRow("SELECT DB_NAME()").Scan(&targetDB)
-		if err != nil {
-			t.Fatalf("Failed to get current database: %v", err)
-		}
+	err := conn.QueryRow("SELECT DB_NAME()").Scan(&targetDB)
+	if err != nil {
+		t.Fatalf("Failed to get current database: %v", err)
 	}
 
 	// Check if it's a system database - we can't enable PREVIEW_FEATURES on system databases

--- a/vector_test.go
+++ b/vector_test.go
@@ -1,0 +1,1134 @@
+package mssql
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVectorElementTypeString(t *testing.T) {
+	testCases := []struct {
+		elementType VectorElementType
+		expected    string
+	}{
+		{VectorElementFloat32, "FLOAT32"},
+		{VectorElementFloat16, "FLOAT16"},
+		{VectorElementType(0xFF), "UNKNOWN(0xFF)"},
+	}
+
+	for _, tc := range testCases {
+		result := tc.elementType.String()
+		assert.Equal(t, tc.expected, result, "String() for 0x%02X", tc.elementType)
+	}
+}
+
+func TestVectorElementTypeBytesPerElement(t *testing.T) {
+	assert.Equal(t, 4, VectorElementFloat32.BytesPerElement(), "Float32 bytes")
+	assert.Equal(t, 2, VectorElementFloat16.BytesPerElement(), "Float16 bytes")
+}
+
+func TestVectorElementTypeIsValid(t *testing.T) {
+	assert.True(t, VectorElementFloat32.IsValid(), "Float32 should be valid")
+	assert.True(t, VectorElementFloat16.IsValid(), "Float16 should be valid")
+	assert.False(t, VectorElementType(0x99).IsValid(), "Unknown type 0x99 should be invalid")
+}
+
+func TestVectorElementTypeMaxDimensions(t *testing.T) {
+	assert.Equal(t, 1998, VectorElementFloat32.MaxDimensions(), "Float32 max dims")
+	assert.Equal(t, 3996, VectorElementFloat16.MaxDimensions(), "Float16 max dims")
+}
+
+func TestVectorEncodeDecode(t *testing.T) {
+	testCases := []struct {
+		name   string
+		vector Vector
+	}{
+		{
+			name:   "empty vector",
+			vector: Vector{ElementType: VectorElementFloat32, Data: []float32{}},
+		},
+		{
+			name:   "single element",
+			vector: Vector{ElementType: VectorElementFloat32, Data: []float32{1.0}},
+		},
+		{
+			name:   "three elements",
+			vector: Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0, 3.0}},
+		},
+		{
+			name:   "negative values",
+			vector: Vector{ElementType: VectorElementFloat32, Data: []float32{-1.0, -2.5, 3.75}},
+		},
+		{
+			name:   "small values",
+			vector: Vector{ElementType: VectorElementFloat32, Data: []float32{0.001, 0.002, 0.003}},
+		},
+		{
+			name:   "large values",
+			vector: Vector{ElementType: VectorElementFloat32, Data: []float32{1000000.0, 2000000.0, 3000000.0}},
+		},
+		{
+			name:   "mixed values",
+			vector: Vector{ElementType: VectorElementFloat32, Data: []float32{0.0, -0.5, 1.5, 100.0, -100.0}},
+		},
+		{
+			name:   "special values",
+			vector: Vector{ElementType: VectorElementFloat32, Data: []float32{float32(math.Inf(1)), float32(math.Inf(-1)), float32(math.NaN())}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Encode
+			encoded, err := tc.vector.encodeToBytes()
+			if err != nil {
+				t.Fatalf("encodeToBytes failed: %v", err)
+			}
+
+			// Decode
+			var decoded Vector
+			err = decoded.decodeFromBytes(encoded)
+			if err != nil {
+				t.Fatalf("decodeFromBytes failed: %v", err)
+			}
+
+			// Compare element type
+			if decoded.ElementType != tc.vector.ElementType {
+				t.Fatalf("element type mismatch: got %v, want %v", decoded.ElementType, tc.vector.ElementType)
+			}
+
+			// Compare dimensions
+			if len(decoded.Data) != len(tc.vector.Data) {
+				t.Fatalf("length mismatch: got %d, want %d", len(decoded.Data), len(tc.vector.Data))
+			}
+
+			for i := range tc.vector.Data {
+				// Handle NaN specially
+				if math.IsNaN(float64(tc.vector.Data[i])) {
+					if !math.IsNaN(float64(decoded.Data[i])) {
+						t.Errorf("index %d: expected NaN, got %v", i, decoded.Data[i])
+					}
+				} else if decoded.Data[i] != tc.vector.Data[i] {
+					t.Errorf("index %d: got %v, want %v", i, decoded.Data[i], tc.vector.Data[i])
+				}
+			}
+		})
+	}
+}
+
+func TestVectorFloat16EncodeDecode(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []float32
+		expected []float32 // Expected after round-trip (may differ due to precision)
+	}{
+		{
+			name:     "simple values",
+			input:    []float32{1.0, 2.0, -2.0, 0.5},
+			expected: []float32{1.0, 2.0, -2.0, 0.5},
+		},
+		{
+			name:     "zero values",
+			input:    []float32{0.0},
+			expected: []float32{0.0},
+		},
+		{
+			name:     "infinity",
+			input:    []float32{float32(math.Inf(1)), float32(math.Inf(-1))},
+			expected: []float32{float32(math.Inf(1)), float32(math.Inf(-1))},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := Vector{ElementType: VectorElementFloat16, Data: tc.input}
+
+			// Encode
+			encoded, err := v.encodeToBytes()
+			if err != nil {
+				t.Fatalf("encodeToBytes failed: %v", err)
+			}
+
+			// Verify header shows float16
+			if encoded[4] != byte(VectorElementFloat16) {
+				t.Errorf("element type byte: got 0x%02X, want 0x%02X", encoded[4], VectorElementFloat16)
+			}
+
+			// Decode
+			var decoded Vector
+			err = decoded.decodeFromBytes(encoded)
+			if err != nil {
+				t.Fatalf("decodeFromBytes failed: %v", err)
+			}
+
+			if decoded.ElementType != VectorElementFloat16 {
+				t.Fatalf("element type mismatch: got %v, want float16", decoded.ElementType)
+			}
+
+			if len(decoded.Data) != len(tc.expected) {
+				t.Fatalf("length mismatch: got %d, want %d", len(decoded.Data), len(tc.expected))
+			}
+
+			for i := range tc.expected {
+				if math.IsNaN(float64(tc.expected[i])) {
+					if !math.IsNaN(float64(decoded.Data[i])) {
+						t.Errorf("index %d: expected NaN, got %v", i, decoded.Data[i])
+					}
+				} else if math.IsInf(float64(tc.expected[i]), 0) {
+					if decoded.Data[i] != tc.expected[i] {
+						t.Errorf("index %d: got %v, want %v", i, decoded.Data[i], tc.expected[i])
+					}
+				} else if decoded.Data[i] != tc.expected[i] {
+					t.Errorf("index %d: got %v, want %v", i, decoded.Data[i], tc.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFloat32ToFloat16Conversion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    float32
+		expected uint16
+	}{
+		{"positive 1.0", 1.0, 0x3C00},
+		{"negative 2.0", -2.0, 0xC000},
+		{"half 0.5", 0.5, 0x3800},
+		{"zero", 0.0, 0x0000},
+		{"positive infinity", float32(math.Inf(1)), 0x7C00},
+		{"negative infinity", float32(math.Inf(-1)), 0xFC00},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := float32ToFloat16(tc.input)
+			if result != tc.expected {
+				t.Errorf("float32ToFloat16(%v): got 0x%04X, want 0x%04X", tc.input, result, tc.expected)
+			}
+		})
+	}
+
+	// Test NaN separately - IEEE 754 allows multiple valid NaN representations.
+	// Any value with exponent=0x1F (all ones) and non-zero fraction is a valid NaN.
+	// Positive NaN: 0x7C01-0x7FFF, Negative NaN: 0xFC01-0xFFFF
+	nanResult := float32ToFloat16(float32(math.NaN()))
+	// Use float16InfBits (0x7C00) as exponent mask and float16MantissaMask (0x03FF) for fraction
+	if (nanResult&float16InfBits) != float16InfBits || (nanResult&float16MantissaMask) == 0 {
+		t.Errorf("float32ToFloat16(NaN): got 0x%04X, want any NaN (exp=0x1F, non-zero fraction)", nanResult)
+	}
+}
+
+func TestFloat16ToFloat32Conversion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    uint16
+		expected float32
+	}{
+		{"positive 1.0", 0x3C00, 1.0},
+		{"negative 2.0", 0xC000, -2.0},
+		{"half 0.5", 0x3800, 0.5},
+		{"zero", 0x0000, 0.0},
+		{"positive infinity", 0x7C00, float32(math.Inf(1))},
+		{"negative infinity", 0xFC00, float32(math.Inf(-1))},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := float16ToFloat32(tc.input)
+			if result != tc.expected {
+				t.Errorf("float16ToFloat32(0x%04X): got %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+
+	// Test NaN separately
+	nanResult := float16ToFloat32(0x7E00)
+	if !math.IsNaN(float64(nanResult)) {
+		t.Errorf("float16ToFloat32(0x7E00): got %v, want NaN", nanResult)
+	}
+}
+
+func TestVectorHeader(t *testing.T) {
+	v := Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0, 3.0}}
+	encoded, err := v.encodeToBytes()
+	if err != nil {
+		t.Fatalf("encodeToBytes failed: %v", err)
+	}
+
+	// Check header
+	if encoded[0] != vectorMagic {
+		t.Errorf("magic byte: got 0x%02X, want 0x%02X", encoded[0], vectorMagic)
+	}
+	if encoded[1] != vectorVersion {
+		t.Errorf("version byte: got 0x%02X, want 0x%02X", encoded[1], vectorVersion)
+	}
+
+	dimensions := binary.LittleEndian.Uint16(encoded[2:4])
+	if dimensions != 3 {
+		t.Errorf("dimensions: got %d, want 3", dimensions)
+	}
+
+	if encoded[4] != byte(VectorElementFloat32) {
+		t.Errorf("element type: got 0x%02X, want 0x%02X", encoded[4], VectorElementFloat32)
+	}
+
+	// Reserved bytes should be zero
+	if encoded[5] != 0 || encoded[6] != 0 || encoded[7] != 0 {
+		t.Errorf("reserved bytes should be zero: got 0x%02X 0x%02X 0x%02X", encoded[5], encoded[6], encoded[7])
+	}
+
+	// Check total size
+	expectedSize := vectorHeaderSize + 3*4 // 8 + 12 = 20 bytes
+	if len(encoded) != expectedSize {
+		t.Errorf("total size: got %d, want %d", len(encoded), expectedSize)
+	}
+}
+
+func TestVectorDecodeInvalidData(t *testing.T) {
+	testCases := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "too short for header",
+			data: []byte{0xA9, 0x01, 0x03, 0x00},
+		},
+		{
+			name: "wrong magic byte",
+			data: []byte{0xAA, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		},
+		{
+			name: "wrong version",
+			data: []byte{0xA9, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		},
+		{
+			name: "unsupported element type",
+			data: []byte{0xA9, 0x01, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, // type 0x02 is not supported
+		},
+		{
+			name: "data too short for float32 dimensions",
+			data: []byte{0xA9, 0x01, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, // says 3 dims but only 1 value
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v Vector
+			err := v.decodeFromBytes(tc.data)
+			if err == nil {
+				t.Error("expected error but got nil")
+			}
+		})
+	}
+}
+
+func TestVectorNil(t *testing.T) {
+	v := Vector{Data: nil}
+
+	encoded, err := v.encodeToBytes()
+	if err != nil {
+		t.Fatalf("encodeToBytes failed: %v", err)
+	}
+	if encoded != nil {
+		t.Errorf("nil data vector should encode to nil, got %v", encoded)
+	}
+
+	var decoded Vector
+	err = decoded.decodeFromBytes(nil)
+	if err != nil {
+		t.Fatalf("decodeFromBytes(nil) failed: %v", err)
+	}
+	if decoded.Data != nil {
+		t.Errorf("decoded nil should have nil Data, got %v", decoded.Data)
+	}
+
+	// Empty (non-nil) buffer should return an error (truncated/corrupt data)
+	err = decoded.decodeFromBytes([]byte{})
+	if err == nil {
+		t.Fatal("decodeFromBytes([]) should fail for empty non-nil buffer")
+	}
+}
+
+func TestVectorIsNull(t *testing.T) {
+	v := Vector{}
+	if !v.IsNull() {
+		t.Error("empty Vector should be null")
+	}
+
+	v = Vector{Data: nil}
+	if !v.IsNull() {
+		t.Error("Vector with nil Data should be null")
+	}
+
+	v = Vector{ElementType: VectorElementFloat32, Data: []float32{1.0}}
+	if v.IsNull() {
+		t.Error("Vector with data should not be null")
+	}
+}
+
+func TestVectorValue(t *testing.T) {
+	v := Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0, 3.0}}
+
+	val, err := v.Value()
+	if err != nil {
+		t.Fatalf("Value() failed: %v", err)
+	}
+
+	// Value() returns a JSON string for SQL Server parameter binding
+	jsonStr, ok := val.(string)
+	if !ok {
+		t.Fatalf("Value() should return string, got %T", val)
+	}
+
+	expectedJSON := "[1, 2, 3]"
+	if jsonStr != expectedJSON {
+		t.Errorf("Value() returned %q, expected %q", jsonStr, expectedJSON)
+	}
+
+	// Test that the JSON can be decoded back to a Vector
+	var decoded Vector
+	err = decoded.decodeFromJSON(jsonStr)
+	if err != nil {
+		t.Fatalf("decodeFromJSON failed: %v", err)
+	}
+
+	if len(decoded.Data) != len(v.Data) {
+		t.Fatalf("length mismatch: got %d, want %d", len(decoded.Data), len(v.Data))
+	}
+
+	for i := range v.Data {
+		if decoded.Data[i] != v.Data[i] {
+			t.Errorf("index %d: got %v, want %v", i, decoded.Data[i], v.Data[i])
+		}
+	}
+}
+
+func TestVectorValueNaNRoundTrip(t *testing.T) {
+	// Test that NaN values can round-trip through ToJSON/decodeFromJSON
+	// ToJSON encodes NaN as null, decodeFromJSON should decode null back to NaN
+	v := Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, float32(math.NaN()), 3.0}}
+
+	val, err := v.Value()
+	if err != nil {
+		t.Fatalf("Value() failed: %v", err)
+	}
+
+	jsonStr, ok := val.(string)
+	if !ok {
+		t.Fatalf("Value() should return string, got %T", val)
+	}
+
+	// NaN should be encoded as null
+	expectedJSON := "[1, null, 3]"
+	if jsonStr != expectedJSON {
+		t.Errorf("Value() returned %q, expected %q", jsonStr, expectedJSON)
+	}
+
+	// Test that the JSON can be decoded back to a Vector with NaN
+	var decoded Vector
+	err = decoded.decodeFromJSON(jsonStr)
+	if err != nil {
+		t.Fatalf("decodeFromJSON failed: %v", err)
+	}
+
+	if len(decoded.Data) != len(v.Data) {
+		t.Fatalf("length mismatch: got %d, want %d", len(decoded.Data), len(v.Data))
+	}
+
+	// First element should match
+	if decoded.Data[0] != 1.0 {
+		t.Errorf("index 0: got %v, want 1.0", decoded.Data[0])
+	}
+
+	// Second element should be NaN (null in JSON -> NaN)
+	if !math.IsNaN(float64(decoded.Data[1])) {
+		t.Errorf("index 1: got %v, want NaN", decoded.Data[1])
+	}
+
+	// Third element should match
+	if decoded.Data[2] != 3.0 {
+		t.Errorf("index 2: got %v, want 3.0", decoded.Data[2])
+	}
+}
+
+func TestVectorValueInfRejected(t *testing.T) {
+	// Test that Inf values cause Value() to return an error
+	// (Inf cannot be losslessly round-tripped through JSON)
+	v := Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, float32(math.Inf(1)), 3.0}}
+
+	_, err := v.Value()
+	if err == nil {
+		t.Fatal("Value() should return error for vector with Inf values")
+	}
+
+	// Negative infinity should also fail
+	v = Vector{ElementType: VectorElementFloat32, Data: []float32{float32(math.Inf(-1))}}
+	_, err = v.Value()
+	if err == nil {
+		t.Fatal("Value() should return error for vector with -Inf values")
+	}
+}
+
+func TestVectorScan(t *testing.T) {
+	original := Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0, 3.0}}
+	encoded, _ := original.encodeToBytes()
+
+	var v Vector
+	err := v.Scan(encoded)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+
+	if len(v.Data) != len(original.Data) {
+		t.Fatalf("length mismatch: got %d, want %d", len(v.Data), len(original.Data))
+	}
+
+	for i := range original.Data {
+		if v.Data[i] != original.Data[i] {
+			t.Errorf("index %d: got %v, want %v", i, v.Data[i], original.Data[i])
+		}
+	}
+
+	// Scan nil
+	err = v.Scan(nil)
+	if err != nil {
+		t.Fatalf("Scan(nil) failed: %v", err)
+	}
+	if v.Data != nil {
+		t.Errorf("Scan(nil) should set Data to nil")
+	}
+}
+
+func TestVectorScanFromFloat64Slice(t *testing.T) {
+	// Test scanning from []float64 to Vector
+	float64Values := []float64{1.5, 2.5, 3.5}
+	var v Vector
+	err := v.Scan(float64Values)
+	if err != nil {
+		t.Fatalf("Scan([]float64) failed: %v", err)
+	}
+
+	if len(v.Data) != len(float64Values) {
+		t.Fatalf("length mismatch: got %d, want %d", len(v.Data), len(float64Values))
+	}
+
+	for i, val := range float64Values {
+		if v.Data[i] != float32(val) {
+			t.Errorf("index %d: got %v, want %v", i, v.Data[i], float32(val))
+		}
+	}
+}
+
+func TestVectorScanFromFloat32Slice(t *testing.T) {
+	// Test scanning from []float32 to Vector (should copy, not reference)
+	float32Values := []float32{1.0, 2.0, 3.0}
+	var v Vector
+	err := v.Scan(float32Values)
+	if err != nil {
+		t.Fatalf("Scan([]float32) failed: %v", err)
+	}
+
+	if len(v.Data) != len(float32Values) {
+		t.Fatalf("length mismatch: got %d, want %d", len(v.Data), len(float32Values))
+	}
+
+	// Modify original - should not affect scanned value
+	float32Values[0] = 999.0
+	if v.Data[0] == 999.0 {
+		t.Error("Scan([]float32) should copy the slice, not reference it")
+	}
+}
+
+func TestNullVector(t *testing.T) {
+	// Valid value
+	nv := NullVector{
+		Vector: Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0, 3.0}},
+		Valid:  true,
+	}
+
+	val, err := nv.Value()
+	if err != nil {
+		t.Fatalf("Value() failed: %v", err)
+	}
+	if val == nil {
+		t.Error("Value() should not be nil for valid NullVector")
+	}
+
+	// Null value
+	nv = NullVector{Valid: false}
+	val, err = nv.Value()
+	if err != nil {
+		t.Fatalf("Value() failed: %v", err)
+	}
+	if val != nil {
+		t.Error("Value() should be nil for invalid NullVector")
+	}
+
+	// Scan valid
+	encoded, _ := (Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0}}).encodeToBytes()
+	err = nv.Scan(encoded)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if !nv.Valid {
+		t.Error("NullVector should be valid after scanning data")
+	}
+	if len(nv.Vector.Data) != 2 {
+		t.Errorf("Vector length: got %d, want 2", len(nv.Vector.Data))
+	}
+
+	// Scan nil
+	err = nv.Scan(nil)
+	if err != nil {
+		t.Fatalf("Scan(nil) failed: %v", err)
+	}
+	if nv.Valid {
+		t.Error("NullVector should not be valid after scanning nil")
+	}
+}
+
+func TestNullVectorScanError(t *testing.T) {
+	// Test that NullVector.Scan sets Valid=false on scan error
+	nv := NullVector{
+		Vector: Vector{ElementType: VectorElementFloat32, Data: []float32{1.0}},
+		Valid:  true, // Start as valid
+	}
+
+	// Invalid vector data (wrong magic byte)
+	invalidData := []byte{0xAA, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	err := nv.Scan(invalidData)
+	if err == nil {
+		t.Error("Expected error for invalid vector data")
+	}
+	if nv.Valid {
+		t.Error("NullVector.Valid should be false after scan error")
+	}
+}
+
+func TestVectorScanUnsupportedType(t *testing.T) {
+	var v Vector
+	err := v.Scan(42) // int is not supported
+	if err == nil {
+		t.Error("Expected error for unsupported type")
+	}
+	if !strings.Contains(err.Error(), "cannot convert") {
+		t.Errorf("Expected 'cannot convert' error, got: %v", err)
+	}
+}
+
+func TestVectorDecodeEmptyJSON(t *testing.T) {
+	var v Vector
+	err := v.decodeFromJSON("[]")
+	if err != nil {
+		t.Fatalf("decodeFromJSON([]) failed: %v", err)
+	}
+	if v.Data == nil {
+		t.Error("Empty array should produce non-nil slice")
+	}
+	if len(v.Data) != 0 {
+		t.Error("Empty array should produce zero-length slice")
+	}
+}
+
+func TestVectorDecodeNullJSON(t *testing.T) {
+	var v Vector
+	err := v.decodeFromJSON("null")
+	if err != nil {
+		t.Fatalf("decodeFromJSON(null) failed: %v", err)
+	}
+	if v.Data != nil {
+		t.Error("JSON null should produce nil Data (SQL NULL)")
+	}
+}
+
+func TestVectorDecodeInvalidJSON(t *testing.T) {
+	var v Vector
+	err := v.decodeFromJSON("not json")
+	if err == nil {
+		t.Error("Expected error for malformed JSON")
+	}
+}
+
+func TestVectorString(t *testing.T) {
+	testCases := []struct {
+		vector   Vector
+		expected string
+	}{
+		{Vector{}, "NULL"},
+		{Vector{Data: nil}, "NULL"},
+		{Vector{ElementType: VectorElementFloat32, Data: []float32{}}, "VECTOR(FLOAT32, 0) : []"},
+		{Vector{ElementType: VectorElementFloat32, Data: []float32{1.0}}, "VECTOR(FLOAT32, 1) : [1]"},
+		{Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0, 3.0}}, "VECTOR(FLOAT32, 3) : [1, 2, 3]"},
+		{Vector{ElementType: VectorElementFloat16, Data: []float32{1.5, -2.5}}, "VECTOR(FLOAT16, 2) : [1.5, -2.5]"},
+	}
+
+	for _, tc := range testCases {
+		result := tc.vector.String()
+		if result != tc.expected {
+			t.Errorf("String() for %v: got %q, want %q", tc.vector, result, tc.expected)
+		}
+	}
+}
+
+func TestVectorDimensions(t *testing.T) {
+	testCases := []struct {
+		vector   Vector
+		expected int
+	}{
+		{Vector{}, 0},
+		{Vector{Data: nil}, 0},
+		{Vector{ElementType: VectorElementFloat32, Data: []float32{}}, 0},
+		{Vector{ElementType: VectorElementFloat32, Data: []float32{1.0}}, 1},
+		{Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0, 3.0}}, 3},
+	}
+
+	for _, tc := range testCases {
+		result := tc.vector.Dimensions()
+		if result != tc.expected {
+			t.Errorf("Dimensions() for %v: got %d, want %d", tc.vector, result, tc.expected)
+		}
+	}
+}
+
+func TestNewVector(t *testing.T) {
+	values := []float32{1.0, 2.0, 3.0}
+	v, err := NewVector(values)
+	if err != nil {
+		t.Fatalf("NewVector failed: %v", err)
+	}
+
+	if len(v.Data) != len(values) {
+		t.Fatalf("length mismatch: got %d, want %d", len(v.Data), len(values))
+	}
+
+	if v.ElementType != VectorElementFloat32 {
+		t.Errorf("element type: got %v, want float32", v.ElementType)
+	}
+
+	// Verify it's a copy
+	values[0] = 999.0
+	if v.Data[0] == 999.0 {
+		t.Error("NewVector should create a copy of the slice")
+	}
+}
+
+func TestNewVectorWithType(t *testing.T) {
+	values := []float32{1.0, 2.0, 3.0}
+
+	v, err := NewVectorWithType(VectorElementFloat16, values)
+	if err != nil {
+		t.Fatalf("NewVectorWithType failed: %v", err)
+	}
+
+	if v.ElementType != VectorElementFloat16 {
+		t.Errorf("element type: got %v, want float16", v.ElementType)
+	}
+
+	if len(v.Data) != len(values) {
+		t.Fatalf("length mismatch: got %d, want %d", len(v.Data), len(values))
+	}
+}
+
+func TestNewVectorFromFloat64(t *testing.T) {
+	values := []float64{1.0, 2.0, 3.0}
+	v, err := NewVectorFromFloat64(values)
+	if err != nil {
+		t.Fatalf("NewVectorFromFloat64 failed: %v", err)
+	}
+
+	if len(v.Data) != len(values) {
+		t.Fatalf("length mismatch: got %d, want %d", len(v.Data), len(values))
+	}
+
+	if v.ElementType != VectorElementFloat32 {
+		t.Errorf("element type: got %v, want float32", v.ElementType)
+	}
+
+	for i, val := range values {
+		if v.Data[i] != float32(val) {
+			t.Errorf("index %d: got %v, want %v", i, v.Data[i], float32(val))
+		}
+	}
+}
+
+func TestVectorToFloat64(t *testing.T) {
+	v := Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0, 3.0}}
+	result := v.ToFloat64()
+
+	if len(result) != len(v.Data) {
+		t.Fatalf("length mismatch: got %d, want %d", len(result), len(v.Data))
+	}
+
+	for i, val := range v.Data {
+		if result[i] != float64(val) {
+			t.Errorf("index %d: got %v, want %v", i, result[i], float64(val))
+		}
+	}
+
+	// nil data vector
+	nilV := Vector{}
+	nilResult := nilV.ToFloat64()
+	if nilResult != nil {
+		t.Error("ToFloat64() for nil data vector should return nil")
+	}
+}
+
+func TestVectorValues(t *testing.T) {
+	original := []float32{1.0, 2.0, 3.0}
+	v := Vector{ElementType: VectorElementFloat32, Data: original}
+
+	values := v.Values()
+
+	if len(values) != len(original) {
+		t.Fatalf("length mismatch: got %d, want %d", len(values), len(original))
+	}
+
+	// Verify it's a copy
+	values[0] = 999.0
+	if v.Data[0] == 999.0 {
+		t.Error("Values() should return a copy")
+	}
+
+	// nil data
+	nilV := Vector{}
+	if nilV.Values() != nil {
+		t.Error("Values() for nil data should return nil")
+	}
+}
+
+func TestVectorMaxDimensions(t *testing.T) {
+	// Test at maximum allowed for float32
+	maxValues := make([]float32, vectorMaxDimensionsFloat32)
+	v, err := NewVector(maxValues)
+	if err != nil {
+		t.Fatalf("NewVector at max dimensions failed: %v", err)
+	}
+	if len(v.Data) != vectorMaxDimensionsFloat32 {
+		t.Errorf("length: got %d, want %d", len(v.Data), vectorMaxDimensionsFloat32)
+	}
+
+	// Test exceeding maximum for float32
+	tooManyValues := make([]float32, vectorMaxDimensionsFloat32+1)
+	_, err = NewVector(tooManyValues)
+	if err == nil {
+		t.Error("NewVector should fail when exceeding max dimensions")
+	}
+
+	// Test at maximum allowed for float16
+	maxFloat16 := make([]float32, vectorMaxDimensionsFloat16)
+	v, err = NewVectorWithType(VectorElementFloat16, maxFloat16)
+	if err != nil {
+		t.Fatalf("NewVectorWithType(float16) at max dimensions failed: %v", err)
+	}
+
+	// Test encode with oversized vector
+	oversizedVector := Vector{ElementType: VectorElementFloat32, Data: tooManyValues}
+	_, err = oversizedVector.encodeToBytes()
+	if err == nil {
+		t.Error("encodeToBytes should fail when exceeding max dimensions")
+	}
+}
+
+func TestVectorBinaryFormat(t *testing.T) {
+	// Test that encoding matches expected TDS format
+	v := Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0}}
+	encoded, err := v.encodeToBytes()
+	if err != nil {
+		t.Fatalf("encodeToBytes failed: %v", err)
+	}
+
+	// Expected format:
+	// Header: A9 01 02 00 00 00 00 00 (magic, version, 2 dims, float32 type, 3 reserved)
+	// Data: 00 00 80 3F (1.0 as float32 LE), 00 00 00 40 (2.0 as float32 LE)
+	expected := []byte{
+		0xA9, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, // Header
+		0x00, 0x00, 0x80, 0x3F, // 1.0f
+		0x00, 0x00, 0x00, 0x40, // 2.0f
+	}
+
+	if !bytes.Equal(encoded, expected) {
+		t.Errorf("binary format mismatch:\ngot:  %v\nwant: %v", encoded, expected)
+	}
+}
+
+func TestVectorFloat16BinaryFormat(t *testing.T) {
+	// Test float16 binary encoding
+	v := Vector{ElementType: VectorElementFloat16, Data: []float32{1.0, 2.0}}
+	encoded, err := v.encodeToBytes()
+	if err != nil {
+		t.Fatalf("encodeToBytes failed: %v", err)
+	}
+
+	// Expected format:
+	// Header: A9 01 02 00 01 00 00 00 (magic, version, 2 dims, float16 type=0x01, 3 reserved)
+	// Data: 00 3C (1.0 as float16 LE), 00 40 (2.0 as float16 LE)
+	expected := []byte{
+		0xA9, 0x01, 0x02, 0x00, 0x01, 0x00, 0x00, 0x00, // Header
+		0x00, 0x3C, // 1.0 as float16
+		0x00, 0x40, // 2.0 as float16
+	}
+
+	if !bytes.Equal(encoded, expected) {
+		t.Errorf("float16 binary format mismatch:\ngot:  %v\nwant: %v", encoded, expected)
+	}
+
+	// Verify total size (8 header + 2*2 data = 12 bytes)
+	if len(encoded) != 12 {
+		t.Errorf("total size: got %d, want 12", len(encoded))
+	}
+}
+
+func TestVectorPrecisionLossWarning(t *testing.T) {
+	// Track precision loss warnings
+	var warnings []struct {
+		index     int
+		original  float64
+		converted float32
+	}
+
+	// Set custom handler using the thread-safe setter
+	SetVectorPrecisionLossHandler(func(index int, original float64, converted float32) {
+		warnings = append(warnings, struct {
+			index     int
+			original  float64
+			converted float32
+		}{index, original, converted})
+	})
+	defer SetVectorPrecisionLossHandler(nil)
+
+	// Test with value that loses precision
+	preciseValue := 0.123456789012345 // More precision than float32 can hold
+	_, err := NewVectorFromFloat64([]float64{1.0, preciseValue, 3.0})
+	if err != nil {
+		t.Fatalf("NewVectorFromFloat64 failed: %v", err)
+	}
+
+	// Should have exactly one warning (only first precision loss reported)
+	if len(warnings) != 1 {
+		t.Errorf("expected 1 warning, got %d", len(warnings))
+	}
+	if len(warnings) > 0 && warnings[0].index != 1 {
+		t.Errorf("expected warning at index 1, got %d", warnings[0].index)
+	}
+
+	// Test with values that don't lose precision
+	warnings = nil
+	_, err = NewVectorFromFloat64([]float64{1.0, 2.0, 3.0})
+	if err != nil {
+		t.Fatalf("NewVectorFromFloat64 failed: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for exact values, got %d", len(warnings))
+	}
+
+	// Test SetVectorPrecisionWarnings
+	SetVectorPrecisionWarnings(false)
+	// Handler should now be nil - verify by checking no warnings fire
+	warnings = nil
+	_, _ = NewVectorFromFloat64([]float64{preciseValue})
+	if len(warnings) != 0 {
+		t.Error("SetVectorPrecisionWarnings(false) should disable warnings")
+	}
+}
+
+// TestVectorTypeFunctions tests the type-related functions for Vector type.
+// These tests cover code paths in types.go that are otherwise only exercised
+// during database operations.
+func TestVectorTypeFunctions(t *testing.T) {
+	// Test makeDecl for typeVectorN with float32
+	t.Run("makeDecl float32", func(t *testing.T) {
+		ti := typeInfo{TypeId: typeVectorN, Size: 20, Scale: 0} // 3 float32 = 12 bytes data + 8 bytes header = 20
+		decl := makeDecl(ti)
+		expected := "vector(3)"
+		if decl != expected {
+			t.Errorf("Expected makeDecl to return %q, got: %q", expected, decl)
+		}
+	})
+
+	t.Run("makeDecl float16", func(t *testing.T) {
+		ti := typeInfo{TypeId: typeVectorN, Size: 14, Scale: 1} // 3 float16 = 6 bytes data + 8 bytes header = 14
+		decl := makeDecl(ti)
+		expected := "vector(3, float16)"
+		if decl != expected {
+			t.Errorf("Expected makeDecl to return %q, got: %q", expected, decl)
+		}
+	})
+
+	t.Run("makeDecl invalid size", func(t *testing.T) {
+		// Test with size too small for header
+		ti := typeInfo{TypeId: typeVectorN, Size: 4, Scale: 0}
+		decl := makeDecl(ti)
+		expected := "vector"
+		if decl != expected {
+			t.Errorf("Expected makeDecl to return %q, got: %q", expected, decl)
+		}
+	})
+
+	t.Run("makeDecl zero payload", func(t *testing.T) {
+		// Test with size == header (0 dimensions)
+		ti := typeInfo{TypeId: typeVectorN, Size: 8, Scale: 0} // size == vectorHeaderSize, 0 dimensions
+		decl := makeDecl(ti)
+		// payloadSize == 0, so returns "vector"
+		expected := "vector"
+		if decl != expected {
+			t.Errorf("Expected makeDecl to return %q for zero-payload, got: %q", expected, decl)
+		}
+	})
+
+	t.Run("makeDecl misaligned payload", func(t *testing.T) {
+		// Test with payload size that doesn't divide evenly by bytesPerElement
+		ti := typeInfo{TypeId: typeVectorN, Size: 11, Scale: 0} // 8 header + 3 data (not divisible by 4)
+		decl := makeDecl(ti)
+		expected := "vector"
+		if decl != expected {
+			t.Errorf("Expected makeDecl to return %q for misaligned payload, got: %q", expected, decl)
+		}
+	})
+
+	// Test makeGoLangTypeName for typeVectorN
+	t.Run("makeGoLangTypeName", func(t *testing.T) {
+		ti := typeInfo{TypeId: typeVectorN}
+		typeName := makeGoLangTypeName(ti)
+		if typeName != "VECTOR" {
+			t.Errorf("Expected makeGoLangTypeName to return 'VECTOR', got: %s", typeName)
+		}
+	})
+
+	// Test makeGoLangScanType for typeVectorN
+	t.Run("makeGoLangScanType", func(t *testing.T) {
+		// All vectors should return []byte (raw binary payload)
+		ti := typeInfo{TypeId: typeVectorN, Scale: 0}
+		scanType := makeGoLangScanType(ti)
+		expected := "[]uint8" // []byte is an alias for []uint8
+		if scanType.String() != expected {
+			t.Errorf("Expected scan type %s for float32 Vector, got %s", expected, scanType.String())
+		}
+
+		// float16 vectors also return []byte
+		ti16 := typeInfo{TypeId: typeVectorN, Scale: 1}
+		scanType16 := makeGoLangScanType(ti16)
+		if scanType16.String() != expected {
+			t.Errorf("Expected scan type %s for float16 Vector, got %s", expected, scanType16.String())
+		}
+	})
+
+	// Test makeGoLangTypeLength for typeVectorN
+	t.Run("makeGoLangTypeLength float32", func(t *testing.T) {
+		ti := typeInfo{TypeId: typeVectorN, Size: 20, Scale: 0} // 3 float32
+		length, hasLength := makeGoLangTypeLength(ti)
+		if !hasLength {
+			t.Error("Expected makeGoLangTypeLength to return true for Vector")
+		}
+		expectedLength := int64(3) // Number of dimensions
+		if length != expectedLength {
+			t.Errorf("Expected length %d, got: %d", expectedLength, length)
+		}
+	})
+
+	t.Run("makeGoLangTypeLength float16", func(t *testing.T) {
+		ti := typeInfo{TypeId: typeVectorN, Size: 14, Scale: 1} // 3 float16
+		length, hasLength := makeGoLangTypeLength(ti)
+		if !hasLength {
+			t.Error("Expected makeGoLangTypeLength to return true for Vector")
+		}
+		expectedLength := int64(3) // Number of dimensions
+		if length != expectedLength {
+			t.Errorf("Expected length %d, got: %d", expectedLength, length)
+		}
+	})
+
+	t.Run("makeGoLangTypeLength invalid scale", func(t *testing.T) {
+		// Unknown scale (not 0 or 1) should return false
+		ti := typeInfo{TypeId: typeVectorN, Size: 20, Scale: 99}
+		_, hasLength := makeGoLangTypeLength(ti)
+		if hasLength {
+			t.Error("Expected makeGoLangTypeLength to return false for unknown scale")
+		}
+	})
+
+	t.Run("makeGoLangTypeLength PLP marker", func(t *testing.T) {
+		// PLP/MAX marker (0xffff) should return false
+		ti := typeInfo{TypeId: typeVectorN, Size: 0xffff, Scale: 0}
+		_, hasLength := makeGoLangTypeLength(ti)
+		if hasLength {
+			t.Error("Expected makeGoLangTypeLength to return false for PLP marker")
+		}
+	})
+
+	t.Run("makeGoLangTypeLength too small", func(t *testing.T) {
+		// Size smaller than header should return false
+		ti := typeInfo{TypeId: typeVectorN, Size: 4, Scale: 0}
+		_, hasLength := makeGoLangTypeLength(ti)
+		if hasLength {
+			t.Error("Expected makeGoLangTypeLength to return false for size < header")
+		}
+	})
+
+	t.Run("makeGoLangTypeLength misaligned", func(t *testing.T) {
+		// Payload not divisible by bytesPerElement should return false
+		ti := typeInfo{TypeId: typeVectorN, Size: 11, Scale: 0} // 8 header + 3 bytes (not divisible by 4)
+		_, hasLength := makeGoLangTypeLength(ti)
+		if hasLength {
+			t.Error("Expected makeGoLangTypeLength to return false for misaligned payload")
+		}
+	})
+
+	// Test makeGoLangTypePrecisionScale for typeVectorN
+	t.Run("makeGoLangTypePrecisionScale", func(t *testing.T) {
+		ti := typeInfo{TypeId: typeVectorN}
+		prec, scale, hasPrecScale := makeGoLangTypePrecisionScale(ti)
+		if hasPrecScale {
+			t.Error("Expected makeGoLangTypePrecisionScale to return false for Vector")
+		}
+		if prec != 0 || scale != 0 {
+			t.Errorf("Expected prec=0, scale=0, got prec=%d, scale=%d", prec, scale)
+		}
+	})
+}
+
+// TestConvertInputParameterVector tests the convertInputParameter function for Vector types.
+func TestConvertInputParameterVector(t *testing.T) {
+	t.Run("Vector value", func(t *testing.T) {
+		v := Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0, 3.0}}
+		result, err := convertInputParameter(v)
+		if err != nil {
+			t.Fatalf("convertInputParameter(Vector) returned error: %v", err)
+		}
+		if converted, ok := result.(Vector); !ok {
+			t.Errorf("Expected Vector type, got %T", result)
+		} else if len(converted.Data) != 3 {
+			t.Errorf("Expected 3 elements, got %d", len(converted.Data))
+		}
+	})
+
+	t.Run("NullVector valid value", func(t *testing.T) {
+		v := NullVector{Vector: Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0}}, Valid: true}
+		result, err := convertInputParameter(v)
+		if err != nil {
+			t.Fatalf("convertInputParameter(NullVector) returned error: %v", err)
+		}
+		if converted, ok := result.(NullVector); !ok {
+			t.Errorf("Expected NullVector type, got %T", result)
+		} else if !converted.Valid {
+			t.Error("Expected Valid to be true")
+		}
+	})
+
+	t.Run("NullVector null value", func(t *testing.T) {
+		v := NullVector{Valid: false}
+		result, err := convertInputParameter(v)
+		if err != nil {
+			t.Fatalf("convertInputParameter(NullVector) returned error: %v", err)
+		}
+		if converted, ok := result.(NullVector); !ok {
+			t.Errorf("Expected NullVector type, got %T", result)
+		} else if converted.Valid {
+			t.Error("Expected Valid to be false")
+		}
+	})
+}

--- a/vector_test.go
+++ b/vector_test.go
@@ -544,6 +544,29 @@ func TestVectorScanFromFloat32Slice(t *testing.T) {
 	}
 }
 
+func TestVectorScanRejectsTooManyDimensions(t *testing.T) {
+	tests := []struct {
+		name string
+		src  interface{}
+	}{
+		{name: "float32", src: make([]float32, vectorMaxDimensionsFloat32+1)},
+		{name: "float64", src: make([]float64, vectorMaxDimensionsFloat32+1)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var v Vector
+			err := v.Scan(test.src)
+			if err == nil {
+				t.Fatal("Scan should fail when exceeding max dimensions")
+			}
+			if !strings.Contains(err.Error(), "exceeds maximum 1998") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestNullVector(t *testing.T) {
 	// Valid value
 	nv := NullVector{

--- a/vector_test.go
+++ b/vector_test.go
@@ -916,6 +916,36 @@ func TestVectorMaxDimensions(t *testing.T) {
 	}
 }
 
+func TestVectorDecodeRejectsTooManyDimensions(t *testing.T) {
+	tests := []struct {
+		name        string
+		elementType VectorElementType
+		dimensions  int
+	}{
+		{name: "float32", elementType: VectorElementFloat32, dimensions: vectorMaxDimensionsFloat32 + 1},
+		{name: "float16", elementType: VectorElementFloat16, dimensions: vectorMaxDimensionsFloat16 + 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			buf := make([]byte, vectorHeaderSize+test.dimensions*test.elementType.BytesPerElement())
+			buf[0] = vectorMagic
+			buf[1] = vectorVersion
+			binary.LittleEndian.PutUint16(buf[2:4], uint16(test.dimensions))
+			buf[4] = byte(test.elementType)
+
+			var v Vector
+			err := v.decodeFromBytes(buf)
+			if err == nil {
+				t.Fatal("decodeFromBytes should fail when exceeding max dimensions")
+			}
+			if !strings.Contains(err.Error(), "exceeds maximum") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestVectorBinaryFormat(t *testing.T) {
 	// Test that encoding matches expected TDS format
 	v := Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0}}

--- a/vector_test.go
+++ b/vector_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/go-mssqldb/msdsn"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -1201,6 +1202,31 @@ func TestVectorTypeFunctions(t *testing.T) {
 			t.Errorf("Expected prec=0, scale=0, got prec=%d, scale=%d", prec, scale)
 		}
 	})
+}
+
+func TestReadVectorTypeRejectsLengthAboveColumnMaximum(t *testing.T) {
+	buf := newTdsBuffer(512, nil)
+	binary.LittleEndian.PutUint16(buf.rbuf[:2], 9)
+	buf.rpos = 0
+	buf.rsize = 2
+	buf.final = true
+
+	ti := typeInfo{TypeId: typeVectorN, Size: 8}
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatal("readVectorType should reject a value larger than the column maximum")
+		}
+		err, ok := recovered.(error)
+		if !ok {
+			t.Fatalf("recovered %T, want error", recovered)
+		}
+		if !strings.Contains(err.Error(), "vector length 9 exceeds column maximum 8") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}()
+
+	readVectorType(&ti, buf, nil, msdsn.EncodeParameters{})
 }
 
 // TestConvertInputParameterVector tests the convertInputParameter function for Vector types.

--- a/vector_test.go
+++ b/vector_test.go
@@ -567,6 +567,65 @@ func TestVectorScanRejectsTooManyDimensions(t *testing.T) {
 	}
 }
 
+func TestVectorConstructorsPreserveNil(t *testing.T) {
+	vector, err := NewVector(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !vector.IsNull() {
+		t.Fatal("NewVector(nil) should return a NULL vector")
+	}
+
+	vector, err = NewVectorWithType(VectorElementFloat16, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !vector.IsNull() {
+		t.Fatal("NewVectorWithType(nil) should return a NULL vector")
+	}
+
+	vector, err = NewVectorFromFloat64(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !vector.IsNull() {
+		t.Fatal("NewVectorFromFloat64(nil) should return a NULL vector")
+	}
+
+	vector, err = NewVector([]float32{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vector.IsNull() {
+		t.Fatal("NewVector(empty slice) should not return a NULL vector")
+	}
+
+	vector, err = NewVectorFromFloat64([]float64{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vector.IsNull() {
+		t.Fatal("NewVectorFromFloat64(empty slice) should not return a NULL vector")
+	}
+}
+
+func TestVectorScanPreservesNilSlices(t *testing.T) {
+	var v Vector
+	if err := v.Scan([]float32(nil)); err != nil {
+		t.Fatal(err)
+	}
+	if !v.IsNull() {
+		t.Fatal("Scan([]float32(nil)) should return a NULL vector")
+	}
+
+	if err := v.Scan([]float64(nil)); err != nil {
+		t.Fatal(err)
+	}
+	if !v.IsNull() {
+		t.Fatal("Scan([]float64(nil)) should return a NULL vector")
+	}
+}
+
 func TestNullVector(t *testing.T) {
 	// Valid value
 	nv := NullVector{

--- a/vector_test.go
+++ b/vector_test.go
@@ -49,10 +49,6 @@ func TestVectorEncodeDecode(t *testing.T) {
 		vector Vector
 	}{
 		{
-			name:   "empty vector",
-			vector: Vector{ElementType: VectorElementFloat32, Data: []float32{}},
-		},
-		{
 			name:   "single element",
 			vector: Vector{ElementType: VectorElementFloat32, Data: []float32{1.0}},
 		},
@@ -409,51 +405,13 @@ func TestVectorValue(t *testing.T) {
 	}
 }
 
-func TestVectorValueNaNRoundTrip(t *testing.T) {
-	// Test that NaN values can round-trip through ToJSON/decodeFromJSON
-	// ToJSON encodes NaN as null, decodeFromJSON should decode null back to NaN
+func TestVectorValueNaNRejected(t *testing.T) {
 	v := Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, float32(math.NaN()), 3.0}}
-
-	val, err := v.Value()
-	if err != nil {
-		t.Fatalf("Value() failed: %v", err)
+	if _, err := v.Value(); err == nil {
+		t.Fatal("Value() should return error for vector with NaN values")
 	}
-
-	jsonStr, ok := val.(string)
-	if !ok {
-		t.Fatalf("Value() should return string, got %T", val)
-	}
-
-	// NaN should be encoded as null
-	expectedJSON := "[1, null, 3]"
-	if jsonStr != expectedJSON {
-		t.Errorf("Value() returned %q, expected %q", jsonStr, expectedJSON)
-	}
-
-	// Test that the JSON can be decoded back to a Vector with NaN
-	var decoded Vector
-	err = decoded.decodeFromJSON(jsonStr)
-	if err != nil {
-		t.Fatalf("decodeFromJSON failed: %v", err)
-	}
-
-	if len(decoded.Data) != len(v.Data) {
-		t.Fatalf("length mismatch: got %d, want %d", len(decoded.Data), len(v.Data))
-	}
-
-	// First element should match
-	if decoded.Data[0] != 1.0 {
-		t.Errorf("index 0: got %v, want 1.0", decoded.Data[0])
-	}
-
-	// Second element should be NaN (null in JSON -> NaN)
-	if !math.IsNaN(float64(decoded.Data[1])) {
-		t.Errorf("index 1: got %v, want NaN", decoded.Data[1])
-	}
-
-	// Third element should match
-	if decoded.Data[2] != 3.0 {
-		t.Errorf("index 2: got %v, want 3.0", decoded.Data[2])
+	if got := v.ToJSON(); got != "" {
+		t.Fatalf("ToJSON() = %q; want empty string", got)
 	}
 }
 
@@ -593,20 +551,16 @@ func TestVectorConstructorsPreserveNil(t *testing.T) {
 		t.Fatal("NewVectorFromFloat64(nil) should return a NULL vector")
 	}
 
-	vector, err = NewVector([]float32{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if vector.IsNull() {
-		t.Fatal("NewVector(empty slice) should not return a NULL vector")
+	if _, err = NewVector([]float32{}); err == nil {
+		t.Fatal("NewVector(empty slice) should fail")
 	}
 
-	vector, err = NewVectorFromFloat64([]float64{})
-	if err != nil {
-		t.Fatal(err)
+	if _, err = NewVectorWithType(VectorElementFloat16, []float32{}); err == nil {
+		t.Fatal("NewVectorWithType(empty slice) should fail")
 	}
-	if vector.IsNull() {
-		t.Fatal("NewVectorFromFloat64(empty slice) should not return a NULL vector")
+
+	if _, err = NewVectorFromFloat64([]float64{}); err == nil {
+		t.Fatal("NewVectorFromFloat64(empty slice) should fail")
 	}
 }
 
@@ -706,15 +660,101 @@ func TestVectorScanUnsupportedType(t *testing.T) {
 
 func TestVectorDecodeEmptyJSON(t *testing.T) {
 	var v Vector
-	err := v.decodeFromJSON("[]")
+	if err := v.decodeFromJSON("[]"); err == nil {
+		t.Fatal("decodeFromJSON([]) should fail")
+	}
+}
+
+func TestVectorDecodeJSONNullElement(t *testing.T) {
+	var v Vector
+	if err := v.decodeFromJSON("[1,null,3]"); err == nil {
+		t.Fatal("decodeFromJSON should reject null elements")
+	}
+}
+
+func TestVectorRejectsZeroDimensions(t *testing.T) {
+	vector := Vector{ElementType: VectorElementFloat32, Data: []float32{}}
+	if _, err := vector.encodeToBytes(); err == nil {
+		t.Fatal("encodeToBytes should reject zero dimensions")
+	}
+
+	payload := []byte{vectorMagic, vectorVersion, 0, 0, byte(VectorElementFloat32), 0, 0, 0}
+	if err := vector.decodeFromBytes(payload); err == nil {
+		t.Fatal("decodeFromBytes should reject zero dimensions")
+	}
+
+	if _, err := vector.Value(); err == nil {
+		t.Fatal("Value should reject zero dimensions")
+	}
+}
+
+func TestBulkMakeParamVector(t *testing.T) {
+	bulk := &Bulk{cn: &Conn{sess: &tdsSession{}}}
+	column := columnStruct{ti: typeInfo{
+		TypeId: typeVectorN,
+		Size:   vectorHeaderSize + 3*VectorElementFloat32.BytesPerElement(),
+		Scale:  byte(VectorElementFloat32),
+	}}
+	vector := Vector{ElementType: VectorElementFloat32, Data: []float32{1, 2, 3}}
+
+	param, err := bulk.makeParam(vector, column)
 	if err != nil {
-		t.Fatalf("decodeFromJSON([]) failed: %v", err)
+		t.Fatal(err)
 	}
-	if v.Data == nil {
-		t.Error("Empty array should produce non-nil slice")
+	if param.ti.TypeId != typeVectorN || param.ti.Size != len(param.buffer) {
+		t.Fatalf("unexpected vector parameter metadata: %#v", param.ti)
 	}
-	if len(v.Data) != 0 {
-		t.Error("Empty array should produce zero-length slice")
+
+	var decoded Vector
+	if err := decoded.decodeFromBytes(param.buffer); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, vector, decoded)
+}
+
+func TestBulkMakeParamVectorValidation(t *testing.T) {
+	bulk := &Bulk{cn: &Conn{sess: &tdsSession{}}}
+	column := columnStruct{ti: typeInfo{
+		TypeId: typeVectorN,
+		Size:   vectorHeaderSize + 3*VectorElementFloat32.BytesPerElement(),
+		Scale:  byte(VectorElementFloat32),
+	}}
+
+	for name, vector := range map[string]Vector{
+		"wrong dimensions":   {ElementType: VectorElementFloat32, Data: []float32{1, 2}},
+		"wrong element type": {ElementType: VectorElementFloat16, Data: []float32{1, 2, 3}},
+		"empty":              {ElementType: VectorElementFloat32, Data: []float32{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := bulk.makeParam(vector, column); err == nil {
+				t.Fatal("makeParam should reject invalid vector")
+			}
+		})
+	}
+}
+
+func TestBulkMakeParamNullVector(t *testing.T) {
+	bulk := &Bulk{cn: &Conn{sess: &tdsSession{}}}
+	column := columnStruct{ti: typeInfo{
+		TypeId: typeVectorN,
+		Size:   vectorHeaderSize + 3*VectorElementFloat32.BytesPerElement(),
+		Scale:  byte(VectorElementFloat32),
+	}}
+
+	for name, value := range map[string]interface{}{
+		"nil vector pointer":      (*Vector)(nil),
+		"invalid null vector":     NullVector{},
+		"nil null vector pointer": (*NullVector)(nil),
+	} {
+		t.Run(name, func(t *testing.T) {
+			param, err := bulk.makeParam(value, column)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if param.ti.TypeId != typeVectorN || param.buffer != nil {
+				t.Fatalf("unexpected NULL vector parameter: %#v", param)
+			}
+		})
 	}
 }
 
@@ -1324,6 +1364,16 @@ func TestReadVectorPLPTypeRejectsOversizedPayload(t *testing.T) {
 			name:   "advertised length mismatch",
 			stream: plpStream(20, make([]byte, 12)),
 			want:   "vector PLP length 12 does not match advertised length 20",
+		},
+		{
+			name: "chunk exceeds advertised length",
+			stream: func() []byte {
+				stream := make([]byte, 8+4+8+4)
+				binary.LittleEndian.PutUint64(stream, 4)
+				binary.LittleEndian.PutUint32(stream[8:], 8)
+				return stream
+			}(),
+			want: "vector PLP chunk exceeds advertised length 4",
 		},
 	}
 

--- a/vector_test.go
+++ b/vector_test.go
@@ -737,6 +737,22 @@ func TestVectorDecodeInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestVectorDecodeJSONRejectsOversizedArray(t *testing.T) {
+	values := make([]string, vectorMaxDimensionsFloat32+1)
+	for i := range values {
+		values[i] = "1"
+	}
+
+	var v Vector
+	err := v.decodeFromJSON("[" + strings.Join(values, ",") + "]")
+	if err == nil {
+		t.Fatal("decodeFromJSON should reject an oversized vector")
+	}
+	if !strings.Contains(err.Error(), "vector dimensions 1999 exceeds maximum 1998 for FLOAT32") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestVectorString(t *testing.T) {
 	testCases := []struct {
 		vector   Vector
@@ -1227,6 +1243,58 @@ func TestReadVectorTypeRejectsLengthAboveColumnMaximum(t *testing.T) {
 	}()
 
 	readVectorType(&ti, buf, nil, msdsn.EncodeParameters{})
+}
+
+func TestReadVectorPLPTypeRejectsOversizedPayload(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream []byte
+	}{
+		{
+			name:   "advertised length",
+			stream: plpStream(vectorMaxWireSize+1, []byte{vectorMagic}),
+		},
+		{
+			name:   "unknown length chunks",
+			stream: plpStream(_UNKNOWN_PLP_LEN, make([]byte, vectorMaxWireSize+1)),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			metadata := newTdsBuffer(3, nil)
+			binary.LittleEndian.PutUint16(metadata.rbuf[:2], 0xffff)
+			metadata.rbuf[2] = byte(VectorElementFloat32)
+			metadata.rpos = 0
+			metadata.rsize = 3
+			metadata.final = true
+
+			ti := typeInfo{TypeId: typeVectorN}
+			readVarLen(&ti, metadata, nil, msdsn.EncodeParameters{})
+
+			buf := newTdsBuffer(uint16(len(test.stream)), nil)
+			copy(buf.rbuf[:len(test.stream)], test.stream)
+			buf.rpos = 0
+			buf.rsize = len(test.stream)
+			buf.final = true
+
+			defer func() {
+				recovered := recover()
+				if recovered == nil {
+					t.Fatal("readVectorPLPType should reject an oversized payload")
+				}
+				err, ok := recovered.(error)
+				if !ok {
+					t.Fatalf("recovered %T, want error", recovered)
+				}
+				if !strings.Contains(err.Error(), "exceeds maximum 8000") {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}()
+
+			ti.Reader(&ti, buf, nil, msdsn.EncodeParameters{})
+		})
+	}
 }
 
 // TestConvertInputParameterVector tests the convertInputParameter function for Vector types.

--- a/vector_test.go
+++ b/vector_test.go
@@ -738,7 +738,7 @@ func TestVectorDecodeInvalidJSON(t *testing.T) {
 }
 
 func TestVectorDecodeJSONRejectsOversizedArray(t *testing.T) {
-	values := make([]string, vectorMaxDimensionsFloat32+1)
+	values := make([]string, vectorMaxDimensionsFloat16+1)
 	for i := range values {
 		values[i] = "1"
 	}
@@ -748,8 +748,26 @@ func TestVectorDecodeJSONRejectsOversizedArray(t *testing.T) {
 	if err == nil {
 		t.Fatal("decodeFromJSON should reject an oversized vector")
 	}
-	if !strings.Contains(err.Error(), "vector dimensions 1999 exceeds maximum 1998 for FLOAT32") {
+	if !strings.Contains(err.Error(), "vector dimensions 3997 exceeds maximum 3996") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVectorDecodeJSONInfersFloat16AboveFloat32Limit(t *testing.T) {
+	values := make([]string, vectorMaxDimensionsFloat16)
+	for i := range values {
+		values[i] = "1"
+	}
+
+	var v Vector
+	if err := v.decodeFromJSON("[" + strings.Join(values, ",") + "]"); err != nil {
+		t.Fatalf("decodeFromJSON failed: %v", err)
+	}
+	if v.ElementType != VectorElementFloat16 {
+		t.Fatalf("element type: got %s, want FLOAT16", v.ElementType)
+	}
+	if len(v.Data) != vectorMaxDimensionsFloat16 {
+		t.Fatalf("dimensions: got %d, want %d", len(v.Data), vectorMaxDimensionsFloat16)
 	}
 }
 
@@ -1245,18 +1263,51 @@ func TestReadVectorTypeRejectsLengthAboveColumnMaximum(t *testing.T) {
 	readVectorType(&ti, buf, nil, msdsn.EncodeParameters{})
 }
 
+func TestReadVectorTypeRejectsLengthAboveWireMaximum(t *testing.T) {
+	buf := newTdsBuffer(512, nil)
+	binary.LittleEndian.PutUint16(buf.rbuf[:2], vectorMaxWireSize+1)
+	buf.rpos = 0
+	buf.rsize = 2
+	buf.final = true
+
+	ti := typeInfo{TypeId: typeVectorN, Size: 0xfffe}
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatal("readVectorType should reject a value larger than the VECTOR wire maximum")
+		}
+		err, ok := recovered.(error)
+		if !ok {
+			t.Fatalf("recovered %T, want error", recovered)
+		}
+		if !strings.Contains(err.Error(), "vector length 8001 exceeds wire maximum 8000") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}()
+
+	readVectorType(&ti, buf, nil, msdsn.EncodeParameters{})
+}
+
 func TestReadVectorPLPTypeRejectsOversizedPayload(t *testing.T) {
 	tests := []struct {
 		name   string
 		stream []byte
+		want   string
 	}{
 		{
 			name:   "advertised length",
 			stream: plpStream(vectorMaxWireSize+1, []byte{vectorMagic}),
+			want:   "exceeds maximum 8000",
 		},
 		{
 			name:   "unknown length chunks",
 			stream: plpStream(_UNKNOWN_PLP_LEN, make([]byte, vectorMaxWireSize+1)),
+			want:   "exceeds maximum 8000",
+		},
+		{
+			name:   "advertised length mismatch",
+			stream: plpStream(20, make([]byte, 12)),
+			want:   "vector PLP length 12 does not match advertised length 20",
 		},
 	}
 
@@ -1287,7 +1338,7 @@ func TestReadVectorPLPTypeRejectsOversizedPayload(t *testing.T) {
 				if !ok {
 					t.Fatalf("recovered %T, want error", recovered)
 				}
-				if !strings.Contains(err.Error(), "exceeds maximum 8000") {
+				if !strings.Contains(err.Error(), test.want) {
 					t.Fatalf("unexpected error: %v", err)
 				}
 			}()

--- a/vector_test.go
+++ b/vector_test.go
@@ -619,6 +619,15 @@ func TestNullVector(t *testing.T) {
 		t.Errorf("Vector length: got %d, want 2", len(nv.Vector.Data))
 	}
 
+	// Scan JSON null
+	err = nv.Scan("null")
+	if err != nil {
+		t.Fatalf("Scan(\"null\") failed: %v", err)
+	}
+	if nv.Valid {
+		t.Error("NullVector should not be valid after scanning JSON null")
+	}
+
 	// Scan nil
 	err = nv.Scan(nil)
 	if err != nil {
@@ -737,8 +746,8 @@ func TestBulkMakeParamNullVector(t *testing.T) {
 	bulk := &Bulk{cn: &Conn{sess: &tdsSession{}}}
 	column := columnStruct{ti: typeInfo{
 		TypeId: typeVectorN,
-		Size:   vectorHeaderSize + 3*VectorElementFloat32.BytesPerElement(),
-		Scale:  byte(VectorElementFloat32),
+		Size:   vectorHeaderSize + 3*VectorElementFloat16.BytesPerElement(),
+		Scale:  byte(VectorElementFloat16),
 	}}
 
 	for name, value := range map[string]interface{}{
@@ -751,7 +760,8 @@ func TestBulkMakeParamNullVector(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if param.ti.TypeId != typeVectorN || param.buffer != nil {
+			if param.ti.TypeId != typeVectorN || param.ti.Scale != column.ti.Scale ||
+				param.ti.Size != 0 || param.buffer != nil {
 				t.Fatalf("unexpected NULL vector parameter: %#v", param)
 			}
 		})
@@ -774,6 +784,13 @@ func TestVectorDecodeInvalidJSON(t *testing.T) {
 	err := v.decodeFromJSON("not json")
 	if err == nil {
 		t.Error("Expected error for malformed JSON")
+	}
+}
+
+func TestVectorDecodeJSONRejectsFloat32Overflow(t *testing.T) {
+	var v Vector
+	if err := v.decodeFromJSON("[1e39]"); err == nil {
+		t.Fatal("decodeFromJSON should reject values outside the float32 range")
 	}
 }
 

--- a/vector_test.go
+++ b/vector_test.go
@@ -433,6 +433,45 @@ func TestVectorValueInfRejected(t *testing.T) {
 	}
 }
 
+func TestVectorValueRejectsInvalidDirectLiteral(t *testing.T) {
+	tests := []struct {
+		name   string
+		vector Vector
+		want   string
+	}{
+		{
+			name:   "unsupported element type",
+			vector: Vector{ElementType: VectorElementType(2), Data: []float32{1}},
+			want:   "unsupported vector element type 2",
+		},
+		{
+			name: "float32 dimensions",
+			vector: Vector{
+				ElementType: VectorElementFloat32,
+				Data:        make([]float32, vectorMaxDimensionsFloat32+1),
+			},
+			want: "vector dimensions 1999 exceeds maximum 1998 for FLOAT32",
+		},
+		{
+			name: "float16 dimensions",
+			vector: Vector{
+				ElementType: VectorElementFloat16,
+				Data:        make([]float32, vectorMaxDimensionsFloat16+1),
+			},
+			want: "vector dimensions 3997 exceeds maximum 3996 for FLOAT16",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := test.vector.Value()
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Value() error = %v; want error containing %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestVectorScan(t *testing.T) {
 	original := Vector{ElementType: VectorElementFloat32, Data: []float32{1.0, 2.0, 3.0}}
 	encoded, _ := original.encodeToBytes()
@@ -721,6 +760,50 @@ func TestBulkMakeParamVector(t *testing.T) {
 	assert.Equal(t, vector, decoded)
 }
 
+func TestBulkMakeParamVectorSlices(t *testing.T) {
+	bulk := &Bulk{cn: &Conn{sess: &tdsSession{}}}
+	column := columnStruct{ti: typeInfo{
+		TypeId: typeVectorN,
+		Size:   vectorHeaderSize + 3*VectorElementFloat32.BytesPerElement(),
+		Scale:  byte(VectorElementFloat32),
+	}}
+
+	for name, value := range map[string]interface{}{
+		"float32": []float32{1, 2, 3},
+		"float64": []float64{1, 2, 3},
+	} {
+		t.Run(name, func(t *testing.T) {
+			param, err := bulk.makeParam(value, column)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var decoded Vector
+			if err := decoded.decodeFromBytes(param.buffer); err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, []float32{1, 2, 3}, decoded.Data)
+		})
+	}
+}
+
+func TestBulkMakeParamVectorJSONFallback(t *testing.T) {
+	bulk := &Bulk{cn: &Conn{sess: &tdsSession{}}}
+	column := columnStruct{ti: typeInfo{TypeId: typeNVarChar, Size: 4000}}
+	vector := Vector{ElementType: VectorElementFloat16, Data: []float32{1, 2, 3}}
+
+	param, err := bulk.makeParam(vector, column)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ucs22str(param.buffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "[1, 2, 3]" {
+		t.Fatalf("bulk JSON vector = %q; want %q", got, "[1, 2, 3]")
+	}
+}
+
 func TestBulkMakeParamVectorValidation(t *testing.T) {
 	bulk := &Bulk{cn: &Conn{sess: &tdsSession{}}}
 	column := columnStruct{ti: typeInfo{
@@ -784,6 +867,15 @@ func TestVectorDecodeInvalidJSON(t *testing.T) {
 	err := v.decodeFromJSON("not json")
 	if err == nil {
 		t.Error("Expected error for malformed JSON")
+	}
+}
+
+func TestVectorDecodeJSONRejectsWhitespaceOnlyEmptyArray(t *testing.T) {
+	for _, input := range []string{"[ ]", "[\n]"} {
+		var v Vector
+		if err := v.decodeFromJSON(input); err == nil {
+			t.Fatalf("decodeFromJSON(%q) should reject an empty vector", input)
+		}
 	}
 }
 

--- a/vector_test.go
+++ b/vector_test.go
@@ -1288,6 +1288,22 @@ func TestReadVectorTypeRejectsLengthAboveWireMaximum(t *testing.T) {
 	readVectorType(&ti, buf, nil, msdsn.EncodeParameters{})
 }
 
+func TestReadVectorTypeReadsRemainingEncryptedValue(t *testing.T) {
+	value := []byte{vectorMagic, vectorVersion, byte(VectorElementFloat32), 0, 1, 0, 0, 0, 0, 0, 0, 0}
+	buf := &tdsBuffer{
+		rbuf:  append([]byte{0xaa, 0xbb}, value...),
+		rpos:  2,
+		rsize: len(value) + 2,
+		final: true,
+	}
+	ti := typeInfo{TypeId: typeVectorN, Size: len(value)}
+
+	got := readVectorType(&ti, buf, &cryptoMetadata{}, msdsn.EncodeParameters{})
+	if !bytes.Equal(got.([]byte), value) {
+		t.Fatalf("readVectorType returned %x, want %x", got, value)
+	}
+}
+
 func TestReadVectorPLPTypeRejectsOversizedPayload(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
# SQL Server 2025 VECTOR Type Support

## Overview

This PR adds native support for SQL Server 2025's VECTOR data type, enabling efficient storage and retrieval of vector embeddings for AI/ML workloads in Go applications.

The VECTOR type is designed for similarity search scenarios, storing fixed-dimensional arrays of floating-point numbers optimized for operations like `VECTOR_DISTANCE`.

## Features

### Core Types

- `Vector` - Vector type implementing `driver.Valuer` and `sql.Scanner` interfaces
- `NullVector` - Nullable wrapper for database columns that allow NULL values
- `VectorElementType` - Enum for element precision (float32/float16)

### Element Type Support

| Type | Constant | Bytes | Max Dimensions | Notes |
|------|----------|-------|----------------|-------|
| float32 | VectorElementFloat32 | 4 | 1998 | Default, fully supported |
| float16 | VectorElementFloat16 | 2 | 3996 | Preview feature, requires PREVIEW_FEATURES = ON |

### Wire Format Support

- **Binary TDS format**: Native encoding/decoding matching SQL Server's internal format
- **JSON format**: Backward-compatible parameter transmission for older drivers/servers
- **Automatic format selection**: Uses binary when supported, falls back to JSON

### Framework Compatibility

- Direct support for `[]float32` and `[]float64` parameter binding (no wrapper needed)
- `Vector` and `NullVector` types implement `sql.Scanner` for decoding binary data
- Native protocol version 1 preserves float32 and float16 result metadata
- Float16 parameters use JSON; native float16 results use the binary format
- JSON fallback has no element-type metadata: arrays through 1998 dimensions decode as float32, including short float16 columns

### Connection String Option

```
vectortypesupport=v1    # Enable native binary TDS results and float32 parameters
vectortypesupport=off   # Default: JSON format for backward compatibility
```

## API Summary

### Creating Vectors

```go
// From float32 slice (default)
v, err := mssql.NewVector([]float32{1.0, 2.0, 3.0})

// From float64 slice (converted to float32)
v, err := mssql.NewVectorFromFloat64([]float64{1.0, 2.0, 3.0})

// With explicit element type (for float16)
v, err := mssql.NewVectorWithType(mssql.VectorElementFloat16, values)
```

### Inserting Vectors

```go
// Using Vector type
_, err = db.Exec("INSERT INTO embeddings (v) VALUES (@p1)", v)

// Using []float32 directly (convenient for frameworks)
_, err = db.Exec("INSERT INTO embeddings (v) VALUES (@p1)", []float32{1.0, 2.0, 3.0})

// Using []float64 (auto-converted to float32)
_, err = db.Exec("INSERT INTO embeddings (v) VALUES (@p1)", []float64{1.0, 2.0, 3.0})
```

### Reading Vectors

```go
// To Vector type (recommended)
var v mssql.Vector
err := row.Scan(&v)
fmt.Println(v.Dimensions(), v.Values())

// Nullable columns
var nv mssql.NullVector
err := row.Scan(&nv)
if nv.Valid {
    // Use nv.Vector
}
```

### Similarity Search

```go
queryVec, _ := mssql.NewVector([]float32{1.0, 0.0, 0.0})
rows, _ := db.Query(`
    SELECT name, VECTOR_DISTANCE('cosine', embedding, CAST(@p1 AS VECTOR(3))) as distance
    FROM documents
    ORDER BY distance
`, queryVec)
```

## Files Changed

### New Files

| File | Purpose |
|------|---------|
| vector.go | Core Vector/NullVector types, encoding/decoding, float16 conversion |
| vector_test.go | Comprehensive unit tests (50+ test cases) |
| vector_db_test.go | Database integration tests with SQL Server 2025 |
| doc/how-to-use-vectors.md | Complete usage guide with examples |

### Modified Files

| File | Changes |
|------|---------|
| types.go | Added typeVectorN constant, TDS read/write functions, type metadata |
| bulkcopy.go | Added native and JSON-fallback VECTOR bulk-copy encoding, direct slice support, and validation |
| mssql.go | Vector parameter binding with binary/JSON format selection |
| mssql_go19.go | convertInputParameter for Vector types |
| tds.go | Feature extension negotiation for vector support |
| token.go | Feature ack parsing for vector support |
| msdsn/conn_str.go | vectortypesupport connection string parameter |
| msdsn/conn_str_test.go | Connection string parsing tests |
| tds_login_test.go | Login packet tests with vector feature extension |
| README.md | Added Vector to supported types list |
| .gitignore | Additional test artifact patterns |
| .github/workflows/pr-validation.yml | Interleaved benchmark sampling with matched randomized layouts to remove order and layout bias |

## Implementation Details

### TDS Protocol Integration

- New feature extension `featExtVECTORSUPPORT` (0x0E) for LOGIN7 negotiation
- Binary format: 8-byte header + float32/float16 payload
- Header structure: magic (0xA9), version (0x01), dimensions (2 bytes), element type, reserved (3 bytes)

### NULL Handling

- `NullVector{Valid: false}` sends as `NVARCHAR(1) NULL` for dimension-agnostic NULL insertion
- This workaround avoids SQL Server's requirement for matching dimensions on NULL vector parameters

### Special Value Handling

- **NaN and Infinity**: Rejected by JSON parameter paths because JSON cannot represent them as numbers
- **Precision warnings**: Optional callback for float64→float32 precision loss detection

### Thread Safety

- `SetVectorPrecisionLossHandler()` uses mutex for thread-safe handler updates
- Precision warnings fire once per vector (first loss only) for performance

### Driver Value Types

The `readVectorType` function returns `[]byte` (raw binary vector payload), which is a standard `database/sql/driver.Value` type. This follows Go database driver conventions where drivers return primitive types and custom types handle decoding via `sql.Scanner`.

Applications should scan to `Vector` or `NullVector` types, which implement `sql.Scanner` and decode the binary representation automatically.

## Testing

### Unit Tests (`go test ./...`)

- Vector encoding/decoding (float32 and float16)
- Float16 conversion accuracy
- JSON serialization/deserialization
- NULL handling
- Error cases (invalid data, unsupported types)
- Maximum dimension limits
- Type metadata functions

### Integration Tests (requires SQL Server 2025)

- Insert/select round-trips
- NULL vector handling
- Different dimension counts (1D to 500D)
- Special floating-point values
- `VECTOR_DISTANCE` similarity search
- Column metadata verification
- Batch operations
- Native and JSON-fallback bulk copy, including direct slices and NULL vectors
- Float16 with `PREVIEW_FEATURES`

### Test Coverage

- New vector-specific tests: 50+ test functions
- All existing tests continue to pass
- Graceful skip on pre-2025 SQL Server instances

## Requirements

- SQL Server 2025 or later for VECTOR type support
- go-mssqldb 1.9.7 or later
- For float16: `ALTER DATABASE SCOPED CONFIGURATION SET PREVIEW_FEATURES = ON`

## Migration Notes

- **Runtime backward compatible**: Default `vectortypesupport=off` uses JSON format
- **Source compatible**: The option is stored in the existing `msdsn.Config.Parameters` map, so the exported struct layout is unchanged
- **Opt-in optimization**: Set `vectortypesupport=v1` for native binary vector results and float32 parameters with SQL Server 2025 and later versions

## Related Documentation

- [How to Use Vectors Guide](doc/how-to-use-vectors.md)
- [SQL Server 2025 Vector Documentation](https://learn.microsoft.com/sql/relational-databases/vectors/vectors-sql-server)
- [VECTOR_DISTANCE Function](https://learn.microsoft.com/sql/t-sql/functions/vector-distance-transact-sql)

## Acknowledgments

Thanks to @shueybubbles for the review feedback that improved:
- Direct `[]float32` and `[]float64` parameter support
- Thread-safe precision warning API


---

## Connection string flag: research and decision

We asked whether this feature needs a connection string flag, and whether "breaking changes aren't
something to worry about in Go" holds. Summary of what the primary sources say.

**Go's compatibility rules cover API shape and exported struct layout, not behavior.**
[Keeping Your Modules Compatible](https://go.dev/blog/module-compatibility) gives the rule
"add, don't change or remove". The implementation keeps the exported `msdsn.Config` layout
unchanged by storing `vectortypesupport` in the existing `Parameters` map and exposing an accessor
method. Existing keyed and unkeyed literals continue to compile. The same page is explicit that
source compatibility is not the whole question:

> However, behavior changes can also break users, even if user code continues to compile.

Its worked example is `json.Decoder` and unknown fields: rather than change behaviour for everyone,
the Go team added `Decoder.DisallowUnknownFields` so that "calling this method opts a user in to the
new behavior, but not doing so preserves the old behavior for existing users."

[Go 1 and the Future of Go Programs](https://go.dev/doc/go1compat) does not extend to us. It is
scoped to "the language and ... the standard packages", is explicitly "at the source level", and
only expresses a hope that third-party modules behave similarly. No tooling detects a behavioural
regression in a v1.x minor release; `gorelease` checks API shape.

**A Go driver cannot hand back an arbitrary type.**
[`driver.Value`](https://pkg.go.dev/database/sql/driver#Value) is a closed set: `int64`,
`float64`, `bool`, `[]byte`, `string`, `time.Time`, nil. Richer types are reconstructed on the
destination side via [`sql.Scanner`](https://pkg.go.dev/database/sql#Scanner).
[`Rows.Scan`](https://pkg.go.dev/database/sql#Rows.Scan) converts within documented rules and errors
outside them. So the caller's scan destination, not the driver, decides the Go type. This is a real
difference from JDBC, where `getObject()` makes the driver's choice the caller's type.

Two places a driver's type choice does reach callers unfiltered:

- `*interface{}`, where "Scan copies the value provided by the underlying driver without conversion"
- `ColumnTypeScanType()`, which tooling reads

**The principle we settled on:**

> A connection string flag is warranted when the feature changes the bytes on the wire or carries a
> performance/compatibility trade-off the caller must choose. It is not warranted when the change is
> confined to metadata that `database/sql` already insulates callers from.

**Applied here:** vector clears that bar, so `vectortypesupport` stays. Negotiating the binary
protocol changes what the server sends. Native results preserve float32 and float16 metadata,
while float16 parameters use JSON and float32 parameters use the binary path. JDBC/ODBC already
expose `vectorTypeSupport`, so callers moving between drivers expect the same knob. Default `off`
preserves existing behaviour byte for byte.



