### PR TITLE
feat: add nullable civil types for date/time parameters

### DIFF
--- a/civil_null.go
+++ b/civil_null.go
@@ -1,0 +1,159 @@
+package mssql
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"time"
+
+	"github.com/golang-sql/civil"
+)
+
+type NullDate struct {
+	Date  civil.Date
+	Valid bool
+}
+
+func (n *NullDate) Scan(value interface{}) error {
+	if value == nil {
+		n.Date, n.Valid = civil.Date{}, false
+		return nil
+	}
+	switch v := value.(type) {
+	case time.Time:
+		n.Valid = true
+		n.Date = civil.DateOf(v)
+		return nil
+	default:
+		return fmt.Errorf("cannot scan %T into NullDate", value)
+	}
+}
+
+func (n NullDate) Value() (driver.Value, error) {
+	if !n.Valid {
+		return nil, nil
+	}
+	return n.Date, nil
+}
+
+func (n NullDate) String() string {
+	if !n.Valid {
+		return "NULL"
+	}
+	return n.Date.String()
+}
+
+func (n NullDate) MarshalText() ([]byte, error) {
+	if !n.Valid {
+		return []byte("null"), nil
+	}
+	return n.Date.MarshalText()
+}
+
+func (n *NullDate) UnmarshalText(data []byte) error {
+	if string(data) == "null" {
+		n.Date, n.Valid = civil.Date{}, false
+		return nil
+	}
+	n.Valid = true
+	return n.Date.UnmarshalText(data)
+}
+
+type NullDateTime struct {
+	DateTime civil.DateTime
+	Valid    bool
+}
+
+func (n *NullDateTime) Scan(value interface{}) error {
+	if value == nil {
+		n.DateTime, n.Valid = civil.DateTime{}, false
+		return nil
+	}
+	switch v := value.(type) {
+	case time.Time:
+		n.Valid = true
+		n.DateTime = civil.DateTimeOf(v)
+		return nil
+	default:
+		return fmt.Errorf("cannot scan %T into NullDateTime", value)
+	}
+}
+
+func (n NullDateTime) Value() (driver.Value, error) {
+	if !n.Valid {
+		return nil, nil
+	}
+	return n.DateTime, nil
+}
+
+func (n NullDateTime) String() string {
+	if !n.Valid {
+		return "NULL"
+	}
+	return n.DateTime.String()
+}
+
+func (n NullDateTime) MarshalText() ([]byte, error) {
+	if !n.Valid {
+		return []byte("null"), nil
+	}
+	return n.DateTime.MarshalText()
+}
+
+func (n *NullDateTime) UnmarshalText(data []byte) error {
+	if string(data) == "null" {
+		n.DateTime, n.Valid = civil.DateTime{}, false
+		return nil
+	}
+	n.Valid = true
+	return n.DateTime.UnmarshalText(data)
+}
+
+type NullTime struct {
+	Time  civil.Time
+	Valid bool
+}
+
+func (n *NullTime) Scan(value interface{}) error {
+	if value == nil {
+		n.Time, n.Valid = civil.Time{}, false
+		return nil
+	}
+	switch v := value.(type) {
+	case time.Time:
+		n.Valid = true
+		n.Time = civil.TimeOf(v)
+		return nil
+	default:
+		return fmt.Errorf("cannot scan %T into NullTime", value)
+	}
+}
+
+func (n NullTime) Value() (driver.Value, error) {
+	if !n.Valid {
+		return nil, nil
+	}
+	return n.Time, nil
+}
+
+func (n NullTime) String() string {
+	if !n.Valid {
+		return "NULL"
+	}
+	return n.Time.String()
+}
+
+func (n NullTime) MarshalText() ([]byte, error) {
+	if !n.Valid {
+		return []byte("null"), nil
+	}
+	return n.Time.MarshalText()
+}
+
+func (n *NullTime) UnmarshalText(data []byte) error {
+	if string(data) == "null" {
+		n.Time, n.Valid = civil.Time{}, false
+		return nil
+	}
+	n.Valid = true
+	return n.Time.UnmarshalText(data)
+}

