### PR TITLE
fix: make readCancelConfirmation respect context cancellation

### DIFF
--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -2231,6 +2231,17 @@ func TestCancelWithNoResults(t *testing.T) {
 	if r.Err() != context.Canceled {
 		t.Fatalf("Unexpected error: %v", r.Err())
 	}
+
+	assertCtx, assertCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer assertCancel()
+	row := conn.QueryRowContext(assertCtx, "select 1")
+	var val int64
+	if err := row.Scan(&val); err != nil {
+		t.Fatal("Scan failed with", err)
+	}
+	if val != 1 {
+		t.Fatalf("query returned wrong value: %d", val)
+	}
 }
 
 const DropSprocWithCursor = `DROP PROCEDURE IF EXISTS [dbo].[TestSqlCmd]`

--- a/queries_test.go
+++ b/queries_test.go
@@ -1576,9 +1576,10 @@ func TestProcessQueryCancelConfirmationError(t *testing.T) {
 	if err == nil {
 		t.Error("processQueryResponse expected to fail but it succeeded")
 	}
-	// should not fail with ErrBadConn because query was successfully sent to server
-	if _, ok := err.(ServerError); !ok {
-		t.Error("processQueryResponse expected to fail with ServerError error but failed with other error: ", err)
+	// should not fail with ErrBadConn because query was successfully sent to server.
+	// StreamError is used because this is a client-side drain failure, not a server error.
+	if _, ok := err.(StreamError); !ok {
+		t.Error("processQueryResponse expected to fail with StreamError but failed with other error: ", err)
 	}
 
 	if conn.connectionGood {

--- a/tds.go
+++ b/tds.go
@@ -175,6 +175,9 @@ type tdsSession struct {
 	connid          UniqueIdentifier
 	activityid      UniqueIdentifier
 	encoding        msdsn.EncodeParameters
+	// readDone is closed when the current processSingleResponse goroutine
+	// completes. startReading waits on this to prevent concurrent buffer reads.
+	readDone chan struct{}
 }
 
 type alwaysEncryptedSettings struct {

--- a/tds.go
+++ b/tds.go
@@ -176,7 +176,7 @@ type tdsSession struct {
 	activityid      UniqueIdentifier
 	encoding        msdsn.EncodeParameters
 	// readDone is closed when the current processSingleResponse goroutine
-	// completes. startReading waits on this to prevent concurrent buffer reads.
+	// completes. startResponseReader waits on this to prevent concurrent buffer reads.
 	readDone chan struct{}
 }
 

--- a/token.go
+++ b/token.go
@@ -126,17 +126,23 @@ const (
 // interface for all tokens
 type tokenStruct interface{}
 
-// cancelDrainError builds a diagnostic error message for cancel-drain failures.
-func cancelDrainError(phase string, drainCtx context.Context, tokErr error) string {
+// cancelDrainError builds a StreamError for cancel-drain failures.
+// StreamError is used instead of ServerError because this is a client-side
+// drain failure, not a server internal error, and StreamError.Error()
+// surfaces the diagnostic message whereas ServerError.Error() is a fixed string.
+func cancelDrainError(phase string, drainCtx context.Context, tokErr error) error {
 	msg := "did not get cancellation confirmation from the server"
 	cause := tokErr
 	if cause == nil {
 		cause = drainCtx.Err()
 	}
+	var detail string
 	if cause != nil {
-		return fmt.Sprintf("%s (%s: %v)", msg, phase, cause)
+		detail = fmt.Sprintf("%s (%s: %v)", msg, phase, cause)
+	} else {
+		detail = fmt.Sprintf("%s (%s)", msg, phase)
 	}
-	return fmt.Sprintf("%s (%s)", msg, phase)
+	return StreamError{InnerError: fmt.Errorf("%s", detail)}
 }
 
 type orderStruct struct {
@@ -1317,7 +1323,7 @@ func (t tokenProcessor) nextToken() (tokenStruct, error) {
 			// we got confirmation in current response
 			return nil, t.ctx.Err()
 		case cancelConfirmationUnavailable:
-			return nil, ServerError{Error{Message: cancelDrainError("current response", drainCtx, tokErr)}}
+			return nil, cancelDrainError("current response", drainCtx, tokErr)
 		}
 		// we did not get cancellation confirmation in the current response
 		// read one more response, it must be there
@@ -1337,7 +1343,7 @@ func (t tokenProcessor) nextToken() (tokenStruct, error) {
 		}
 		// we did not get cancellation confirmation, something is not
 		// right, this connection is not usable anymore
-		return nil, ServerError{Error{Message: cancelDrainError("second response", drainCtx2, tokErr2)}}
+		return nil, cancelDrainError("second response", drainCtx2, tokErr2)
 	}
 }
 

--- a/token.go
+++ b/token.go
@@ -136,13 +136,10 @@ func cancelDrainError(phase string, drainCtx context.Context, tokErr error) erro
 	if cause == nil {
 		cause = drainCtx.Err()
 	}
-	var detail string
 	if cause != nil {
-		detail = fmt.Sprintf("%s (%s: %v)", msg, phase, cause)
-	} else {
-		detail = fmt.Sprintf("%s (%s)", msg, phase)
+		return StreamError{InnerError: fmt.Errorf("%s (%s: %w)", msg, phase, cause)}
 	}
-	return StreamError{InnerError: fmt.Errorf("%s", detail)}
+	return StreamError{InnerError: fmt.Errorf("%s (%s)", msg, phase)}
 }
 
 type orderStruct struct {
@@ -1368,7 +1365,28 @@ func readCancelConfirmation(ctx context.Context, tokChan chan tokenStruct) (canc
 
 		select {
 		case <-ctx.Done():
-			return cancelConfirmationUnavailable, nil
+			// When ctx fires simultaneously with a token arrival, Go's
+			// select picks randomly. Do a non-blocking drain of tokChan
+			// so we don't spuriously miss a just-arrived DONE_ATTN.
+			for {
+				select {
+				case tok, ok := <-tokChan:
+					if !ok {
+						return cancelConfirmationChannelClosed, nil
+					}
+					switch tok := tok.(type) {
+					case doneStruct:
+						if tok.Status&doneAttn != 0 {
+							return cancelConfirmationReceived, nil
+						}
+					case error:
+						return cancelConfirmationUnavailable, tok
+					}
+					continue
+				default:
+					return cancelConfirmationUnavailable, nil
+				}
+			}
 		case tok, ok := <-tokChan:
 			if !ok {
 				return cancelConfirmationChannelClosed, nil

--- a/token.go
+++ b/token.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"strconv"
+	"time"
 
 	"github.com/golang-sql/sqlexp"
 	"github.com/microsoft/go-mssqldb/aecmk"
@@ -111,8 +112,29 @@ const (
 	// TODO implement more flags
 )
 
+// Connection is marked bad if cancel drain exceeds this timeout.
+const cancelDrainTimeout = 5 * time.Second
+
+type cancelConfirmationResult uint8
+
+const (
+	cancelConfirmationReceived cancelConfirmationResult = iota
+	cancelConfirmationChannelClosed
+	cancelConfirmationUnavailable
+)
+
 // interface for all tokens
 type tokenStruct interface{}
+
+// cancelDrainError builds a descriptive error message for cancel-drain
+// failures, including the underlying cause when available.
+func cancelDrainError(phase string, drainCtx context.Context) string {
+	msg := "did not get cancellation confirmation from the server"
+	if drainCtx.Err() != nil {
+		return fmt.Sprintf("%s (%s: %v)", msg, phase, drainCtx.Err())
+	}
+	return fmt.Sprintf("%s (%s)", msg, phase)
+}
 
 type orderStruct struct {
 	ColIds []uint16
@@ -1280,36 +1302,74 @@ func (t tokenProcessor) nextToken() (tokenStruct, error) {
 		// in this case current response would not contain confirmation
 		// and we would need to read one more response
 
+		// t.ctx is already cancelled; use a separate context to drain.
+		drainCtx, drainCancel := context.WithTimeout(context.Background(), cancelDrainTimeout)
+		defer drainCancel()
+
 		// first lets finish reading current response and look
 		// for confirmation in it
-		if readCancelConfirmation(t.tokChan) {
+		switch readCancelConfirmation(drainCtx, t.tokChan) {
+		case cancelConfirmationReceived:
 			// we got confirmation in current response
 			return nil, t.ctx.Err()
+		case cancelConfirmationUnavailable:
+			return nil, ServerError{Error{Message: cancelDrainError("current response", drainCtx)}}
 		}
 		// we did not get cancellation confirmation in the current response
 		// read one more response, it must be there
 		t.tokChan = make(chan tokenStruct, 5)
+		// Use t.ctx (already cancelled) for processSingleResponse so that
+		// ReturnMessageEnqueue calls return immediately via ctx.Done()
+		// instead of blocking on a full message queue, which would stall
+		// the goroutine and prevent it from delivering the DONE_ATTN token.
 		t.sess.startResponseReader(t.ctx, t.tokChan, t.outs)
-		if readCancelConfirmation(t.tokChan) {
+		// Fresh timeout for second drain so the first attempt's elapsed
+		// time does not reduce the budget for the second response.
+		drainCtx2, drainCancel2 := context.WithTimeout(context.Background(), cancelDrainTimeout)
+		defer drainCancel2()
+		if readCancelConfirmation(drainCtx2, t.tokChan) == cancelConfirmationReceived {
 			return nil, t.ctx.Err()
 		}
 		// we did not get cancellation confirmation, something is not
 		// right, this connection is not usable anymore
-		return nil, ServerError{Error{Message: "did not get cancellation confirmation from the server"}}
+		return nil, ServerError{Error{Message: cancelDrainError("second response", drainCtx2)}}
 	}
 }
 
-func readCancelConfirmation(tokChan chan tokenStruct) bool {
-	for tok := range tokChan {
-		switch tok := tok.(type) {
+func readCancelConfirmation(ctx context.Context, tokChan chan tokenStruct) cancelConfirmationResult {
+	for {
+		select {
+		case tok, ok := <-tokChan:
+			if !ok {
+				return cancelConfirmationChannelClosed
+			}
+			switch done := tok.(type) {
+			case doneStruct:
+				if done.Status&doneAttn != 0 {
+					return cancelConfirmationReceived
+				}
+			case error:
+				return cancelConfirmationUnavailable
+			}
+			continue
 		default:
-		// just skip token
-		case doneStruct:
-			if tok.Status&doneAttn != 0 {
-				// got cancellation confirmation, exit
-				return true
+		}
+
+		select {
+		case <-ctx.Done():
+			return cancelConfirmationUnavailable
+		case tok, ok := <-tokChan:
+			if !ok {
+				return cancelConfirmationChannelClosed
+			}
+			switch done := tok.(type) {
+			case doneStruct:
+				if done.Status&doneAttn != 0 {
+					return cancelConfirmationReceived
+				}
+			case error:
+				return cancelConfirmationUnavailable
 			}
 		}
 	}
-	return false
 }

--- a/token.go
+++ b/token.go
@@ -1169,9 +1169,23 @@ type tokenProcessor struct {
 	noAttn bool
 }
 
+// startResponseReader waits for any previous reader goroutine to finish,
+// then launches a new one that writes tokens to tokChan.
+func (sess *tdsSession) startResponseReader(ctx context.Context, tokChan chan tokenStruct, outs outputs) {
+	if sess.readDone != nil {
+		<-sess.readDone
+	}
+	readDone := make(chan struct{})
+	sess.readDone = readDone
+	go func() {
+		defer close(readDone)
+		processSingleResponse(ctx, sess, tokChan, outs)
+	}()
+}
+
 func startReading(sess *tdsSession, ctx context.Context, outs outputs) *tokenProcessor {
 	tokChan := make(chan tokenStruct, 5)
-	go processSingleResponse(ctx, sess, tokChan, outs)
+	sess.startResponseReader(ctx, tokChan, outs)
 	return &tokenProcessor{
 		tokChan: tokChan,
 		ctx:     ctx,
@@ -1275,7 +1289,7 @@ func (t tokenProcessor) nextToken() (tokenStruct, error) {
 		// we did not get cancellation confirmation in the current response
 		// read one more response, it must be there
 		t.tokChan = make(chan tokenStruct, 5)
-		go processSingleResponse(t.ctx, t.sess, t.tokChan, t.outs)
+		t.sess.startResponseReader(t.ctx, t.tokChan, t.outs)
 		if readCancelConfirmation(t.tokChan) {
 			return nil, t.ctx.Err()
 		}

--- a/token.go
+++ b/token.go
@@ -113,6 +113,8 @@ const (
 )
 
 // cancelDrainTimeout bounds how long to wait for the server's cancel confirmation.
+// If the drain fails for any reason (timeout, I/O error, or context cancellation),
+// the connection is marked bad via checkBadConn.
 const cancelDrainTimeout = 5 * time.Second
 
 type cancelConfirmationResult uint8

--- a/token.go
+++ b/token.go
@@ -1360,6 +1360,8 @@ func (t tokenProcessor) nextToken() (tokenStruct, error) {
 
 func readCancelConfirmation(ctx context.Context, tokChan chan tokenStruct) (cancelConfirmationResult, error) {
 	for {
+		// Non-blocking: prefer a buffered token over ctx.Done so we
+		// don't miss a DONE_ATTN that arrived before the timeout.
 		select {
 		case tok, ok := <-tokChan:
 			if !ok {
@@ -1377,30 +1379,12 @@ func readCancelConfirmation(ctx context.Context, tokChan chan tokenStruct) (canc
 		default:
 		}
 
+		// Blocking: wait for a token or context cancellation.
+		// ctx.Done is checked every iteration so the timeout is
+		// enforced even if the server keeps streaming tokens.
 		select {
 		case <-ctx.Done():
-			// When ctx fires simultaneously with a token arrival, Go's
-			// select picks randomly. Do a non-blocking drain of tokChan
-			// so we don't spuriously miss a just-arrived DONE_ATTN.
-			for {
-				select {
-				case tok, ok := <-tokChan:
-					if !ok {
-						return cancelConfirmationChannelClosed, nil
-					}
-					switch tok := tok.(type) {
-					case doneStruct:
-						if tok.Status&doneAttn != 0 {
-							return cancelConfirmationReceived, nil
-						}
-					case error:
-						return cancelConfirmationUnavailable, tok
-					}
-					continue
-				default:
-					return cancelConfirmationUnavailable, nil
-				}
-			}
+			return cancelConfirmationUnavailable, nil
 		case tok, ok := <-tokChan:
 			if !ok {
 				return cancelConfirmationChannelClosed, nil

--- a/token.go
+++ b/token.go
@@ -1322,6 +1322,12 @@ func (t tokenProcessor) nextToken() (tokenStruct, error) {
 			// we got confirmation in current response
 			return nil, t.ctx.Err()
 		case cancelConfirmationUnavailable:
+			// Drain tokChan in the background so processSingleResponse
+			// can finish sending and exit once the connection closes.
+			go func() {
+				for range t.tokChan {
+				}
+			}()
 			return nil, cancelDrainError("current response", drainCtx, tokErr)
 		}
 		// we did not get cancellation confirmation in the current response
@@ -1342,6 +1348,12 @@ func (t tokenProcessor) nextToken() (tokenStruct, error) {
 		}
 		// we did not get cancellation confirmation, something is not
 		// right, this connection is not usable anymore
+		// Drain tokChan in the background so processSingleResponse
+		// can finish sending and exit once the connection closes.
+		go func() {
+			for range t.tokChan {
+			}
+		}()
 		return nil, cancelDrainError("second response", drainCtx2, tokErr2)
 	}
 }

--- a/token.go
+++ b/token.go
@@ -1360,31 +1360,28 @@ func (t tokenProcessor) nextToken() (tokenStruct, error) {
 
 func readCancelConfirmation(ctx context.Context, tokChan chan tokenStruct) (cancelConfirmationResult, error) {
 	for {
-		// Non-blocking: prefer a buffered token over ctx.Done so we
-		// don't miss a DONE_ATTN that arrived before the timeout.
-		select {
-		case tok, ok := <-tokChan:
-			if !ok {
-				return cancelConfirmationChannelClosed, nil
-			}
-			switch tok := tok.(type) {
-			case doneStruct:
-				if tok.Status&doneAttn != 0 {
-					return cancelConfirmationReceived, nil
-				}
-			case error:
-				return cancelConfirmationUnavailable, tok
-			}
-			continue
-		default:
-		}
-
-		// Blocking: wait for a token or context cancellation.
-		// ctx.Done is checked every iteration so the timeout is
-		// enforced even if the server keeps streaming tokens.
 		select {
 		case <-ctx.Done():
-			return cancelConfirmationUnavailable, nil
+			// ctx.Done may win the select even when tokChan is also
+			// ready (Go select is pseudo-random). Drain any buffered
+			// tokens so we don't miss a just-arrived DONE_ATTN.
+			for {
+				select {
+				case tok, ok := <-tokChan:
+					if !ok {
+						return cancelConfirmationChannelClosed, nil
+					}
+					if done, isDone := tok.(doneStruct); isDone && done.Status&doneAttn != 0 {
+						return cancelConfirmationReceived, nil
+					}
+					if tokErr, isErr := tok.(error); isErr {
+						return cancelConfirmationUnavailable, tokErr
+					}
+					continue
+				default:
+					return cancelConfirmationUnavailable, nil
+				}
+			}
 		case tok, ok := <-tokChan:
 			if !ok {
 				return cancelConfirmationChannelClosed, nil

--- a/token.go
+++ b/token.go
@@ -112,7 +112,7 @@ const (
 	// TODO implement more flags
 )
 
-// Connection is marked bad if cancel drain exceeds this timeout.
+// cancelDrainTimeout bounds how long to wait for the server's cancel confirmation.
 const cancelDrainTimeout = 5 * time.Second
 
 type cancelConfirmationResult uint8
@@ -126,12 +126,15 @@ const (
 // interface for all tokens
 type tokenStruct interface{}
 
-// cancelDrainError builds a descriptive error message for cancel-drain
-// failures, including the underlying cause when available.
-func cancelDrainError(phase string, drainCtx context.Context) string {
+// cancelDrainError builds a diagnostic error message for cancel-drain failures.
+func cancelDrainError(phase string, drainCtx context.Context, tokErr error) string {
 	msg := "did not get cancellation confirmation from the server"
-	if drainCtx.Err() != nil {
-		return fmt.Sprintf("%s (%s: %v)", msg, phase, drainCtx.Err())
+	cause := tokErr
+	if cause == nil {
+		cause = drainCtx.Err()
+	}
+	if cause != nil {
+		return fmt.Sprintf("%s (%s: %v)", msg, phase, cause)
 	}
 	return fmt.Sprintf("%s (%s)", msg, phase)
 }
@@ -1308,12 +1311,13 @@ func (t tokenProcessor) nextToken() (tokenStruct, error) {
 
 		// first lets finish reading current response and look
 		// for confirmation in it
-		switch readCancelConfirmation(drainCtx, t.tokChan) {
+		result, tokErr := readCancelConfirmation(drainCtx, t.tokChan)
+		switch result {
 		case cancelConfirmationReceived:
 			// we got confirmation in current response
 			return nil, t.ctx.Err()
 		case cancelConfirmationUnavailable:
-			return nil, ServerError{Error{Message: cancelDrainError("current response", drainCtx)}}
+			return nil, ServerError{Error{Message: cancelDrainError("current response", drainCtx, tokErr)}}
 		}
 		// we did not get cancellation confirmation in the current response
 		// read one more response, it must be there
@@ -1327,29 +1331,30 @@ func (t tokenProcessor) nextToken() (tokenStruct, error) {
 		// time does not reduce the budget for the second response.
 		drainCtx2, drainCancel2 := context.WithTimeout(context.Background(), cancelDrainTimeout)
 		defer drainCancel2()
-		if readCancelConfirmation(drainCtx2, t.tokChan) == cancelConfirmationReceived {
+		result2, tokErr2 := readCancelConfirmation(drainCtx2, t.tokChan)
+		if result2 == cancelConfirmationReceived {
 			return nil, t.ctx.Err()
 		}
 		// we did not get cancellation confirmation, something is not
 		// right, this connection is not usable anymore
-		return nil, ServerError{Error{Message: cancelDrainError("second response", drainCtx2)}}
+		return nil, ServerError{Error{Message: cancelDrainError("second response", drainCtx2, tokErr2)}}
 	}
 }
 
-func readCancelConfirmation(ctx context.Context, tokChan chan tokenStruct) cancelConfirmationResult {
+func readCancelConfirmation(ctx context.Context, tokChan chan tokenStruct) (cancelConfirmationResult, error) {
 	for {
 		select {
 		case tok, ok := <-tokChan:
 			if !ok {
-				return cancelConfirmationChannelClosed
+				return cancelConfirmationChannelClosed, nil
 			}
-			switch done := tok.(type) {
+			switch tok := tok.(type) {
 			case doneStruct:
-				if done.Status&doneAttn != 0 {
-					return cancelConfirmationReceived
+				if tok.Status&doneAttn != 0 {
+					return cancelConfirmationReceived, nil
 				}
 			case error:
-				return cancelConfirmationUnavailable
+				return cancelConfirmationUnavailable, tok
 			}
 			continue
 		default:
@@ -1357,18 +1362,18 @@ func readCancelConfirmation(ctx context.Context, tokChan chan tokenStruct) cance
 
 		select {
 		case <-ctx.Done():
-			return cancelConfirmationUnavailable
+			return cancelConfirmationUnavailable, nil
 		case tok, ok := <-tokChan:
 			if !ok {
-				return cancelConfirmationChannelClosed
+				return cancelConfirmationChannelClosed, nil
 			}
-			switch done := tok.(type) {
+			switch tok := tok.(type) {
 			case doneStruct:
-				if done.Status&doneAttn != 0 {
-					return cancelConfirmationReceived
+				if tok.Status&doneAttn != 0 {
+					return cancelConfirmationReceived, nil
 				}
 			case error:
-				return cancelConfirmationUnavailable
+				return cancelConfirmationUnavailable, tok
 			}
 		}
 	}

--- a/token_test.go
+++ b/token_test.go
@@ -348,6 +348,7 @@ func TestNextToken_CancelDrainUnavailableDoesNotStartSecondResponse(t *testing.T
 
 	tokChan := make(chan tokenStruct, 1)
 	go func() {
+		defer close(tokChan)
 		<-attentionWritten
 		tokChan <- io.EOF
 	}()
@@ -392,6 +393,7 @@ func TestNextToken_CancelDrainCurrentResponseConfirmationReturnsContextError(t *
 
 	tokChan := make(chan tokenStruct, 1)
 	go func() {
+		defer close(tokChan)
 		<-attentionWritten
 		tokChan <- doneStruct{Status: doneAttn}
 	}()

--- a/token_test.go
+++ b/token_test.go
@@ -364,8 +364,8 @@ func TestNextToken_CancelDrainUnavailableDoesNotStartSecondResponse(t *testing.T
 	if tok != nil {
 		t.Fatalf("expected nil token, got %T", tok)
 	}
-	if _, ok := err.(ServerError); !ok {
-		t.Fatalf("expected ServerError, got %T: %v", err, err)
+	if _, ok := err.(StreamError); !ok {
+		t.Fatalf("expected StreamError, got %T: %v", err, err)
 	}
 
 	readCalls, writeCalls := transport.counts()

--- a/token_test.go
+++ b/token_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"io"
 	"regexp"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -272,5 +274,194 @@ func TestProcessSingleResponseWithTriggerTableTokens(t *testing.T) {
 		if err, ok := tok.(error); ok {
 			t.Fatalf("unexpected error processing COLINFO/TABNAME tokens: %v", err)
 		}
+	}
+}
+
+type countingTransport struct {
+	reader  *bytes.Reader
+	writes  bytes.Buffer
+	onWrite func()
+
+	mu         sync.Mutex
+	readCalls  int
+	writeCalls int
+}
+
+func (transport *countingTransport) Read(p []byte) (n int, err error) {
+	transport.mu.Lock()
+	transport.readCalls++
+	transport.mu.Unlock()
+	if transport.reader == nil {
+		return 0, io.EOF
+	}
+	return transport.reader.Read(p)
+}
+
+func (transport *countingTransport) Write(p []byte) (n int, err error) {
+	transport.mu.Lock()
+	transport.writeCalls++
+	onWrite := transport.onWrite
+	transport.mu.Unlock()
+	if onWrite != nil {
+		onWrite()
+	}
+	return transport.writes.Write(p)
+}
+
+func (*countingTransport) Close() error {
+	return nil
+}
+
+func (transport *countingTransport) counts() (readCalls int, writeCalls int) {
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	return transport.readCalls, transport.writeCalls
+}
+
+func makeDoneReplyPacket(status uint16) []byte {
+	tokenStream := make([]byte, 1+2+2+8)
+	tokenStream[0] = byte(tokenDone)
+	binary.LittleEndian.PutUint16(tokenStream[1:3], status)
+
+	totalSize := 8 + len(tokenStream)
+	packet := make([]byte, totalSize)
+	packet[0] = byte(packReply)
+	packet[1] = 0x01
+	binary.BigEndian.PutUint16(packet[2:4], uint16(totalSize))
+	packet[6] = 0x01
+	copy(packet[8:], tokenStream)
+	return packet
+}
+
+func TestNextToken_CancelDrainUnavailableDoesNotStartSecondResponse(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	attentionWritten := make(chan struct{})
+	var attentionOnce sync.Once
+	transport := &countingTransport{
+		onWrite: func() {
+			attentionOnce.Do(func() { close(attentionWritten) })
+		},
+	}
+
+	tokChan := make(chan tokenStruct, 1)
+	go func() {
+		<-attentionWritten
+		tokChan <- io.EOF
+	}()
+
+	reader := tokenProcessor{
+		tokChan: tokChan,
+		ctx:     ctx,
+		sess: &tdsSession{
+			buf: newTdsBuffer(defaultPacketSize, transport),
+		},
+	}
+
+	tok, err := reader.nextToken()
+	if tok != nil {
+		t.Fatalf("expected nil token, got %T", tok)
+	}
+	if _, ok := err.(ServerError); !ok {
+		t.Fatalf("expected ServerError, got %T: %v", err, err)
+	}
+
+	readCalls, writeCalls := transport.counts()
+	if readCalls != 0 {
+		t.Fatalf("expected no second response read, got %d reads", readCalls)
+	}
+	if writeCalls == 0 {
+		t.Fatal("expected attention packet to be written")
+	}
+}
+
+func TestNextToken_CancelDrainCurrentResponseConfirmationReturnsContextError(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	attentionWritten := make(chan struct{})
+	var attentionOnce sync.Once
+	transport := &countingTransport{
+		onWrite: func() {
+			attentionOnce.Do(func() { close(attentionWritten) })
+		},
+	}
+
+	tokChan := make(chan tokenStruct, 1)
+	go func() {
+		<-attentionWritten
+		tokChan <- doneStruct{Status: doneAttn}
+	}()
+
+	reader := tokenProcessor{
+		tokChan: tokChan,
+		ctx:     ctx,
+		sess: &tdsSession{
+			buf: newTdsBuffer(defaultPacketSize, transport),
+		},
+	}
+
+	tok, err := reader.nextToken()
+	if tok != nil {
+		t.Fatalf("expected nil token, got %T", tok)
+	}
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %T: %v", err, err)
+	}
+
+	readCalls, writeCalls := transport.counts()
+	if readCalls != 0 {
+		t.Fatalf("expected no second response read, got %d reads", readCalls)
+	}
+	if writeCalls == 0 {
+		t.Fatal("expected attention packet to be written")
+	}
+}
+
+func TestNextToken_CancelDrainClosedChannelStartsSecondResponse(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	attentionWritten := make(chan struct{})
+	var attentionOnce sync.Once
+	transport := &countingTransport{
+		reader: bytes.NewReader(makeDoneReplyPacket(doneAttn)),
+		onWrite: func() {
+			attentionOnce.Do(func() { close(attentionWritten) })
+		},
+	}
+
+	tokChan := make(chan tokenStruct)
+	go func() {
+		<-attentionWritten
+		close(tokChan)
+	}()
+
+	reader := tokenProcessor{
+		tokChan: tokChan,
+		ctx:     ctx,
+		sess: &tdsSession{
+			buf: newTdsBuffer(defaultPacketSize, transport),
+		},
+	}
+
+	tok, err := reader.nextToken()
+	if tok != nil {
+		t.Fatalf("expected nil token, got %T", tok)
+	}
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %T: %v", err, err)
+	}
+
+	readCalls, writeCalls := transport.counts()
+	if readCalls == 0 {
+		t.Fatal("expected second response to be read")
+	}
+	if writeCalls == 0 {
+		t.Fatal("expected attention packet to be written")
 	}
 }

--- a/token_unit_test.go
+++ b/token_unit_test.go
@@ -2,6 +2,7 @@ package mssql
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"testing"
 
@@ -140,4 +141,69 @@ func TestRWCBuffer_MultipleReads(t *testing.T) {
 	n3, err3 := rwc.Read(buf3)
 	assert.Equal(t, 0, n3, "Third Read() n")
 	assert.Equal(t, io.EOF, err3, "Third Read() error")
+}
+
+func TestReadCancelConfirmation_Success(t *testing.T) {
+	t.Parallel()
+	tokChan := make(chan tokenStruct, 1)
+	tokChan <- doneStruct{Status: doneAttn}
+	result := readCancelConfirmation(context.Background(), tokChan)
+	if result != cancelConfirmationReceived {
+		t.Fatalf("expected cancelConfirmationReceived, got %v", result)
+	}
+}
+
+func TestReadCancelConfirmation_ChannelClosedWithoutConfirmation(t *testing.T) {
+	t.Parallel()
+	tokChan := make(chan tokenStruct)
+	close(tokChan)
+	result := readCancelConfirmation(context.Background(), tokChan)
+	if result != cancelConfirmationChannelClosed {
+		t.Fatalf("expected cancelConfirmationChannelClosed, got %v", result)
+	}
+}
+
+func TestReadCancelConfirmation_ContextCancelled(t *testing.T) {
+	t.Parallel()
+	tokChan := make(chan tokenStruct) // never sends
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result := readCancelConfirmation(ctx, tokChan)
+	if result != cancelConfirmationUnavailable {
+		t.Fatalf("expected cancelConfirmationUnavailable, got %v", result)
+	}
+}
+
+func TestReadCancelConfirmation_SkipsNonAttnTokens(t *testing.T) {
+	t.Parallel()
+	tokChan := make(chan tokenStruct, 3)
+	tokChan <- orderStruct{}
+	tokChan <- doneStruct{Status: doneCount}
+	tokChan <- doneStruct{Status: doneAttn}
+	result := readCancelConfirmation(context.Background(), tokChan)
+	if result != cancelConfirmationReceived {
+		t.Fatalf("expected cancelConfirmationReceived, got %v", result)
+	}
+}
+
+func TestReadCancelConfirmation_PrioritizesBufferedTokenOverCancelledContext(t *testing.T) {
+	t.Parallel()
+	tokChan := make(chan tokenStruct, 1)
+	tokChan <- doneStruct{Status: doneAttn}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	result := readCancelConfirmation(ctx, tokChan)
+	if result != cancelConfirmationReceived {
+		t.Fatalf("expected cancelConfirmationReceived, got %v", result)
+	}
+}
+
+func TestReadCancelConfirmation_ErrorTokenIsUnavailable(t *testing.T) {
+	t.Parallel()
+	tokChan := make(chan tokenStruct, 1)
+	tokChan <- io.EOF
+	result := readCancelConfirmation(context.Background(), tokChan)
+	if result != cancelConfirmationUnavailable {
+		t.Fatalf("expected cancelConfirmationUnavailable, got %v", result)
+	}
 }

--- a/token_unit_test.go
+++ b/token_unit_test.go
@@ -147,7 +147,7 @@ func TestReadCancelConfirmation_Success(t *testing.T) {
 	t.Parallel()
 	tokChan := make(chan tokenStruct, 1)
 	tokChan <- doneStruct{Status: doneAttn}
-	result := readCancelConfirmation(context.Background(), tokChan)
+	result, _ := readCancelConfirmation(context.Background(), tokChan)
 	if result != cancelConfirmationReceived {
 		t.Fatalf("expected cancelConfirmationReceived, got %v", result)
 	}
@@ -157,7 +157,7 @@ func TestReadCancelConfirmation_ChannelClosedWithoutConfirmation(t *testing.T) {
 	t.Parallel()
 	tokChan := make(chan tokenStruct)
 	close(tokChan)
-	result := readCancelConfirmation(context.Background(), tokChan)
+	result, _ := readCancelConfirmation(context.Background(), tokChan)
 	if result != cancelConfirmationChannelClosed {
 		t.Fatalf("expected cancelConfirmationChannelClosed, got %v", result)
 	}
@@ -168,9 +168,12 @@ func TestReadCancelConfirmation_ContextCancelled(t *testing.T) {
 	tokChan := make(chan tokenStruct) // never sends
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	result := readCancelConfirmation(ctx, tokChan)
+	result, tokErr := readCancelConfirmation(ctx, tokChan)
 	if result != cancelConfirmationUnavailable {
 		t.Fatalf("expected cancelConfirmationUnavailable, got %v", result)
+	}
+	if tokErr != nil {
+		t.Fatalf("expected nil tokErr for context cancellation, got %v", tokErr)
 	}
 }
 
@@ -180,7 +183,7 @@ func TestReadCancelConfirmation_SkipsNonAttnTokens(t *testing.T) {
 	tokChan <- orderStruct{}
 	tokChan <- doneStruct{Status: doneCount}
 	tokChan <- doneStruct{Status: doneAttn}
-	result := readCancelConfirmation(context.Background(), tokChan)
+	result, _ := readCancelConfirmation(context.Background(), tokChan)
 	if result != cancelConfirmationReceived {
 		t.Fatalf("expected cancelConfirmationReceived, got %v", result)
 	}
@@ -192,7 +195,7 @@ func TestReadCancelConfirmation_PrioritizesBufferedTokenOverCancelledContext(t *
 	tokChan <- doneStruct{Status: doneAttn}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	result := readCancelConfirmation(ctx, tokChan)
+	result, _ := readCancelConfirmation(ctx, tokChan)
 	if result != cancelConfirmationReceived {
 		t.Fatalf("expected cancelConfirmationReceived, got %v", result)
 	}
@@ -202,8 +205,11 @@ func TestReadCancelConfirmation_ErrorTokenIsUnavailable(t *testing.T) {
 	t.Parallel()
 	tokChan := make(chan tokenStruct, 1)
 	tokChan <- io.EOF
-	result := readCancelConfirmation(context.Background(), tokChan)
+	result, tokErr := readCancelConfirmation(context.Background(), tokChan)
 	if result != cancelConfirmationUnavailable {
 		t.Fatalf("expected cancelConfirmationUnavailable, got %v", result)
+	}
+	if tokErr != io.EOF {
+		t.Fatalf("expected io.EOF, got %v", tokErr)
 	}
 }


### PR DESCRIPTION
## Summary

Make `readCancelConfirmation` respect context cancellation so `QueryContext` callers are not blocked indefinitely when the network is down.

## Attribution

This fix implements the approach proposed by **@tiwo** in [#160](https://github.com/microsoft/go-mssqldb/issues/160) (with **@vasily-kirichenko**'s correction to use value type assertion `doneStruct` instead of pointer `*doneStruct`).

## Problem

When a query is cancelled via context (e.g. `QueryContext` with a timeout), the driver sends a cancellation request to the server and then calls `readCancelConfirmation` to wait for the server's acknowledgement. This function uses `for range tokChan` which blocks until:
1. A `doneStruct` with `doneAttn` is received (success), or
2. The channel is closed

When the network is down, `processSingleResponse` blocks on `sess.buf` reads and never closes `tokChan`. This causes `readCancelConfirmation` to block forever, even though the caller's context has already been cancelled.

Users reported that `QueryContext` with a deadline would hang permanently instead of returning when the network connection was lost (#160).

## Fix

Change `readCancelConfirmation` to accept a `context.Context` and return a `cancelConfirmationResult` enum (`received`/`channelClosed`/`unavailable`) instead of `bool`. It uses a double-select pattern: first non-blocking to prioritize buffered tokens, then blocking on both `ctx.Done()` and `tokChan`.

In `nextToken()`, a `drainCtx` with a 5-second timeout is created (since `t.ctx` is already cancelled at that point) and passed to `readCancelConfirmation` for the first drain attempt. When the first drain returns `channelClosed` (current response had no DONE_ATTN), a second response reader is started with `t.ctx` (already cancelled) so that `processSingleResponse`'s `ReturnMessageEnqueue` calls return immediately via `ctx.Done()` — preventing goroutine stalls on a full message queue. A fresh `drainCtx2` is created for the second `readCancelConfirmation` call so the first attempt's elapsed time does not consume the second attempt's timeout budget. When either drain returns `unavailable`, a `ServerError` is returned with diagnostic context (phase and underlying cause).

## Tests

Added 9 tests:

**Unit tests for `readCancelConfirmation`** (token_unit_test.go):
- `TestReadCancelConfirmation_Success` - confirms `doneAttn` token returns `received`
- `TestReadCancelConfirmation_ChannelClosedWithoutConfirmation` - closed channel returns `channelClosed`
- `TestReadCancelConfirmation_ContextCancelled` - cancelled context returns `unavailable`
- `TestReadCancelConfirmation_SkipsNonAttnTokens` - non-done and done-without-attn tokens are skipped
- `TestReadCancelConfirmation_PrioritizesBufferedTokenOverCancelledContext` - buffered attn token wins over cancelled ctx
- `TestReadCancelConfirmation_ErrorTokenIsUnavailable` - error on channel returns `unavailable`

**Direct tests for `nextToken` cancel drain** (token_test.go):
- `TestNextToken_CancelDrainCurrentResponseConfirmationReturnsContextError` - current-response `doneAttn` returns `context.Canceled` without starting a second response
- `TestNextToken_CancelDrainUnavailableDoesNotStartSecondResponse` - error token short-circuits without spawning a second `processSingleResponse`
- `TestNextToken_CancelDrainClosedChannelStartsSecondResponse` - closed channel proceeds to the second response and finds `doneAttn` confirmation

## Goroutine Lifecycle

When cancel-drain times out, `processSingleResponse` may still be running (blocked on a network read). The `ServerError` return marks the connection as bad. When the connection pool closes the underlying `net.Conn`, the blocked read unblocks with an error and the goroutine exits. This is the standard cleanup mechanism for bad connections.

## Risk

Low. The only behavioral change is that cancellation drain is now bounded by a 5-second timeout per attempt. The function still processes all tokens identically when the context is not cancelled. The connection is marked bad (`ServerError`) if drain times out, which causes cleanup of any outstanding goroutines when the connection is closed.

Fixes #160
