### PR TITLE
feat: add FailoverPartnerSPN connection string parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Other supported formats are listed below.
 * `keepAlive` - in seconds; 0 to disable (default is 30)
 * `failoverpartner` - host or host\instance (default is no partner).
 * `failoverport` - used only when there is no instance in failoverpartner (default 1433)
+* `FailoverPartnerSPN` - The kerberos SPN (Service Principal Name) for the failover partner. Default is MSSQLSvc/host:port.
 * `packet size` - in bytes; 512 to 32767 (default is 4096)
   * Encrypted connections have a maximum packet size of 16383 bytes
   * Further information on usage: <https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/configure-the-network-packet-size-server-configuration-option>

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Other supported formats are listed below.
 * `keepAlive` - in seconds; 0 to disable (default is 30)
 * `failoverpartner` - host or host\instance (default is no partner).
 * `failoverport` - used only when there is no instance in failoverpartner (default 1433)
-* `FailoverPartnerSPN` - The kerberos SPN (Service Principal Name) for the failover partner. Default is MSSQLSvc/host:port.
+* `FailoverPartnerSPN` - The kerberos SPN (Service Principal Name) for the failover partner. Default is MSSQLSvc/host:(port\|instance), matching how the driver generates `ServerSPN`.
 * `packet size` - in bytes; 512 to 32767 (default is 4096)
   * Encrypted connections have a maximum packet size of 16383 bytes
   * Further information on usage: <https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/configure-the-network-packet-size-server-configuration-option>

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Other supported formats are listed below.
 * `keepAlive` - in seconds; 0 to disable (default is 30)
 * `failoverpartner` - host or host\instance (default is no partner).
 * `failoverport` - used only when there is no instance in failoverpartner (default 1433)
-* `FailoverPartnerSPN` - The kerberos SPN (Service Principal Name) for the failover partner. Default is MSSQLSvc/host:(port\|instance), matching how the driver generates `ServerSPN`.
+* `failoverpartnerspn` - The kerberos SPN (Service Principal Name) for the failover partner. Default is MSSQLSvc/host:(port|instance), matching how the driver generates `ServerSPN`.
 * `packet size` - in bytes; 512 to 32767 (default is 4096)
   * Encrypted connections have a maximum packet size of 16383 bytes
   * Further information on usage: <https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/configure-the-network-packet-size-server-configuration-option>

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -79,6 +79,7 @@ const (
 	ApplicationIntent      = "applicationintent"
 	FailoverPartner        = "failoverpartner"
 	FailOverPort           = "failoverport"
+	FailoverPartnerSpn     = "failoverpartnerspn"
 	DisableRetry           = "disableretry"
 	Server                 = "server"
 	Protocol               = "protocol"
@@ -115,8 +116,9 @@ type Config struct {
 	Encryption Encryption
 	TLSConfig  *tls.Config
 
-	FailOverPartner string
-	FailOverPort    uint64
+	FailOverPartner    string
+	FailOverPort       uint64
+	FailOverPartnerSPN string
 
 	// If true the TLSConfig servername should use the routed server.
 	HostInCertificateProvided bool
@@ -526,6 +528,11 @@ func Parse(dsn string) (Config, error) {
 			f := "invalid failover port '%v': %v"
 			return p, fmt.Errorf(f, failOverPort, err.Error())
 		}
+	}
+
+	failOverPartnerSPN, ok := params[FailoverPartnerSpn]
+	if ok {
+		p.FailOverPartnerSPN = failOverPartnerSPN
 	}
 
 	disableRetry, ok := params[DisableRetry]

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -732,6 +732,19 @@ func (p Config) URL() *url.URL {
 		q.Add(Timezone, tz.String())
 	}
 
+	if p.FailOverPartner != "" {
+		q.Add(FailoverPartner, p.FailOverPartner)
+	}
+	if p.FailOverPort != 0 {
+		q.Add(FailOverPort, strconv.FormatUint(p.FailOverPort, 10))
+	}
+	if p.ServerSPN != "" {
+		q.Add(ServerSpn, p.ServerSPN)
+	}
+	if p.FailOverPartnerSPN != "" {
+		q.Add(FailoverPartnerSpn, p.FailOverPartnerSPN)
+	}
+
 	if len(q) > 0 {
 		res.RawQuery = q.Encode()
 	}

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -373,6 +373,27 @@ func TestURLWithIPv6Address(t *testing.T) {
 	}
 }
 