--- a/civil_null_integration_test.go
+++ b/civil_null_integration_test.go
@@ -1,0 +1,260 @@
+package mssql
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/golang-sql/civil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNullCivilTypesInsertAndRead(t *testing.T) {
+	db := requireTestDB(t)
+	ctx := testContext(t)
+
+	// Use a single connection because temp tables are connection-scoped
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	tableName := "#test_null_civil_types"
+	_, err = conn.ExecContext(ctx, `
+		CREATE TABLE `+tableName+` (
+			id       INT IDENTITY PRIMARY KEY,
+			d        DATE         NULL,
+			dt2      DATETIME2(7) NULL,
+			tm       TIME(7)      NULL
+		)`)
+	require.NoError(t, err)
+
+	refTime := time.Date(2025, 6, 15, 14, 30, 45, 123456700, time.UTC)
+	validDate := NullDate{Date: civil.DateOf(refTime), Valid: true}
+	validDateTime := NullDateTime{DateTime: civil.DateTimeOf(refTime), Valid: true}
+	validTime := NullTime{Time: civil.TimeOf(refTime), Valid: true}
+	nullDate := NullDate{Valid: false}
+	nullDateTime := NullDateTime{Valid: false}
+	nullTime := NullTime{Valid: false}
+
+	// Insert non-null row
+	_, err = conn.ExecContext(ctx,
+		"INSERT INTO "+tableName+" (d, dt2, tm) VALUES (@p1, @p2, @p3)",
+		validDate, validDateTime, validTime)
+	require.NoError(t, err, "insert non-null row")
+
+	// Insert null row
+	_, err = conn.ExecContext(ctx,
+		"INSERT INTO "+tableName+" (d, dt2, tm) VALUES (@p1, @p2, @p3)",
+		nullDate, nullDateTime, nullTime)
+	require.NoError(t, err, "insert null row")
+
+	// Read back both rows
+	rows, err := conn.QueryContext(ctx,
+		"SELECT d, dt2, tm FROM "+tableName+" ORDER BY id")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	// Row 1: non-null values
+	require.True(t, rows.Next(), "expected first row")
+	var gotDate NullDate
+	var gotDateTime NullDateTime
+	var gotTime NullTime
+	err = rows.Scan(&gotDate, &gotDateTime, &gotTime)
+	require.NoError(t, err, "scan non-null row")
+
+	assert.True(t, gotDate.Valid, "date should be valid")
+	assert.Equal(t, validDate.Date, gotDate.Date, "date value")
+	assert.True(t, gotDateTime.Valid, "datetime should be valid")
+	assert.Equal(t, validDateTime.DateTime.Date, gotDateTime.DateTime.Date, "datetime date part")
+	assert.Equal(t, validDateTime.DateTime.Time.Hour, gotDateTime.DateTime.Time.Hour, "datetime hour")
+	assert.Equal(t, validDateTime.DateTime.Time.Minute, gotDateTime.DateTime.Time.Minute, "datetime minute")
+	assert.Equal(t, validDateTime.DateTime.Time.Second, gotDateTime.DateTime.Time.Second, "datetime second")
+	assert.True(t, gotTime.Valid, "time should be valid")
+	assert.Equal(t, validTime.Time.Hour, gotTime.Time.Hour, "time hour")
+	assert.Equal(t, validTime.Time.Minute, gotTime.Time.Minute, "time minute")
+	assert.Equal(t, validTime.Time.Second, gotTime.Time.Second, "time second")
+
+	// Row 2: null values
+	require.True(t, rows.Next(), "expected second row")
+	var gotNullDate NullDate
+	var gotNullDateTime NullDateTime
+	var gotNullTime NullTime
+	err = rows.Scan(&gotNullDate, &gotNullDateTime, &gotNullTime)
+	require.NoError(t, err, "scan null row")
+
+	assert.False(t, gotNullDate.Valid, "date should be null")
+	assert.False(t, gotNullDateTime.Valid, "datetime should be null")
+	assert.False(t, gotNullTime.Valid, "time should be null")
+
+	assert.False(t, rows.Next(), "expected no more rows")
+	require.NoError(t, rows.Err())
+}
+
+func TestNullCivilTypesQueryRow(t *testing.T) {
+	db := requireTestDB(t)
+	ctx := testContext(t)
+
+	// Query a NULL literal cast to each type
+	var d NullDate
+	var dt NullDateTime
+	var tm NullTime
+	err := db.QueryRowContext(ctx,
+		"SELECT CAST(NULL AS DATE), CAST(NULL AS DATETIME2), CAST(NULL AS TIME)").
+		Scan(&d, &dt, &tm)
+	require.NoError(t, err)
+	assert.False(t, d.Valid, "date should be null")
+	assert.False(t, dt.Valid, "datetime should be null")
+	assert.False(t, tm.Valid, "time should be null")
+
+	// Query non-null literals
+	err = db.QueryRowContext(ctx,
+		"SELECT CAST('2025-01-15' AS DATE), CAST('2025-01-15 10:30:00' AS DATETIME2), CAST('10:30:00' AS TIME)").
+		Scan(&d, &dt, &tm)
+	require.NoError(t, err)
+	assert.True(t, d.Valid)
+	assert.Equal(t, civil.Date{Year: 2025, Month: 1, Day: 15}, d.Date)
+	assert.True(t, dt.Valid)
+	assert.Equal(t, 2025, dt.DateTime.Date.Year)
+	assert.Equal(t, time.Month(1), dt.DateTime.Date.Month)
+	assert.Equal(t, 15, dt.DateTime.Date.Day)
+	assert.True(t, tm.Valid)
+	assert.Equal(t, 10, tm.Time.Hour)
+	assert.Equal(t, 30, tm.Time.Minute)
+}
+
+func TestNullCivilTypesTVP(t *testing.T) {
+	db := requireTestDB(t)
+	ctx := testContext(t)
+
+	typeName := "test_null_civil_tvp_type"
+
+	// Clean up any existing type (ignore error)
+	db.ExecContext(ctx, "DROP TYPE IF EXISTS "+typeName)
+
+	_, err := db.ExecContext(ctx, `
+		CREATE TYPE `+typeName+` AS TABLE (
+			d   DATE         NULL,
+			dt2 DATETIME2(7) NULL,
+			tm  TIME(7)      NULL
+		)`)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		db.ExecContext(ctx, "DROP TYPE "+typeName)
+	})
+
+	type tvpRow struct {
+		D   NullDate     `tvp:"d"`
+		Dt2 NullDateTime `tvp:"dt2"`
+		Tm  NullTime     `tvp:"tm"`
+	}
+
+	refTime := time.Date(2025, 3, 20, 8, 15, 30, 0, time.UTC)
+	param := TVP{
+		TypeName: typeName,
+		Value: []tvpRow{
+			{
+				D:   NullDate{Date: civil.DateOf(refTime), Valid: true},
+				Dt2: NullDateTime{DateTime: civil.DateTimeOf(refTime), Valid: true},
+				Tm:  NullTime{Time: civil.TimeOf(refTime), Valid: true},
+			},
+			{
+				D:   NullDate{Valid: false},
+				Dt2: NullDateTime{Valid: false},
+				Tm:  NullTime{Valid: false},
+			},
+		},
+	}
+
+	rows, err := db.QueryContext(ctx,
+		"SELECT d, dt2, tm FROM @tvp ORDER BY d DESC", sql.Named("tvp", param))
+	require.NoError(t, err, "TVP query")
+	defer rows.Close()
+
+	// First row should be the non-null one (non-null date sorts after null)
+	require.True(t, rows.Next())
+	var d NullDate
+	var dt NullDateTime
+	var tm NullTime
+	err = rows.Scan(&d, &dt, &tm)
+	require.NoError(t, err, "scan TVP non-null row")
+	assert.True(t, d.Valid)
+	assert.Equal(t, civil.DateOf(refTime), d.Date)
+	assert.True(t, dt.Valid)
+	assert.True(t, tm.Valid)
+
+	// Second row should be null
+	require.True(t, rows.Next())
+	err = rows.Scan(&d, &dt, &tm)
+	require.NoError(t, err, "scan TVP null row")
+	assert.False(t, d.Valid)
+	assert.False(t, dt.Valid)
+	assert.False(t, tm.Valid)
+
+	assert.False(t, rows.Next())
+	require.NoError(t, rows.Err())
+}
+
+func TestNullCivilTypesOutputParam(t *testing.T) {
+	db := requireTestDB(t)
+	ctx := testContext(t)
+
+	// Use a single connection because temp stored procedures are connection-scoped
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	procName := "#test_null_civil_output"
+	_, err = conn.ExecContext(ctx, `
+		CREATE PROCEDURE `+procName+`
+			@outDate DATE OUTPUT,
+			@outDateTime DATETIME2 OUTPUT,
+			@outTime TIME OUTPUT,
+			@setNull BIT
+		AS
+		BEGIN
+			IF @setNull = 1
+			BEGIN
+				SET @outDate = NULL
+				SET @outDateTime = NULL
+				SET @outTime = NULL
+			END
+			ELSE
+			BEGIN
+				SET @outDate = '2025-12-25'
+				SET @outDateTime = '2025-12-25 18:00:00'
+				SET @outTime = '18:00:00'
+			END
+		END`)
+	require.NoError(t, err)
+
+	// Test non-null output
+	var d NullDate
+	var dt NullDateTime
+	var tm NullTime
+	_, err = conn.ExecContext(ctx, procName,
+		sql.Named("outDate", sql.Out{Dest: &d}),
+		sql.Named("outDateTime", sql.Out{Dest: &dt}),
+		sql.Named("outTime", sql.Out{Dest: &tm}),
+		sql.Named("setNull", false))
+	require.NoError(t, err, "exec proc with non-null output")
+	assert.True(t, d.Valid, "output date should be valid")
+	assert.Equal(t, civil.Date{Year: 2025, Month: 12, Day: 25}, d.Date)
+	assert.True(t, dt.Valid, "output datetime should be valid")
+	assert.True(t, tm.Valid, "output time should be valid")
+	assert.Equal(t, 18, tm.Time.Hour)
+
+	// Test null output
+	d = NullDate{}
+	dt = NullDateTime{}
+	tm = NullTime{}
+	_, err = conn.ExecContext(ctx, procName,
+		sql.Named("outDate", sql.Out{Dest: &d}),
+		sql.Named("outDateTime", sql.Out{Dest: &dt}),
+		sql.Named("outTime", sql.Out{Dest: &tm}),
+		sql.Named("setNull", true))
+	require.NoError(t, err, "exec proc with null output")
+	assert.False(t, d.Valid, "output date should be null")
+	assert.False(t, dt.Valid, "output datetime should be null")
+	assert.False(t, tm.Valid, "output time should be null")
+}

