### PR TITLE
ci: add devcontainer build validation workflow

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -7,10 +7,53 @@ on:
     paths:
       - '.devcontainer/**'
       - '.dockerignore'
+      - 'go.mod'
 
 permissions: {}
 
 jobs:
+  check-go-version-alignment:
+    name: Verify Go version alignment
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # actions/checkout v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Verify Dockerfile Go version satisfies go.mod
+        run: |
+          # Extract the major.minor Go version required by go.mod
+          GOMOD_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
+          GOMOD_MAJOR_MINOR=$(echo "$GOMOD_VERSION" | grep -oE '^[0-9]+\.[0-9]+')
+
+          # Extract the Go version from the Dockerfile base image tag
+          DOCKERFILE_TAG=$(grep -oP 'devcontainers/go:\K[0-9]+\.[0-9]+' .devcontainer/Dockerfile)
+
+          echo "go.mod requires:        go ${GOMOD_VERSION} (major.minor: ${GOMOD_MAJOR_MINOR})"
+          echo "Dockerfile base image:  go:${DOCKERFILE_TAG}"
+
+          if [[ -z "$GOMOD_MAJOR_MINOR" || -z "$DOCKERFILE_TAG" ]]; then
+            echo "ERROR: Could not parse versions"
+            exit 1
+          fi
+
+          if [[ "$GOMOD_MAJOR_MINOR" != "$DOCKERFILE_TAG" ]]; then
+            echo ""
+            echo "ERROR: Version mismatch!"
+            echo "The devcontainer base image (go:${DOCKERFILE_TAG}) does not match"
+            echo "the Go version required by go.mod (${GOMOD_MAJOR_MINOR})."
+            echo ""
+            echo "Update .devcontainer/Dockerfile:"
+            echo "  FROM mcr.microsoft.com/devcontainers/go:${GOMOD_MAJOR_MINOR}-bookworm"
+            echo ""
+            echo "You may also need to update the pinned Go tool versions in the Dockerfile"
+            echo "(gopls, delve, staticcheck) to versions compatible with Go ${GOMOD_MAJOR_MINOR}."
+            exit 1
+          fi
+
+          echo "OK: Versions are aligned."
+
   build:
     name: Build devcontainer
     runs-on: ubuntu-latest

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,28 @@
+name: devcontainer
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.devcontainer/**'
+      - '.dockerignore'
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build devcontainer
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # actions/checkout v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Build devcontainer image
+        # devcontainers/ci v0.3
+        uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5 # v0.3
+        with:
+          imageName: go-mssqldb-devcontainer
+          push: never

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -7,7 +7,17 @@ on:
     paths:
       - '.devcontainer/**'
       - '.dockerignore'
+      - '.github/workflows/devcontainer.yml'
       - 'go.mod'
+  push:
+    branches:
+      - main
+    paths:
+      - '.devcontainer/**'
+      - '.dockerignore'
+      - '.github/workflows/devcontainer.yml'
+      - 'go.mod'
+  workflow_dispatch:
 
 permissions: {}
 
@@ -28,7 +38,7 @@ jobs:
           GOMOD_MAJOR_MINOR=$(echo "$GOMOD_VERSION" | grep -oE '^[0-9]+\.[0-9]+')
 
           # Extract the Go version from the Dockerfile base image tag
-          DOCKERFILE_TAG=$(grep -oP 'devcontainers/go:\K[0-9]+\.[0-9]+' .devcontainer/Dockerfile)
+          DOCKERFILE_TAG=$(sed -n 's/.*devcontainers\/go:\([0-9]*\.[0-9]*\).*/\1/p' .devcontainer/Dockerfile)
 
           echo "go.mod requires:        go ${GOMOD_VERSION} (major.minor: ${GOMOD_MAJOR_MINOR})"
           echo "Dockerfile base image:  go:${DOCKERFILE_TAG}"


### PR DESCRIPTION
Adds a CI workflow that validates the devcontainer on PRs that touch `.devcontainer/**`, `.dockerignore`, or `go.mod`.

## Jobs

### check-go-version-alignment
Verifies the Go major.minor version in `.devcontainer/Dockerfile` matches the `go` directive in `go.mod`. Fails with actionable guidance if they drift apart. Matches the guard from go-sqlcmd's `devcontainer-check.yml`.

### build
Builds the devcontainer image using `devcontainers/ci@v0.3` (SHA-pinned) with `push: never` (build-only, no registry push).

## Security
- `permissions: {}` at workflow level with `contents: read` on each job
- All actions SHA-pinned per repo conventions
