### PR TITLE
perf: use pointer receiver for columnStruct to avoid copy

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -198,7 +198,7 @@ type columnStruct struct {
 	cryptoMeta *cryptoMetadata
 }
 
-func (c columnStruct) isEncrypted() bool {
+func (c *columnStruct) isEncrypted() bool {
 	return isEncryptedFlag(c.Flags)
 }
 
@@ -206,7 +206,7 @@ func isEncryptedFlag(flags uint16) bool {
 	return colFlagEncrypted == (flags & colFlagEncrypted)
 }
 
-func (c columnStruct) originalTypeInfo() typeInfo {
+func (c *columnStruct) originalTypeInfo() typeInfo {
 	if c.isEncrypted() {
 		return c.cryptoMeta.typeInfo
 	}


### PR DESCRIPTION
A profile showed there were still calls to duffcopy in parseRow. The culprit turned out to be the use of a value receiver for these methods, which was necessitating a copy.