--- a/civil_null_test.go
+++ b/civil_null_test.go
@@ -1,0 +1,504 @@
+package mssql
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"testing"
+	"time"
+
+	"github.com/golang-sql/civil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNullDate_Scan(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		input     interface{}
+		wantDate  civil.Date
+		wantValid bool
+		wantErr   bool
+	}{
+		{
+			name:      "nil value",
+			input:     nil,
+			wantDate:  civil.Date{},
+			wantValid: false,
+		},
+		{
+			name:      "valid time.Time",
+			input:     time.Date(2023, 12, 25, 14, 30, 0, 0, time.UTC),
+			wantDate:  civil.Date{Year: 2023, Month: 12, Day: 25},
+			wantValid: true,
+		},
+		{
+			name:    "invalid type",
+			input:   "not a time",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var n NullDate
+			err := n.Scan(tc.input)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantValid, n.Valid)
+			if tc.wantValid {
+				assert.Equal(t, tc.wantDate, n.Date)
+			}
+		})
+	}
+}
+
+func TestNullDate_Value(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		nullDate  NullDate
+		wantValue driver.Value
+	}{
+		{
+			name:      "invalid returns nil",
+			nullDate:  NullDate{Valid: false},
+			wantValue: nil,
+		},
+		{
+			name:      "valid returns civil.Date",
+			nullDate:  NullDate{Date: civil.Date{Year: 2023, Month: 12, Day: 25}, Valid: true},
+			wantValue: civil.Date{Year: 2023, Month: 12, Day: 25},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.nullDate.Value()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantValue, got)
+		})
+	}
+}
+
+func TestNullDateTime_Scan(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		input        interface{}
+		wantDateTime civil.DateTime
+		wantValid    bool
+		wantErr      bool
+	}{
+		{
+			name:         "nil value",
+			input:        nil,
+			wantDateTime: civil.DateTime{},
+			wantValid:    false,
+		},
+		{
+			name:  "valid time.Time",
+			input: time.Date(2023, 12, 25, 14, 30, 45, 0, time.UTC),
+			wantDateTime: civil.DateTime{
+				Date: civil.Date{Year: 2023, Month: 12, Day: 25},
+				Time: civil.Time{Hour: 14, Minute: 30, Second: 45},
+			},
+			wantValid: true,
+		},
+		{
+			name:    "invalid type",
+			input:   123,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var n NullDateTime
+			err := n.Scan(tc.input)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantValid, n.Valid)
+			if tc.wantValid {
+				assert.Equal(t, tc.wantDateTime, n.DateTime)
+			}
+		})
+	}
+}
+
+func TestNullDateTime_Value(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		nullDateTime NullDateTime
+		wantValue    driver.Value
+	}{
+		{
+			name:         "invalid returns nil",
+			nullDateTime: NullDateTime{Valid: false},
+			wantValue:    nil,
+		},
+		{
+			name: "valid returns civil.DateTime",
+			nullDateTime: NullDateTime{
+				DateTime: civil.DateTime{
+					Date: civil.Date{Year: 2023, Month: 12, Day: 25},
+					Time: civil.Time{Hour: 14, Minute: 30, Second: 45},
+				},
+				Valid: true,
+			},
+			wantValue: civil.DateTime{
+				Date: civil.Date{Year: 2023, Month: 12, Day: 25},
+				Time: civil.Time{Hour: 14, Minute: 30, Second: 45},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.nullDateTime.Value()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantValue, got)
+		})
+	}
+}
+
+func TestNullTime_Scan(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		input     interface{}
+		wantTime  civil.Time
+		wantValid bool
+		wantErr   bool
+	}{
+		{
+			name:      "nil value",
+			input:     nil,
+			wantTime:  civil.Time{},
+			wantValid: false,
+		},
+		{
+			name:      "valid time.Time",
+			input:     time.Date(2023, 12, 25, 14, 30, 45, 123000000, time.UTC),
+			wantTime:  civil.Time{Hour: 14, Minute: 30, Second: 45, Nanosecond: 123000000},
+			wantValid: true,
+		},
+		{
+			name:    "invalid type",
+			input:   []byte{1, 2, 3},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var n NullTime
+			err := n.Scan(tc.input)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantValid, n.Valid)
+			if tc.wantValid {
+				assert.Equal(t, tc.wantTime, n.Time)
+			}
+		})
+	}
+}
+
+func TestNullTime_Value(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		nullTime  NullTime
+		wantValue driver.Value
+	}{
+		{
+			name:      "invalid returns nil",
+			nullTime:  NullTime{Valid: false},
+			wantValue: nil,
+		},
+		{
+			name:      "valid returns civil.Time",
+			nullTime:  NullTime{Time: civil.Time{Hour: 14, Minute: 30, Second: 45}, Valid: true},
+			wantValue: civil.Time{Hour: 14, Minute: 30, Second: 45},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.nullTime.Value()
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantValue, got)
+		})
+	}
+}
+
+func TestNullDate_String(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "NULL", NullDate{Valid: false}.String())
+	assert.Equal(t, "2023-12-25", NullDate{Date: civil.Date{Year: 2023, Month: 12, Day: 25}, Valid: true}.String())
+}
+
+func TestNullDateTime_String(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "NULL", NullDateTime{Valid: false}.String())
+	assert.Equal(t, "2023-12-25T14:30:45", NullDateTime{
+		DateTime: civil.DateTime{
+			Date: civil.Date{Year: 2023, Month: 12, Day: 25},
+			Time: civil.Time{Hour: 14, Minute: 30, Second: 45},
+		},
+		Valid: true,
+	}.String())
+}
+
+func TestNullTime_String(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "NULL", NullTime{Valid: false}.String())
+	assert.Equal(t, "14:30:45", NullTime{Time: civil.Time{Hour: 14, Minute: 30, Second: 45}, Valid: true}.String())
+}
+
+func TestNullDate_MarshalText(t *testing.T) {
+	t.Parallel()
+	text, err := NullDate{Valid: false}.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, []byte("null"), text)
+
+	text, err = NullDate{Date: civil.Date{Year: 2023, Month: 12, Day: 25}, Valid: true}.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, []byte("2023-12-25"), text)
+}
+
+func TestNullDateTime_MarshalText(t *testing.T) {
+	t.Parallel()
+	text, err := NullDateTime{Valid: false}.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, []byte("null"), text)
+
+	text, err = NullDateTime{
+		DateTime: civil.DateTime{
+			Date: civil.Date{Year: 2023, Month: 12, Day: 25},
+			Time: civil.Time{Hour: 14, Minute: 30, Second: 45},
+		},
+		Valid: true,
+	}.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, []byte("2023-12-25T14:30:45"), text)
+}
+
+func TestNullTime_MarshalText(t *testing.T) {
+	t.Parallel()
+	text, err := NullTime{Valid: false}.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, []byte("null"), text)
+
+	text, err = NullTime{Time: civil.Time{Hour: 14, Minute: 30, Second: 45}, Valid: true}.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, []byte("14:30:45"), text)
+}
+
+func TestNullDate_UnmarshalText(t *testing.T) {
+	t.Parallel()
+	var n NullDate
+	require.NoError(t, n.UnmarshalText([]byte("null")))
+	assert.False(t, n.Valid)
+
+	require.NoError(t, n.UnmarshalText([]byte("2023-12-25")))
+	assert.True(t, n.Valid)
+	assert.Equal(t, civil.Date{Year: 2023, Month: 12, Day: 25}, n.Date)
+
+	assert.Error(t, n.UnmarshalText([]byte("not-a-date")))
+}
+
+func TestNullDateTime_UnmarshalText(t *testing.T) {
+	t.Parallel()
+	var n NullDateTime
+	require.NoError(t, n.UnmarshalText([]byte("null")))
+	assert.False(t, n.Valid)
+
+	require.NoError(t, n.UnmarshalText([]byte("2023-12-25T14:30:45")))
+	assert.True(t, n.Valid)
+	assert.Equal(t, civil.DateTime{
+		Date: civil.Date{Year: 2023, Month: 12, Day: 25},
+		Time: civil.Time{Hour: 14, Minute: 30, Second: 45},
+	}, n.DateTime)
+
+	assert.Error(t, n.UnmarshalText([]byte("not-a-datetime")))
+}
+
+func TestNullTime_UnmarshalText(t *testing.T) {
+	t.Parallel()
+	var n NullTime
+	require.NoError(t, n.UnmarshalText([]byte("null")))
+	assert.False(t, n.Valid)
+
+	require.NoError(t, n.UnmarshalText([]byte("14:30:45")))
+	assert.True(t, n.Valid)
+	assert.Equal(t, civil.Time{Hour: 14, Minute: 30, Second: 45}, n.Time)
+
+	assert.Error(t, n.UnmarshalText([]byte("not-a-time")))
+}
+
+func TestConvertInputParameter_NullCivilTypes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NullDate valid", func(t *testing.T) {
+		input := NullDate{Date: civil.Date{Year: 2023, Month: 12, Day: 25}, Valid: true}
+		got, err := convertInputParameter(input)
+		require.NoError(t, err)
+		assert.Equal(t, civil.Date{Year: 2023, Month: 12, Day: 25}, got)
+	})
+
+	t.Run("NullDate invalid", func(t *testing.T) {
+		input := NullDate{Valid: false}
+		got, err := convertInputParameter(input)
+		require.NoError(t, err)
+		assert.Equal(t, input, got)
+	})
+
+	t.Run("NullDateTime valid", func(t *testing.T) {
+		input := NullDateTime{
+			DateTime: civil.DateTime{
+				Date: civil.Date{Year: 2023, Month: 12, Day: 25},
+				Time: civil.Time{Hour: 14, Minute: 30, Second: 45},
+			},
+			Valid: true,
+		}
+		got, err := convertInputParameter(input)
+		require.NoError(t, err)
+		assert.Equal(t, input.DateTime, got)
+	})
+
+	t.Run("NullDateTime invalid", func(t *testing.T) {
+		input := NullDateTime{Valid: false}
+		got, err := convertInputParameter(input)
+		require.NoError(t, err)
+		assert.Equal(t, input, got)
+	})
+
+	t.Run("NullTime valid", func(t *testing.T) {
+		input := NullTime{Time: civil.Time{Hour: 14, Minute: 30, Second: 45}, Valid: true}
+		got, err := convertInputParameter(input)
+		require.NoError(t, err)
+		assert.Equal(t, civil.Time{Hour: 14, Minute: 30, Second: 45}, got)
+	})
+
+	t.Run("NullTime invalid", func(t *testing.T) {
+		input := NullTime{Valid: false}
+		got, err := convertInputParameter(input)
+		require.NoError(t, err)
+		assert.Equal(t, input, got)
+	})
+}
+
+func TestMakeParam_NullCivilTypes(t *testing.T) {
+	t.Parallel()
+	s := &Stmt{}
+
+	t.Run("NullDate null", func(t *testing.T) {
+		res, err := s.makeParam(NullDate{Valid: false})
+		require.NoError(t, err)
+		assert.Equal(t, uint8(typeDateN), res.ti.TypeId)
+		assert.Equal(t, 3, res.ti.Size)
+		assert.Empty(t, res.buffer)
+	})
+
+	t.Run("NullDateTime null", func(t *testing.T) {
+		res, err := s.makeParam(NullDateTime{Valid: false})
+		require.NoError(t, err)
+		assert.Equal(t, uint8(typeDateTime2N), res.ti.TypeId)
+		assert.Equal(t, uint8(7), res.ti.Scale)
+		assert.Equal(t, 8, res.ti.Size)
+		assert.Empty(t, res.buffer)
+	})
+
+	t.Run("NullTime null", func(t *testing.T) {
+		res, err := s.makeParam(NullTime{Valid: false})
+		require.NoError(t, err)
+		assert.Equal(t, uint8(typeTimeN), res.ti.TypeId)
+		assert.Equal(t, uint8(7), res.ti.Scale)
+		assert.Equal(t, 5, res.ti.Size)
+		assert.Empty(t, res.buffer)
+	})
+}
+
+func TestCreateZeroType_NullCivilTypes(t *testing.T) {
+	t.Parallel()
+	tvp := TVP{}
+
+	t.Run("NullDate returns zero civil.Date", func(t *testing.T) {
+		result := tvp.createZeroType(NullDate{})
+		assert.Equal(t, civil.Date{}, result)
+	})
+
+	t.Run("NullDateTime returns zero civil.DateTime", func(t *testing.T) {
+		result := tvp.createZeroType(NullDateTime{})
+		assert.Equal(t, civil.DateTime{}, result)
+	})
+
+	t.Run("NullTime returns zero civil.Time", func(t *testing.T) {
+		result := tvp.createZeroType(NullTime{})
+		assert.Equal(t, civil.Time{}, result)
+	})
+}
+
+func TestVerifyStandardTypeOnNull_NullCivilTypes(t *testing.T) {
+	t.Parallel()
+	tvp := TVP{}
+
+	t.Run("NullDate null writes null byte", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := tvp.verifyStandardTypeOnNull(&buf, NullDate{Valid: false})
+		assert.True(t, result)
+		assert.Equal(t, []byte{0}, buf.Bytes())
+	})
+
+	t.Run("NullDate valid returns false", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := tvp.verifyStandardTypeOnNull(&buf, NullDate{Valid: true})
+		assert.False(t, result)
+		assert.Empty(t, buf.Bytes())
+	})
+
+	t.Run("NullDateTime null writes null byte", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := tvp.verifyStandardTypeOnNull(&buf, NullDateTime{Valid: false})
+		assert.True(t, result)
+		assert.Equal(t, []byte{0}, buf.Bytes())
+	})
+
+	t.Run("NullDateTime valid returns false", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := tvp.verifyStandardTypeOnNull(&buf, NullDateTime{Valid: true})
+		assert.False(t, result)
+		assert.Empty(t, buf.Bytes())
+	})
+
+	t.Run("NullTime null writes null byte", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := tvp.verifyStandardTypeOnNull(&buf, NullTime{Valid: false})
+		assert.True(t, result)
+		assert.Equal(t, []byte{0}, buf.Bytes())
+	})
+
+	t.Run("NullTime valid returns false", func(t *testing.T) {
+		var buf bytes.Buffer
+		result := tvp.verifyStandardTypeOnNull(&buf, NullTime{Valid: true})
+		assert.False(t, result)
+		assert.Empty(t, buf.Bytes())
+	})
+}

