### PR TITLE
fix: close TCP connection on connect() error to prevent leaks

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -1169,6 +1169,14 @@ initiate_connection:
 		return nil, err
 	}
 
+	// Ensure the TCP connection is closed if connect() returns an error.
+	// On success the connection is owned by the returned tdsSession.
+	defer func() {
+		if err != nil {
+			conn.Close()
+		}
+	}()
+
 	toconn := newTimeoutConn(conn, p.ConnTimeout)
 	outbuf := newTdsBuffer(packetSize, toconn)
 
@@ -1376,7 +1384,6 @@ initiate_connection:
 				if token.isError() {
 					tokenErr := token.getError()
 					tokenErr.Message = "login error: " + tokenErr.Message
-					conn.Close()
 					return nil, tokenErr
 				}
 			case error:


### PR DESCRIPTION
## Summary

Closes TCP connections that leak when `connect()` returns an error after successfully dialing.

## Problem

After `dialConnection()` succeeds, multiple error paths in `connect()` return `nil, err` without closing the underlying TCP connection. This leaks TCP connections when:
- TLS handshake fails
- `readPrelogin` fails
- `interpretPreloginResponse` fails  
- `prepareLogin` fails
- `sendLogin` fails
- Login token processing encounters an error
- Any of the TLS/config setup steps fail

Users reported observing `ESTABLISHED` TCP connections that never close, even after `db.Close()`, when the database name is incorrect (#173) or other connection setup failures occur (#243).

## Fix

Add a `defer` immediately after `dialConnection()` that closes `conn` if `err != nil` on return. This provides a single, uniform cleanup point for all error paths.

The existing explicit `conn.Close()` in the `doneStruct` login error case is removed since the defer now handles it.

The server routing path (`routedServer != ""`) already calls `toconn.Close()` before `goto initiate_connection`, so the old connection is properly closed before a new one is dialed. The defer captures the `conn` variable by reference, so it will see the latest connection from the most recent `dialConnection` call.

## Risk

Low. This is a straightforward resource cleanup that only fires on error paths.

Fixes #243, fixes #173