### PR TITLE
fix: use GitHub App token for release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,16 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - name: Run Release Please
+        uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56571f # v4.1.3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Problem

The release-please workflow fails with:
\\\
GitHub Actions is not permitted to create or approve pull requests
\\\

The org policy blocks enabling 'Allow GitHub Actions to create and approve pull requests' in repository settings.

## Solution

Use a GitHub App for authentication instead of \GITHUB_TOKEN\. This is also **more secure** than using a PAT:

| Feature | PAT | GitHub App |
|---------|-----|------------|
| Tied to user account | ✅ Yes (risk) | ❌ No |
| Token rotation | Manual | Automatic (1 hour) |
| Survives user leaving org | ❌ No | ✅ Yes |
| Audit trail | User actions | App-specific logs |

## Setup Required

After merging, add these repository secrets:

1. **\RELEASE_PLEASE_APP_ID\**: The GitHub App ID
2. **\RELEASE_PLEASE_APP_PRIVATE_KEY\**: The GitHub App private key (.pem file contents)

### Creating the GitHub App

1. Go to org settings → Developer settings → GitHub Apps → New GitHub App
2. Permissions needed:
   - **Contents**: Read and write
   - **Pull requests**: Read and write
3. Install the app on this repository
4. Generate a private key

## Changes

- Add \create-github-app-token\ step to generate token from App credentials
- Pin actions to commit SHAs for supply chain security
- Use app token for release-please-action

Fixes the release-please workflow failure.