--- a/mssql.go
+++ b/mssql.go
@@ -1228,6 +1228,20 @@ func (s *Stmt) makeParam(val driver.Value) (res param, err error) {
 		} else {
 			res.ti.TypeId = typeDateTimeN
 		}
+	case NullDate:
+		res.buffer = []byte{}
+		res.ti.TypeId = typeDateN
+		res.ti.Size = 3
+	case NullDateTime:
+		res.buffer = []byte{}
+		res.ti.TypeId = typeDateTime2N
+		res.ti.Scale = 7
+		res.ti.Size = 8
+	case NullTime:
+		res.buffer = []byte{}
+		res.ti.TypeId = typeTimeN
+		res.ti.Scale = 7
+		res.ti.Size = 5
 	case driver.Valuer:
 		// We have a custom Valuer implementation with a nil value
 		return s.makeParam(nil)

--- a/mssql_go19.go
+++ b/mssql_go19.go
@@ -73,6 +73,21 @@ func convertInputParameter(val interface{}) (interface{}, error) {
 		return val, nil
 	case civil.Time:
 		return val, nil
+	case NullDate:
+		if v.Valid {
+			return v.Date, nil
+		}
+		return val, nil
+	case NullDateTime:
+		if v.Valid {
+			return v.DateTime, nil
+		}
+		return val, nil
+	case NullTime:
+		if v.Valid {
+			return v.Time, nil
+		}
+		return val, nil
 	// case *apd.Decimal:
 	// 	return nil
 	case float32:

--- a/tvp_go19.go
+++ b/tvp_go19.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang-sql/civil"
 	"github.com/microsoft/go-mssqldb/msdsn"
 )
 
