### PR TITLE
test: cover startResponseReader serialization against concurrent buffer reads

### DIFF
--- a/token_test.go
+++ b/token_test.go
@@ -471,11 +471,18 @@ func TestNextToken_CancelDrainClosedChannelStartsSecondResponse(t *testing.T) {
 }
 
 // blockingTransport blocks Read until unblock is closed, then returns EOF.
+// It signals readEntered when a Read call begins, allowing deterministic
+// synchronization without time.Sleep.
 type blockingTransport struct {
-	unblock chan struct{}
+	unblock     chan struct{}
+	readEntered chan struct{}
 }
 
 func (b *blockingTransport) Read([]byte) (int, error) {
+	select {
+	case b.readEntered <- struct{}{}:
+	default:
+	}
 	<-b.unblock
 	return 0, io.EOF
 }
@@ -487,14 +494,24 @@ func (b *blockingTransport) Close() error                 { return nil }
 // the previous goroutine to finish before launching a new one.
 func TestStartResponseReaderSerializes(t *testing.T) {
 	// First reader: transport blocks until we say so.
+	readEntered := make(chan struct{}, 1)
 	unblock := make(chan struct{})
 	sess := &tdsSession{
-		buf: newTdsBuffer(defaultPacketSize, &blockingTransport{unblock: unblock}),
+		buf: newTdsBuffer(defaultPacketSize, &blockingTransport{
+			unblock:     unblock,
+			readEntered: readEntered,
+		}),
 	}
 
 	ch1 := make(chan tokenStruct, 10)
 	sess.startResponseReader(context.Background(), ch1, outputs{})
-	// First goroutine is now blocked inside processSingleResponse on Read.
+
+	// Wait for the first goroutine to actually enter Read, proving it's blocked.
+	select {
+	case <-readEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first reader never entered Read")
+	}
 
 	// Launch second startResponseReader in a goroutine; it should block on
 	// <-sess.readDone until the first reader finishes.
@@ -505,14 +522,14 @@ func TestStartResponseReaderSerializes(t *testing.T) {
 		secondStarted.Store(1)
 	}()
 
-	// Give the goroutine time to reach the <-sess.readDone wait.
-	time.Sleep(50 * time.Millisecond)
+	// The second goroutine cannot proceed while the first reader is blocked,
+	// so secondStarted must still be 0.
 	if secondStarted.Load() != 0 {
 		t.Fatal("second startResponseReader returned before first completed")
 	}
 
-	// Unblock the first reader. processSingleResponse will hit EOF, recover
-	// from the panic, and close ch1 + readDone.
+	// Unblock the first reader. processSingleResponse will receive EOF from
+	// BeginRead as an error, send it to ch1, and return, closing readDone.
 	close(unblock)
 
 	// Second call should now proceed.

--- a/token_test.go
+++ b/token_test.go
@@ -496,6 +496,9 @@ func TestStartResponseReaderSerializes(t *testing.T) {
 	// First reader: transport blocks until we say so.
 	readEntered := make(chan struct{}, 1)
 	unblock := make(chan struct{})
+	var closeOnce sync.Once
+	closeUnblock := func() { closeOnce.Do(func() { close(unblock) }) }
+	t.Cleanup(closeUnblock)
 	sess := &tdsSession{
 		buf: newTdsBuffer(defaultPacketSize, &blockingTransport{
 			unblock:     unblock,
@@ -530,7 +533,7 @@ func TestStartResponseReaderSerializes(t *testing.T) {
 
 	// Unblock the first reader. processSingleResponse will receive EOF from
 	// BeginRead as an error, send it to ch1, and return, closing readDone.
-	close(unblock)
+	closeUnblock()
 
 	// Second call should now proceed.
 	select {

--- a/token_test.go
+++ b/token_test.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"regexp"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -468,46 +470,56 @@ func TestNextToken_CancelDrainClosedChannelStartsSecondResponse(t *testing.T) {
 	}
 }
 
+// blockingTransport blocks Read until unblock is closed, then returns EOF.
+type blockingTransport struct {
+	unblock chan struct{}
+}
+
+func (b *blockingTransport) Read([]byte) (int, error) {
+	<-b.unblock
+	return 0, io.EOF
+}
+
+func (b *blockingTransport) Write(p []byte) (int, error) { return len(p), nil }
+func (b *blockingTransport) Close() error                 { return nil }
+
 // TestStartResponseReaderSerializes verifies that startResponseReader waits for
 // the previous goroutine to finish before launching a new one.
 func TestStartResponseReaderSerializes(t *testing.T) {
-	// Build a minimal TDS reply with just a DONE(final) token.
-	buildDonePacket := func() []byte {
-		tokenStream := []byte{
-			byte(tokenDone), 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		}
-		totalSize := 8 + len(tokenStream)
-		packet := make([]byte, totalSize)
-		packet[0] = byte(packReply)
-		packet[1] = 0x01
-		binary.BigEndian.PutUint16(packet[2:4], uint16(totalSize))
-		packet[6] = 0x01
-		copy(packet[8:], tokenStream)
-		return packet
+	// First reader: transport blocks until we say so.
+	unblock := make(chan struct{})
+	sess := &tdsSession{
+		buf: newTdsBuffer(defaultPacketSize, &blockingTransport{unblock: unblock}),
 	}
 
-	// First call: launch a reader and let it finish.
-	pkt1 := buildDonePacket()
-	sess := &tdsSession{
-		buf: newTdsBuffer(defaultPacketSize, closableBuffer{bytes.NewBuffer(pkt1)}),
-	}
 	ch1 := make(chan tokenStruct, 10)
 	sess.startResponseReader(context.Background(), ch1, outputs{})
-	for range ch1 {
-	}
+	// First goroutine is now blocked inside processSingleResponse on Read.
 
-	// Second call: replace the transport and launch another reader.
-	// startResponseReader must wait for the first goroutine (already done)
-	// before starting the second. If it doesn't serialize, the second read
-	// would race on sess.buf.
-	pkt2 := buildDonePacket()
-	sess.buf = newTdsBuffer(defaultPacketSize, closableBuffer{bytes.NewBuffer(pkt2)})
+	// Launch second startResponseReader in a goroutine; it should block on
+	// <-sess.readDone until the first reader finishes.
+	var secondStarted atomic.Int32
 	ch2 := make(chan tokenStruct, 10)
-	sess.startResponseReader(context.Background(), ch2, outputs{})
-	for range ch2 {
+	go func() {
+		sess.startResponseReader(context.Background(), ch2, outputs{})
+		secondStarted.Store(1)
+	}()
+
+	// Give the goroutine time to reach the <-sess.readDone wait.
+	time.Sleep(50 * time.Millisecond)
+	if secondStarted.Load() != 0 {
+		t.Fatal("second startResponseReader returned before first completed")
 	}
 
-	// If we reach here without a panic or race, serialization is working.
-}
+	// Unblock the first reader. processSingleResponse will hit EOF, recover
+	// from the panic, and close ch1 + readDone.
+	close(unblock)
+
+	// Second call should now proceed.
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("second startResponseReader did not return after first completed")
+	case <-ch2:
+		// Expected: second reader started and wrote (or closed) ch2.
+	}
 }

--- a/token_test.go
+++ b/token_test.go
@@ -472,7 +472,7 @@ func TestNextToken_CancelDrainClosedChannelStartsSecondResponse(t *testing.T) {
 
 // blockingTransport blocks Read until unblock is closed, then returns EOF.
 // It signals readEntered when a Read call begins, allowing deterministic
-// synchronization without time.Sleep.
+// synchronization of the start of Read.
 type blockingTransport struct {
 	unblock     chan struct{}
 	readEntered chan struct{}

--- a/token_test.go
+++ b/token_test.go
@@ -520,10 +520,16 @@ func TestStartResponseReaderSerializes(t *testing.T) {
 	// <-sess.readDone until the first reader finishes.
 	var secondStarted atomic.Int32
 	ch2 := make(chan tokenStruct, 10)
+	goroutineStarted := make(chan struct{})
 	go func() {
+		close(goroutineStarted)
 		sess.startResponseReader(context.Background(), ch2, outputs{})
 		secondStarted.Store(1)
 	}()
+
+	// Wait for the goroutine to be scheduled and reach startResponseReader.
+	<-goroutineStarted
+	time.Sleep(100 * time.Millisecond)
 
 	// The second goroutine cannot proceed while the first reader is blocked,
 	// so secondStarted must still be 0.

--- a/token_test.go
+++ b/token_test.go
@@ -467,3 +467,47 @@ func TestNextToken_CancelDrainClosedChannelStartsSecondResponse(t *testing.T) {
 		t.Fatal("expected attention packet to be written")
 	}
 }
+
+// TestStartResponseReaderSerializes verifies that startResponseReader waits for
+// the previous goroutine to finish before launching a new one.
+func TestStartResponseReaderSerializes(t *testing.T) {
+	// Build a minimal TDS reply with just a DONE(final) token.
+	buildDonePacket := func() []byte {
+		tokenStream := []byte{
+			byte(tokenDone), 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		}
+		totalSize := 8 + len(tokenStream)
+		packet := make([]byte, totalSize)
+		packet[0] = byte(packReply)
+		packet[1] = 0x01
+		binary.BigEndian.PutUint16(packet[2:4], uint16(totalSize))
+		packet[6] = 0x01
+		copy(packet[8:], tokenStream)
+		return packet
+	}
+
+	// First call: launch a reader and let it finish.
+	pkt1 := buildDonePacket()
+	sess := &tdsSession{
+		buf: newTdsBuffer(defaultPacketSize, closableBuffer{bytes.NewBuffer(pkt1)}),
+	}
+	ch1 := make(chan tokenStruct, 10)
+	sess.startResponseReader(context.Background(), ch1, outputs{})
+	for range ch1 {
+	}
+
+	// Second call: replace the transport and launch another reader.
+	// startResponseReader must wait for the first goroutine (already done)
+	// before starting the second. If it doesn't serialize, the second read
+	// would race on sess.buf.
+	pkt2 := buildDonePacket()
+	sess.buf = newTdsBuffer(defaultPacketSize, closableBuffer{bytes.NewBuffer(pkt2)})
+	ch2 := make(chan tokenStruct, 10)
+	sess.startResponseReader(context.Background(), ch2, outputs{})
+	for range ch2 {
+	}
+
+	// If we reach here without a panic or race, serialization is working.
+}
+}

--- a/token_test.go
+++ b/token_test.go
@@ -601,3 +601,47 @@ func TestNextToken_CancelDrainClosedChannelStartsSecondResponse(t *testing.T) {
 		t.Fatal("expected attention packet to be written")
 	}
 }
+
+// TestStartResponseReaderSerializes verifies that startResponseReader waits for
+// the previous goroutine to finish before launching a new one.
+func TestStartResponseReaderSerializes(t *testing.T) {
+	// Build a minimal TDS reply with just a DONE(final) token.
+	buildDonePacket := func() []byte {
+		tokenStream := []byte{
+			byte(tokenDone), 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		}
+		totalSize := 8 + len(tokenStream)
+		packet := make([]byte, totalSize)
+		packet[0] = byte(packReply)
+		packet[1] = 0x01
+		binary.BigEndian.PutUint16(packet[2:4], uint16(totalSize))
+		packet[6] = 0x01
+		copy(packet[8:], tokenStream)
+		return packet
+	}
+
+	// First call: launch a reader and let it finish.
+	pkt1 := buildDonePacket()
+	sess := &tdsSession{
+		buf: newTdsBuffer(defaultPacketSize, closableBuffer{bytes.NewBuffer(pkt1)}),
+	}
+	ch1 := make(chan tokenStruct, 10)
+	sess.startResponseReader(context.Background(), ch1, outputs{})
+	for range ch1 {
+	}
+
+	// Second call: replace the transport and launch another reader.
+	// startResponseReader must wait for the first goroutine (already done)
+	// before starting the second. If it doesn't serialize, the second read
+	// would race on sess.buf.
+	pkt2 := buildDonePacket()
+	sess.buf = newTdsBuffer(defaultPacketSize, closableBuffer{bytes.NewBuffer(pkt2)})
+	ch2 := make(chan tokenStruct, 10)
+	sess.startResponseReader(context.Background(), ch2, outputs{})
+	for range ch2 {
+	}
+
+	// If we reach here without a panic or race, serialization is working.
+}
+}

--- a/token_test.go
+++ b/token_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"regexp"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -651,33 +650,46 @@ func TestStartResponseReaderSerializes(t *testing.T) {
 
 	// Launch second startResponseReader in a goroutine; it should block on
 	// <-sess.readDone until the first reader finishes.
-	var secondStarted atomic.Int32
 	ch2 := make(chan tokenStruct, 10)
 	goroutineStarted := make(chan struct{})
+	secondCallReturned := make(chan struct{})
 	go func() {
 		close(goroutineStarted)
 		sess.startResponseReader(context.Background(), ch2, outputs{})
-		secondStarted.Store(1)
+		close(secondCallReturned)
 	}()
 
 	// Wait for the goroutine to be scheduled and reach startResponseReader.
 	<-goroutineStarted
-	time.Sleep(100 * time.Millisecond)
 
-	// The second goroutine cannot proceed while the first reader is blocked,
-	// so secondStarted must still be 0.
-	if secondStarted.Load() != 0 {
+	// The second reader must not enter Read or return from startResponseReader
+	// while the first reader is blocked.
+	select {
+	case <-readEntered:
+		t.Fatal("second reader entered Read before first completed")
+	case <-secondCallReturned:
 		t.Fatal("second startResponseReader returned before first completed")
+	case <-time.After(100 * time.Millisecond):
 	}
 
 	// Unblock the first reader. processSingleResponse will receive EOF from
 	// BeginRead as an error, send it to ch1, and return, closing readDone.
 	closeUnblock()
 
-	// Second call should now proceed.
+	// The second call should now return and its reader should enter Read.
 	select {
+	case <-secondCallReturned:
 	case <-time.After(5 * time.Second):
 		t.Fatal("second startResponseReader did not return after first completed")
+	}
+	select {
+	case <-readEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second reader never entered Read")
+	}
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("second reader did not finish after entering Read")
 	case <-ch2:
 		// Expected: second reader started and wrote (or closed) ch2.
 	}

--- a/token_test.go
+++ b/token_test.go
@@ -605,7 +605,7 @@ func TestNextToken_CancelDrainClosedChannelStartsSecondResponse(t *testing.T) {
 
 // blockingTransport blocks Read until unblock is closed, then returns EOF.
 // It signals readEntered when a Read call begins, allowing deterministic
-// synchronization without time.Sleep.
+// synchronization of the start of Read.
 type blockingTransport struct {
 	unblock     chan struct{}
 	readEntered chan struct{}

--- a/token_test.go
+++ b/token_test.go
@@ -653,10 +653,16 @@ func TestStartResponseReaderSerializes(t *testing.T) {
 	// <-sess.readDone until the first reader finishes.
 	var secondStarted atomic.Int32
 	ch2 := make(chan tokenStruct, 10)
+	goroutineStarted := make(chan struct{})
 	go func() {
+		close(goroutineStarted)
 		sess.startResponseReader(context.Background(), ch2, outputs{})
 		secondStarted.Store(1)
 	}()
+
+	// Wait for the goroutine to be scheduled and reach startResponseReader.
+	<-goroutineStarted
+	time.Sleep(100 * time.Millisecond)
 
 	// The second goroutine cannot proceed while the first reader is blocked,
 	// so secondStarted must still be 0.

--- a/token_test.go
+++ b/token_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"regexp"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -602,46 +603,56 @@ func TestNextToken_CancelDrainClosedChannelStartsSecondResponse(t *testing.T) {
 	}
 }
 
+// blockingTransport blocks Read until unblock is closed, then returns EOF.
+type blockingTransport struct {
+	unblock chan struct{}
+}
+
+func (b *blockingTransport) Read([]byte) (int, error) {
+	<-b.unblock
+	return 0, io.EOF
+}
+
+func (b *blockingTransport) Write(p []byte) (int, error) { return len(p), nil }
+func (b *blockingTransport) Close() error                 { return nil }
+
 // TestStartResponseReaderSerializes verifies that startResponseReader waits for
 // the previous goroutine to finish before launching a new one.
 func TestStartResponseReaderSerializes(t *testing.T) {
-	// Build a minimal TDS reply with just a DONE(final) token.
-	buildDonePacket := func() []byte {
-		tokenStream := []byte{
-			byte(tokenDone), 0x00, 0x00, 0x00, 0x00,
-			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		}
-		totalSize := 8 + len(tokenStream)
-		packet := make([]byte, totalSize)
-		packet[0] = byte(packReply)
-		packet[1] = 0x01
-		binary.BigEndian.PutUint16(packet[2:4], uint16(totalSize))
-		packet[6] = 0x01
-		copy(packet[8:], tokenStream)
-		return packet
+	// First reader: transport blocks until we say so.
+	unblock := make(chan struct{})
+	sess := &tdsSession{
+		buf: newTdsBuffer(defaultPacketSize, &blockingTransport{unblock: unblock}),
 	}
 
-	// First call: launch a reader and let it finish.
-	pkt1 := buildDonePacket()
-	sess := &tdsSession{
-		buf: newTdsBuffer(defaultPacketSize, closableBuffer{bytes.NewBuffer(pkt1)}),
-	}
 	ch1 := make(chan tokenStruct, 10)
 	sess.startResponseReader(context.Background(), ch1, outputs{})
-	for range ch1 {
-	}
+	// First goroutine is now blocked inside processSingleResponse on Read.
 
-	// Second call: replace the transport and launch another reader.
-	// startResponseReader must wait for the first goroutine (already done)
-	// before starting the second. If it doesn't serialize, the second read
-	// would race on sess.buf.
-	pkt2 := buildDonePacket()
-	sess.buf = newTdsBuffer(defaultPacketSize, closableBuffer{bytes.NewBuffer(pkt2)})
+	// Launch second startResponseReader in a goroutine; it should block on
+	// <-sess.readDone until the first reader finishes.
+	var secondStarted atomic.Int32
 	ch2 := make(chan tokenStruct, 10)
-	sess.startResponseReader(context.Background(), ch2, outputs{})
-	for range ch2 {
+	go func() {
+		sess.startResponseReader(context.Background(), ch2, outputs{})
+		secondStarted.Store(1)
+	}()
+
+	// Give the goroutine time to reach the <-sess.readDone wait.
+	time.Sleep(50 * time.Millisecond)
+	if secondStarted.Load() != 0 {
+		t.Fatal("second startResponseReader returned before first completed")
 	}
 
-	// If we reach here without a panic or race, serialization is working.
-}
+	// Unblock the first reader. processSingleResponse will hit EOF, recover
+	// from the panic, and close ch1 + readDone.
+	close(unblock)
+
+	// Second call should now proceed.
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("second startResponseReader did not return after first completed")
+	case <-ch2:
+		// Expected: second reader started and wrote (or closed) ch2.
+	}
 }

--- a/token_test.go
+++ b/token_test.go
@@ -629,6 +629,9 @@ func TestStartResponseReaderSerializes(t *testing.T) {
 	// First reader: transport blocks until we say so.
 	readEntered := make(chan struct{}, 1)
 	unblock := make(chan struct{})
+	var closeOnce sync.Once
+	closeUnblock := func() { closeOnce.Do(func() { close(unblock) }) }
+	t.Cleanup(closeUnblock)
 	sess := &tdsSession{
 		buf: newTdsBuffer(defaultPacketSize, &blockingTransport{
 			unblock:     unblock,
@@ -663,7 +666,7 @@ func TestStartResponseReaderSerializes(t *testing.T) {
 
 	// Unblock the first reader. processSingleResponse will receive EOF from
 	// BeginRead as an error, send it to ch1, and return, closing readDone.
-	close(unblock)
+	closeUnblock()
 
 	// Second call should now proceed.
 	select {

--- a/token_test.go
+++ b/token_test.go
@@ -604,11 +604,18 @@ func TestNextToken_CancelDrainClosedChannelStartsSecondResponse(t *testing.T) {
 }
 
 // blockingTransport blocks Read until unblock is closed, then returns EOF.
+// It signals readEntered when a Read call begins, allowing deterministic
+// synchronization without time.Sleep.
 type blockingTransport struct {
-	unblock chan struct{}
+	unblock     chan struct{}
+	readEntered chan struct{}
 }
 
 func (b *blockingTransport) Read([]byte) (int, error) {
+	select {
+	case b.readEntered <- struct{}{}:
+	default:
+	}
 	<-b.unblock
 	return 0, io.EOF
 }
@@ -620,14 +627,24 @@ func (b *blockingTransport) Close() error                 { return nil }
 // the previous goroutine to finish before launching a new one.
 func TestStartResponseReaderSerializes(t *testing.T) {
 	// First reader: transport blocks until we say so.
+	readEntered := make(chan struct{}, 1)
 	unblock := make(chan struct{})
 	sess := &tdsSession{
-		buf: newTdsBuffer(defaultPacketSize, &blockingTransport{unblock: unblock}),
+		buf: newTdsBuffer(defaultPacketSize, &blockingTransport{
+			unblock:     unblock,
+			readEntered: readEntered,
+		}),
 	}
 
 	ch1 := make(chan tokenStruct, 10)
 	sess.startResponseReader(context.Background(), ch1, outputs{})
-	// First goroutine is now blocked inside processSingleResponse on Read.
+
+	// Wait for the first goroutine to actually enter Read, proving it's blocked.
+	select {
+	case <-readEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first reader never entered Read")
+	}
 
 	// Launch second startResponseReader in a goroutine; it should block on
 	// <-sess.readDone until the first reader finishes.
@@ -638,14 +655,14 @@ func TestStartResponseReaderSerializes(t *testing.T) {
 		secondStarted.Store(1)
 	}()
 
-	// Give the goroutine time to reach the <-sess.readDone wait.
-	time.Sleep(50 * time.Millisecond)
+	// The second goroutine cannot proceed while the first reader is blocked,
+	// so secondStarted must still be 0.
 	if secondStarted.Load() != 0 {
 		t.Fatal("second startResponseReader returned before first completed")
 	}
 
-	// Unblock the first reader. processSingleResponse will hit EOF, recover
-	// from the panic, and close ch1 + readDone.
+	// Unblock the first reader. processSingleResponse will receive EOF from
+	// BeginRead as an error, send it to ch1, and return, closing readDone.
 	close(unblock)
 
 	// Second call should now proceed.


### PR DESCRIPTION
## Summary

Adds the regression test for `startResponseReader` serialization. The production fix landed separately in #359, so this PR is test-only.

## Background

`startReading()` spawns a `processSingleResponse` goroutine that reads from `sess.buf`. If the caller does not fully drain the rows before executing the next statement, a second goroutine reads the same buffer concurrently. Both write `tdsBuffer.rpos` and `tdsBuffer.rsize` without synchronisation, which `go test -race` reports as a data race.

The fix is the `readDone chan struct{}` field on `tdsSession`: each `processSingleResponse` goroutine closes its channel on exit, and `startResponseReader` waits on the previous one before spawning a new goroutine. That shipped in `65e137f` (#359, "make readCancelConfirmation respect context cancellation") and is already on `main` — it is the only commit on `main` that touches `readDone`. This PR adds the coverage that was missing.

## What the test does

`TestStartResponseReaderSerializes` holds the first reader inside `Read` using a blocking transport, starts a second `startResponseReader` in a goroutine, and asserts it has not returned. It then unblocks the first reader and asserts the second proceeds.

## Verification

Mutation-tested rather than assumed. With the wait disabled in `token.go`:

```go
if sess.readDone != nil && false {
	<-sess.readDone
}
```

the test fails as intended:

```
    token_test.go:537: second startResponseReader returned before first completed
--- FAIL: TestStartResponseReaderSerializes (0.11s)
```

Restoring the wait returns it to green over `-count=5`.

On the `time.Sleep(100 * time.Millisecond)`: it guards a negative assertion — proving the second call has *not* returned — which cannot be made fully deterministic without a hook into the blocked receive. I measured how much of it is load-bearing. With the wait disabled and the sleep cut to `1 * time.Microsecond`, the regression is still caught. The 100ms is headroom, not a threshold the result depends on.