+func TestConnParseRoundTripFailoverPartnerSPN(t *testing.T) {
+	connStr := "sqlserver://sa:sa@localhost?database=master&failoverpartner=mirror&failoverport=2000&serverspn=MSSQLSvc%2Fprimary%3A1433&failoverpartnerspn=MSSQLSvc%2Fmirror%3A2000&disableretry=true&dial+timeout=30"
+	params, err := Parse(connStr)
+	if err != nil {
+		t.Fatal("Test URL is not valid", err)
+	}
+	if params.FailOverPartner != "mirror" || params.FailOverPort != 2000 || params.FailOverPartnerSPN != "MSSQLSvc/mirror:2000" || params.ServerSPN != "MSSQLSvc/primary:1433" {
+		t.Fatal("Initial parse did not set failover fields correctly")
+	}
+	rtParams, err := Parse(params.URL().String())
+	if err != nil {
+		t.Fatal("Params after roundtrip are not valid", err)
+	}
+	t.Log("params.URL " + params.URL().String())
+	params.ActivityID = nil
+	rtParams.ActivityID = nil
+	if !reflect.DeepEqual(params, rtParams) {
+		t.Fatal("Parameters do not match after roundtrip", params, rtParams)
+	}
+}
+
 func TestServerNameInTLSConfig(t *testing.T) {
 	var tests = []struct {
 		dsn          string

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -386,7 +386,6 @@ func TestConnParseRoundTripFailoverPartnerSPN(t *testing.T) {
 	if err != nil {
 		t.Fatal("Params after roundtrip are not valid", err)
 	}
-	t.Log("params.URL " + params.URL().String())
 	params.ActivityID = nil
 	rtParams.ActivityID = nil
 	if !reflect.DeepEqual(params, rtParams) {

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -102,6 +102,10 @@ func TestValidConnectionString(t *testing.T) {
 		{"server=(local)", func(p Config) bool { return p.Host == "localhost" }},
 		{"ServerSPN=serverspn;Workstation ID=workstid", func(p Config) bool { return p.ServerSPN == "serverspn" && p.Workstation == "workstid" }},
 		{"failoverpartner=fopartner;failoverport=2000", func(p Config) bool { return p.FailOverPartner == "fopartner" && p.FailOverPort == 2000 }},
+		{"failoverpartner=fopartner;failoverport=2000;FailoverPartnerSPN=MSSQLSvc/fopartner:2000", func(p Config) bool {
+			return p.FailOverPartner == "fopartner" && p.FailOverPort == 2000 && p.FailOverPartnerSPN == "MSSQLSvc/fopartner:2000"
+		}},
+		{"FailoverPartnerSPN=MSSQLSvc/mirror:1433", func(p Config) bool { return p.FailOverPartnerSPN == "MSSQLSvc/mirror:1433" }},
 		{"app name=appname;applicationintent=ReadOnly;database=testdb", func(p Config) bool { return p.AppName == "appname" && p.ReadOnlyIntent }},
 		{"encrypt=disable", func(p Config) bool { return p.Encryption == EncryptionDisabled }},
 		{"encrypt=disable;tlsmin=1.1", func(p Config) bool { return p.Encryption == EncryptionDisabled && p.TLSConfig == nil }},

--- a/mssql.go
+++ b/mssql.go
@@ -432,6 +432,9 @@ func (d *Driver) connect(ctx context.Context, c *Connector, params msdsn.Config)
 		if params.FailOverPort != 0 {
 			params.Port = params.FailOverPort
 		}
+		if params.FailOverPartnerSPN != "" {
+			params.ServerSPN = params.FailOverPartnerSPN
+		}
 
 		sess, err = connect(ctx, c, d.logger, params)
 		if err != nil {

--- a/mssql.go
+++ b/mssql.go
@@ -419,24 +419,32 @@ func (d *Driver) open(ctx context.Context, dsn string) (*Conn, error) {
 	return d.connect(ctx, c, params)
 }
 
+
+func failoverPartnerParams(params msdsn.Config) *msdsn.Config {
+	if params.FailOverPartner == "" {
+		return nil
+	}
+	params.Host = params.FailOverPartner
+	if params.FailOverPort != 0 {
+		params.Port = params.FailOverPort
+	}
+	if params.FailOverPartnerSPN != "" {
+		params.ServerSPN = params.FailOverPartnerSPN
+	}
+	return &params
+}
+
 // connect to the server, using the provided context for dialing only.
 func (d *Driver) connect(ctx context.Context, c *Connector, params msdsn.Config) (*Conn, error) {
 	sess, err := connect(ctx, c, d.logger, params)
 	if err != nil {
 		// main server failed, try fail-over partner
-		if params.FailOverPartner == "" {
+		foParams := failoverPartnerParams(params)
+		if foParams == nil {
 			return nil, err
 		}
 
-		params.Host = params.FailOverPartner
-		if params.FailOverPort != 0 {
-			params.Port = params.FailOverPort
-		}
-		if params.FailOverPartnerSPN != "" {
-			params.ServerSPN = params.FailOverPartnerSPN
-		}
-
-		sess, err = connect(ctx, c, d.logger, params)
+		sess, err = connect(ctx, c, d.logger, *foParams)
 		if err != nil {
 			// fail-over partner also failed, now fail
 			return nil, err

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -94,6 +94,99 @@ func TestConvertIsolationLevel(t *testing.T) {
 	}
 }
 
+func TestFailoverPartnerParamsReturnsNilWhenNoPartner(t *testing.T) {
+	params := msdsn.Config{
+		Host:      "primary",
+		Port:      1433,
+		ServerSPN: "MSSQLSvc/primary:1433",
+	}
+
+	result := failoverPartnerParams(params)
+	if result != nil {
+		t.Fatal("expected nil when no failover partner is set, got non-nil result")
+	}
+}
+
+func TestFailoverPartnerParams(t *testing.T) {
+	tests := []struct {
+		name         string
+		params       msdsn.Config
+		expectedHost string
+		expectedPort uint64
+		expectedSPN  string
+	}{
+		{
+			name: "FailoverPartnerSPN overrides ServerSPN",
+			params: msdsn.Config{
+				Host:               "primary",
+				Port:               1033,
+				FailOverPartner:    "mirror",
+				ServerSPN:          "MSSQLSvc/primary",
+				FailOverPartnerSPN: "MSSQLSvc/mirror",
+			},
+			expectedHost: "mirror",
+			expectedPort: 1033,
+			expectedSPN:  "MSSQLSvc/mirror",
+		},
+		{
+			name: "ServerSPN preserved when FailoverPartnerSPN not set",
+			params: msdsn.Config{
+				Host:            "primary",
+				Port:            1033,
+				FailOverPartner: "mirror",
+				ServerSPN:       "MSSQLSvc/unique-spn",
+			},
+			expectedHost: "mirror",
+			expectedPort: 1033,
+			expectedSPN:  "MSSQLSvc/unique-spn",
+		},
+		{
+			name: "FailOverPort overrides Port",
+			params: msdsn.Config{
+				Host:               "primary",
+				Port:               1033,
+				FailOverPartner:    "mirror",
+				FailOverPort:       2033,
+				ServerSPN:          "MSSQLSvc/unique-spn",
+			},
+			expectedHost: "mirror",
+			expectedPort: 2033,
+			expectedSPN:  "MSSQLSvc/unique-spn",
+		},
+		{
+			name: "Port preserved when FailOverPort not set",
+			params: msdsn.Config{
+				Host:               "primary",
+				Port:               1033,
+				FailOverPartner:    "mirror",
+				ServerSPN:          "MSSQLSvc/unique-spn",
+			},
+			expectedHost: "mirror",
+			expectedPort: 1033,
+			expectedSPN:  "MSSQLSvc/unique-spn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := failoverPartnerParams(tt.params)
+
+			if result == nil {
+				t.Fatal("expected non-nil result, got nil")
+			}
+			if result.Host != tt.expectedHost {
+				t.Errorf("Host = %q, want %q", result.Host, tt.expectedHost)
+			}
+			if result.Port != tt.expectedPort {
+				t.Errorf("Port = %d, want %d", result.Port, tt.expectedPort)
+			}
+			if result.ServerSPN != tt.expectedSPN {
+				t.Errorf("ServerSPN = %q, want %q", result.ServerSPN, tt.expectedSPN)
+			}
+		})
+	}
+}
+
 // equalErrors is a helper function that compares two errors
 // by comparing their nilness, underlying type, and Error messages
 func equalErrors(e1 error, e2 error) bool {


### PR DESCRIPTION
Add support for specifying a custom Service Principal Name (SPN) for the failover partner, matching the behavior of Microsoft.Data.SqlClient's SqlConnectionStringBuilder.FailoverPartnerSPN property.

When using Kerberos with database mirroring / Basic Availability Groups, the failover partner may require a different SPN than the primary server. This parameter allows users to explicitly set it. If not specified, the SPN is auto-generated from the failover partner host and port.

Ref: https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlconnectionstringbuilder.failoverpartnerspn