@@ -279,6 +280,12 @@ func (tvp TVP) createZeroType(fieldVal interface{}) interface{} {
 		return defaultInt64
 	case sql.NullString:
 		return defaultString
+	case NullDate:
+		return civil.Date{}
+	case NullDateTime:
+		return civil.DateTime{}
+	case NullTime:
+		return civil.Time{}
 	}
 	return fieldVal
 }
@@ -308,6 +315,21 @@ func (tvp TVP) verifyStandardTypeOnNull(buf *bytes.Buffer, tvpVal interface{}) b
 	case sql.NullString:
 		if !val.Valid {
 			binary.Write(buf, binary.LittleEndian, uint64(_PLP_NULL))
+			return true
+		}
+	case NullDate:
+		if !val.Valid {
+			binary.Write(buf, binary.LittleEndian, defaultNull)
+			return true
+		}
+	case NullDateTime:
+		if !val.Valid {
+			binary.Write(buf, binary.LittleEndian, defaultNull)
+			return true
+		}
+	case NullTime:
+		if !val.Valid {
+			binary.Write(buf, binary.LittleEndian, defaultNull)
 			return true
 		}
 	}


### PR DESCRIPTION
## Problem

Users passing `civil.Date`, `civil.DateTime`, or `civil.Time` as query parameters have no way to represent NULL. The stdlib pattern for this is `sql.NullString`, `sql.NullInt64`, etc., but no nullable wrappers exist for the civil types in this driver.

Reported in #289.

## Solution

Add `NullDate`, `NullDateTime`, and `NullTime` types following the same `{Value, Valid}` pattern as `sql.NullString` and the existing `NullUniqueIdentifier`.

Wire them through the driver's parameter pipeline:
- `convertInputParameter` unwraps valid values to their inner civil type; invalid values pass through as-is
- `makeParam` encodes null values with the correct TDS type metadata (typeDateN, typeDateTime2N, typeTimeN)
- TVP support via `createZeroType` and `verifyStandardTypeOnNull`

Each type also implements `String()`, `MarshalText()`, and `UnmarshalText()` for text serialization, matching the `NullUniqueIdentifier` pattern.

## Changes

| File | Change |
|------|--------|
| civil_null.go | `NullDate`, `NullDateTime`, `NullTime` types with `Scanner`/`Valuer`, `String`/`MarshalText`/`UnmarshalText` |
| mssql_go19.go | Handle nullable civil types in `convertInputParameter` |
| mssql.go | Handle null encoding in `makeParam` |
| tvp_go19.go | TVP null handling via `createZeroType` and `verifyStandardTypeOnNull` |
| civil_null_test.go | Unit tests: Scan/Value, String, MarshalText, UnmarshalText, convertInputParameter, makeParam, TVP helpers |
| civil_null_integration_test.go | Integration tests: insert/read, QueryRow, TVP, output parameters |

## Testing

- Unit tests pass without SQL Server: `go test -run 'TestNullDate_|TestNullDateTime_|TestNullTime_|TestConvertInput|TestMakeParam|TestCreateZeroType|TestVerifyStandard' -v`
- Integration tests cover insert/read, QueryRow NULL literals, TVP with nulls, and stored procedure output parameters

Closes #289