### PR TITLE
fix: propagate context deadline to readPrelogin to prevent hangs

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -28,6 +28,15 @@ func TestServerError(t *testing.T) {
 	}
 }
 
+func TestStreamErrorUnwrap(t *testing.T) {
+	originalErr := errors.New("underlying error")
+	streamErr := StreamError{InnerError: originalErr}
+
+	if !errors.Is(streamErr, originalErr) {
+		t.Fatalf("StreamError did not preserve wrapped error. Got '%+v', wanted '%+v'", streamErr.Unwrap(), originalErr)
+	}
+}
+
 func TestRetryableError(t *testing.T) {
 
 	originalErr := driver.ErrBadConn

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -103,8 +103,8 @@ func TestPreloginTimeout(t *testing.T) {
 
 // pastDeadlineContext simulates a context whose deadline has passed but whose
 // Err() method has not yet returned non-nil.  This transient state can occur
-// in real programs due to goroutine scheduling between the time.Until and
-// ctx.Err calls inside preloginTimeout.
+// in real programs due to goroutine scheduling between the ctx.Err() check
+// and the subsequent time.Until(deadline) call inside preloginTimeout.
 type pastDeadlineContext struct {
 	context.Context
 	dl time.Time

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -355,6 +355,7 @@ func TestRoutingRedirectClosesFirstConnection(t *testing.T) {
 		defer close(firstConnClosed)
 		conn, err := listener.Accept()
 		if err != nil {
+			t.Errorf("listener.Accept failed: %v", err)
 			return
 		}
 		// Keep the server side open so we can detect the client close.
@@ -362,8 +363,33 @@ func TestRoutingRedirectClosesFirstConnection(t *testing.T) {
 
 		buf := newTdsBuffer(defaultPacketSize, conn)
 
-		// Complete prelogin handshake.
-		goodPreloginSequence(t, buf)
+		// Inline prelogin/login handshake (cannot use goodPreloginSequence
+		// because t.Fatal from a goroutine is unsupported by testing).
+		packetType, err := buf.BeginRead()
+		if err != nil {
+			t.Errorf("Failed to read PRELOGIN request: %v", err)
+			return
+		}
+		if packetType != packPrelogin {
+			t.Errorf("Client sent non PRELOGIN request packet type %d", packetType)
+			return
+		}
+		preloginFields := map[uint8][]byte{
+			preloginENCRYPTION: {encryptNotSup},
+		}
+		if err := writePrelogin(packReply, buf, preloginFields); err != nil {
+			t.Errorf("Writing PRELOGIN response failed: %v", err)
+			return
+		}
+		packetType, err = buf.BeginRead()
+		if err != nil {
+			t.Errorf("Failed to read LOGIN request: %v", err)
+			return
+		}
+		if packetType != packLogin7 {
+			t.Errorf("Client sent non LOGIN request packet type %d", packetType)
+			return
+		}
 
 		// Send a login response containing an ENVCHANGE routing token
 		// that redirects to 127.0.0.1:1 (a port nothing listens on).

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -86,7 +86,33 @@ func TestPreloginTimeout(t *testing.T) {
 			t.Fatalf("error=%v, want %v", err, context.Canceled)
 		}
 	})
+
+	t.Run("deadline passed but Err not yet propagated", func(t *testing.T) {
+		// Simulates the race where ctx.Err() returns nil but
+		// time.Until(deadline) is already <= 0.
+		ctx := pastDeadlineContext{
+			Context: context.Background(),
+			dl:      time.Now().Add(-time.Second),
+		}
+		_, err := preloginTimeout(ctx, 30*time.Second)
+		if err != context.DeadlineExceeded {
+			t.Fatalf("error=%v, want %v", err, context.DeadlineExceeded)
+		}
+	})
 }
+
+// pastDeadlineContext simulates a context whose deadline has passed but whose
+// Err() method has not yet returned non-nil.  This transient state can occur
+// in real programs due to goroutine scheduling between the time.Until and
+// ctx.Err calls inside preloginTimeout.
+type pastDeadlineContext struct {
+	context.Context
+	dl time.Time
+}
+
+func (c pastDeadlineContext) Deadline() (time.Time, bool) { return c.dl, true }
+func (c pastDeadlineContext) Err() error                  { return nil }
+func (c pastDeadlineContext) Done() <-chan struct{}        { return nil }
 
 // TestPreloginRespectsContextDeadline verifies that readPrelogin honors the
 // context deadline rather than hanging for the full ConnTimeout when the
@@ -471,4 +497,135 @@ func TestRoutingRedirectClosesFirstConnection(t *testing.T) {
 	}
 
 	t.Logf("Routing redirect correctly failed: %v", err)
+}
+
+// sendLoginResponse writes a minimal loginAck + done response to the TDS
+// buffer, completing the server side of a successful login handshake.
+func sendLoginResponse(buf *tdsBuffer) error {
+	buf.BeginPacket(packReply, false)
+	// loginAck token
+	buf.WriteByte(byte(tokenLoginAck))
+	binary.Write(buf, binary.LittleEndian, uint16(10))
+	buf.WriteByte(1)                                        // Interface = SQL_TSQL
+	binary.Write(buf, binary.BigEndian, uint32(0x74000004)) // TDSVersion
+	buf.WriteByte(0)                                        // ProgNameLen = 0
+	binary.Write(buf, binary.BigEndian, uint32(0))          // ProgVer
+	// done token
+	buf.WriteByte(byte(tokenDone))
+	binary.Write(buf, binary.LittleEndian, uint16(0)) // status
+	binary.Write(buf, binary.LittleEndian, uint16(0)) // curCmd
+	binary.Write(buf, binary.LittleEndian, uint64(0)) // rowCount
+	return buf.FinishPacket()
+}
+
+// TestConnectSuccessfulPreloginAndLogin exercises the full success path of
+// connect() through a mock server that handles prelogin and login without
+// requiring a real SQL Server instance. This covers the deferred-close
+// cleanup path (toconn = nil on success).
+func TestConnectSuccessfulPreloginAndLogin(t *testing.T) {
+	addr := &net.TCPAddr{IP: net.IP{127, 0, 0, 1}}
+	listener, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Fatal("Cannot start listener:", err)
+	}
+	defer listener.Close()
+	resolved := listener.Addr().(*net.TCPAddr)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer conn.Close()
+		buf := newTdsBuffer(defaultPacketSize, conn)
+		goodPreloginSequence(t, buf)
+		serverErr <- sendLoginResponse(buf)
+	}()
+
+	dsn := fmt.Sprintf("sqlserver://sa:unused@%s:%d?protocol=tcp&encrypt=disable&connection+timeout=5&dial+timeout=2",
+		resolved.IP.String(), resolved.Port)
+	db, err := sql.Open("sqlserver", dsn)
+	if err != nil {
+		t.Fatal("sql.Open failed:", err)
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Expected successful connection, got: %v", err)
+	}
+	conn.Close()
+
+	if sErr := <-serverErr; sErr != nil {
+		t.Errorf("Mock server error: %v", sErr)
+	}
+}
+
+// TestPreloginDeadlineAndSocketTimeoutRace exercises the path where the
+// connection timeout and context deadline fire at nearly the same instant.
+// Using identical values for both maximizes the chance of exercising the
+// net.Error-to-DeadlineExceeded conversion path in connect().
+func TestPreloginDeadlineAndSocketTimeoutRace(t *testing.T) {
+	addr := &net.TCPAddr{IP: net.IP{127, 0, 0, 1}}
+	listener, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Fatal("Cannot start listener:", err)
+	}
+	defer listener.Close()
+	resolved := listener.Addr().(*net.TCPAddr)
+
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			buf := make([]byte, 4096)
+			_, _ = conn.Read(buf)
+			<-done
+			conn.Close()
+		}
+	}()
+
+	// Use the same value for both timeouts so the socket timeout and context
+	// deadline fire at approximately the same instant.
+	const timeout = 300 * time.Millisecond
+	dsn := fmt.Sprintf("sqlserver://sa:unused@%s:%d?connection+timeout=0&dial+timeout=2&protocol=tcp&encrypt=disable",
+		resolved.IP.String(), resolved.Port)
+
+	db, err := sql.Open("sqlserver", dsn)
+	if err != nil {
+		t.Fatal("sql.Open failed:", err)
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	start := time.Now()
+	_, err = db.Conn(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Expected connection to fail")
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("Connection took %v, expected ~%v", elapsed, timeout)
+	}
+
+	// Either error is acceptable; both prove the timeout was respected.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		var ne net.Error
+		if !errors.As(err, &ne) || !ne.Timeout() {
+			t.Errorf("expected DeadlineExceeded or net timeout, got: %v", err)
+		}
+	}
 }

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -134,24 +134,39 @@ func TestPreloginRespectsContextDeadline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
+	type connResult struct {
+		conn    *sql.Conn
+		err     error
+		elapsed time.Duration
+	}
+	resultCh := make(chan connResult, 1)
 	start := time.Now()
-	conn, err := db.Conn(ctx)
-	elapsed := time.Since(start)
+	go func() {
+		conn, err := db.Conn(ctx)
+		resultCh <- connResult{conn: conn, err: err, elapsed: time.Since(start)}
+	}()
 
-	if err == nil {
-		conn.Close()
+	var result connResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("db.Conn(ctx) did not return before hard timeout; possible prelogin deadline regression")
+	}
+
+	if result.err == nil {
+		result.conn.Close()
 		t.Fatal("Expected connection to fail, but it succeeded")
 	}
 
 	// The connection should fail well before the full ConnTimeout (30s).
 	// We use a generous 5s bound to avoid flakes on slow CI; the real
 	// expectation is ~500ms from the context deadline.
-	if elapsed > 5*time.Second {
-		t.Errorf("Connection took %v, expected it to respect the 500ms context deadline", elapsed)
+	if result.elapsed > 5*time.Second {
+		t.Errorf("Connection took %v, expected it to respect the 500ms context deadline", result.elapsed)
 	}
 
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("expected context.DeadlineExceeded, got: %v", err)
+	if !errors.Is(result.err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded, got: %v", result.err)
 	}
 }
 
@@ -200,20 +215,35 @@ func TestPreloginRespectsContextCancel(t *testing.T) {
 	timer := time.AfterFunc(500*time.Millisecond, cancel)
 	defer timer.Stop()
 
+	type connResult struct {
+		conn    *sql.Conn
+		err     error
+		elapsed time.Duration
+	}
+	resultCh := make(chan connResult, 1)
 	start := time.Now()
-	conn, err := db.Conn(ctx)
-	elapsed := time.Since(start)
+	go func() {
+		conn, err := db.Conn(ctx)
+		resultCh <- connResult{conn: conn, err: err, elapsed: time.Since(start)}
+	}()
 
-	if err == nil {
-		conn.Close()
+	var result connResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("db.Conn(ctx) did not return before hard timeout; possible prelogin cancellation regression")
+	}
+
+	if result.err == nil {
+		result.conn.Close()
 		t.Fatal("Expected connection to fail, but it succeeded")
 	}
 
-	if elapsed > 5*time.Second {
-		t.Errorf("Connection took %v, expected it to respect context cancellation within ~500ms", elapsed)
+	if result.elapsed > 5*time.Second {
+		t.Errorf("Connection took %v, expected it to respect context cancellation within ~500ms", result.elapsed)
 	}
 
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("expected context.Canceled, got: %v", err)
+	if !errors.Is(result.err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", result.err)
 	}
 }

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -46,6 +46,19 @@ func TestPreloginTimeout(t *testing.T) {
 		}
 	})
 
+	t.Run("zero connection timeout uses context deadline", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		defer cancel()
+
+		got, err := preloginTimeout(ctx, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got <= 0 || got > 250*time.Millisecond {
+			t.Fatalf("timeout=%v, want a positive value no greater than %v", got, 250*time.Millisecond)
+		}
+	})
+
 	t.Run("expired deadline returns context error", func(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 		defer cancel()

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -194,9 +194,11 @@ func TestPreloginRespectsContextCancel(t *testing.T) {
 	defer db.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Cancel after 500ms to simulate a caller-driven cancellation.
-	time.AfterFunc(500*time.Millisecond, cancel)
+	timer := time.AfterFunc(500*time.Millisecond, cancel)
+	defer timer.Stop()
 
 	start := time.Now()
 	conn, err := db.Conn(ctx)

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -112,7 +112,7 @@ type pastDeadlineContext struct {
 
 func (c pastDeadlineContext) Deadline() (time.Time, bool) { return c.dl, true }
 func (c pastDeadlineContext) Err() error                  { return nil }
-func (c pastDeadlineContext) Done() <-chan struct{}        { return nil }
+func (c pastDeadlineContext) Done() <-chan struct{}       { return nil }
 
 // TestPreloginRespectsContextDeadline verifies that readPrelogin honors the
 // context deadline rather than hanging for the full ConnTimeout when the
@@ -441,11 +441,11 @@ func TestRoutingRedirectClosesFirstConnection(t *testing.T) {
 		// loginAck token so the login-response loop exits and
 		// processes the routing ENVCHANGE.
 		buf.WriteByte(byte(tokenLoginAck))
-		binary.Write(buf, binary.LittleEndian, uint16(10)) // payload size
-		buf.WriteByte(1)                                    // Interface = SQL_TSQL
+		binary.Write(buf, binary.LittleEndian, uint16(10))      // payload size
+		buf.WriteByte(1)                                        // Interface = SQL_TSQL
 		binary.Write(buf, binary.BigEndian, uint32(0x74000004)) // TDSVersion
-		buf.WriteByte(0)                                    // ProgNameLen = 0
-		binary.Write(buf, binary.BigEndian, uint32(0))      // ProgVer
+		buf.WriteByte(0)                                        // ProgNameLen = 0
+		binary.Write(buf, binary.BigEndian, uint32(0))          // ProgVer
 
 		buf.WriteByte(byte(tokenDone))
 		binary.Write(buf, binary.LittleEndian, uint16(0)) // status
@@ -540,7 +540,35 @@ func TestConnectSuccessfulPreloginAndLogin(t *testing.T) {
 		}
 		defer conn.Close()
 		buf := newTdsBuffer(defaultPacketSize, conn)
-		goodPreloginSequence(t, buf)
+
+		// Inline the prelogin/login handshake instead of calling
+		// goodPreloginSequence, which uses t.Fatal (unsafe from a goroutine).
+		packetType, err := buf.BeginRead()
+		if err != nil {
+			serverErr <- fmt.Errorf("read PRELOGIN request: %w", err)
+			return
+		}
+		if packetType != packPrelogin {
+			serverErr <- fmt.Errorf("expected PRELOGIN packet, got %d", packetType)
+			return
+		}
+		fields := map[uint8][]byte{
+			preloginENCRYPTION: {encryptNotSup},
+		}
+		if err := writePrelogin(packReply, buf, fields); err != nil {
+			serverErr <- fmt.Errorf("write PRELOGIN response: %w", err)
+			return
+		}
+		packetType, err = buf.BeginRead()
+		if err != nil {
+			serverErr <- fmt.Errorf("read LOGIN request: %w", err)
+			return
+		}
+		if packetType != packLogin7 {
+			serverErr <- fmt.Errorf("expected LOGIN packet, got %d", packetType)
+			return
+		}
+
 		serverErr <- sendLoginResponse(buf)
 	}()
 

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -142,9 +142,67 @@ func TestPreloginRespectsContextDeadline(t *testing.T) {
 		t.Fatal("Expected connection to fail, but it succeeded")
 	}
 
-	// The connection should fail within ~2x the context deadline.
-	// If the fix is broken, it would take the full ConnTimeout (30s).
+	// The connection should fail well before the full ConnTimeout (30s).
+	// We use a generous 5s bound to avoid flakes on slow CI; the real
+	// expectation is ~500ms from the context deadline.
 	if elapsed > 5*time.Second {
 		t.Errorf("Connection took %v, expected it to respect the 500ms context deadline", elapsed)
+	}
+}
+
+// TestPreloginRespectsContextCancel verifies that readPrelogin unblocks
+// when the context is canceled even without a deadline set.
+func TestPreloginRespectsContextCancel(t *testing.T) {
+	addr := &net.TCPAddr{IP: net.IP{127, 0, 0, 1}}
+	listener, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Fatal("Cannot start listener:", err)
+	}
+	defer listener.Close()
+	resolved := listener.Addr().(*net.TCPAddr)
+
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			buf := make([]byte, 4096)
+			_, _ = conn.Read(buf)
+			<-done
+			conn.Close()
+		}
+	}()
+
+	// connTimeout=30 and no context deadline: without the cancel watcher,
+	// this would block for the full 30s.
+	dsn := fmt.Sprintf("sqlserver://sa:unused@%s:%d?connection+timeout=30&dial+timeout=2&protocol=tcp&encrypt=disable",
+		resolved.IP.String(), resolved.Port)
+
+	db, err := sql.Open("sqlserver", dsn)
+	if err != nil {
+		t.Fatal("sql.Open failed:", err)
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel after 500ms to simulate a caller-driven cancellation.
+	time.AfterFunc(500*time.Millisecond, cancel)
+
+	start := time.Now()
+	conn, err := db.Conn(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		conn.Close()
+		t.Fatal("Expected connection to fail, but it succeeded")
+	}
+
+	if elapsed > 5*time.Second {
+		t.Errorf("Connection took %v, expected it to respect context cancellation within ~500ms", elapsed)
 	}
 }

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -3,6 +3,7 @@ package mssql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net"
 	"testing"
@@ -148,6 +149,10 @@ func TestPreloginRespectsContextDeadline(t *testing.T) {
 	if elapsed > 5*time.Second {
 		t.Errorf("Connection took %v, expected it to respect the 500ms context deadline", elapsed)
 	}
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded, got: %v", err)
+	}
 }
 
 // TestPreloginRespectsContextCancel verifies that readPrelogin unblocks
@@ -204,5 +209,9 @@ func TestPreloginRespectsContextCancel(t *testing.T) {
 
 	if elapsed > 5*time.Second {
 		t.Errorf("Connection took %v, expected it to respect context cancellation within ~500ms", elapsed)
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
 	}
 }

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -166,7 +166,12 @@ func TestPreloginRespectsContextDeadline(t *testing.T) {
 	}
 
 	if !errors.Is(result.err, context.DeadlineExceeded) {
-		t.Errorf("expected context.DeadlineExceeded, got: %v", result.err)
+		// The socket timeout from preloginTimeout and the context deadline
+		// can race. Both prove the deadline was respected; the elapsed
+		// check above is the primary assertion.
+		if ne := (net.Error)(nil); !errors.As(result.err, &ne) || !ne.Timeout() {
+			t.Errorf("expected context.DeadlineExceeded or net timeout, got: %v", result.err)
+		}
 	}
 }
 

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -71,6 +71,19 @@ func TestPreloginTimeout(t *testing.T) {
 			t.Fatalf("error=%v, want %v", err, context.DeadlineExceeded)
 		}
 	})
+
+	t.Run("canceled context without deadline returns context error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := preloginTimeout(ctx, 30*time.Second)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err != context.Canceled {
+			t.Fatalf("error=%v, want %v", err, context.Canceled)
+		}
+	})
 }
 
 // TestPreloginRespectsContextDeadline verifies that readPrelogin honors the

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -3,6 +3,7 @@ package mssql
 import (
 	"context"
 	"database/sql"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net"
@@ -251,4 +252,215 @@ func TestPreloginRespectsContextCancel(t *testing.T) {
 	if !errors.Is(result.err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got: %v", result.err)
 	}
+}
+
+// TestPreloginSocketTimeoutBeforeContextExpiry verifies that when the
+// connection timeout fires before the context deadline, readPrelogin
+// returns a socket timeout error (not a context error).
+func TestPreloginSocketTimeoutBeforeContextExpiry(t *testing.T) {
+	addr := &net.TCPAddr{IP: net.IP{127, 0, 0, 1}}
+	listener, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Fatal("Cannot start listener:", err)
+	}
+	defer listener.Close()
+	resolved := listener.Addr().(*net.TCPAddr)
+
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			// Read prelogin but never respond.
+			buf := make([]byte, 4096)
+			_, _ = conn.Read(buf)
+			<-done
+			conn.Close()
+		}
+	}()
+
+	// Short connection timeout (1s) with a long context (30s).
+	// The socket timeout from preloginTimeout should fire, NOT the context.
+	dsn := fmt.Sprintf("sqlserver://sa:unused@%s:%d?connection+timeout=1&dial+timeout=2&protocol=tcp&encrypt=disable",
+		resolved.IP.String(), resolved.Port)
+
+	db, err := sql.Open("sqlserver", dsn)
+	if err != nil {
+		t.Fatal("sql.Open failed:", err)
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	type connResult struct {
+		conn    *sql.Conn
+		err     error
+		elapsed time.Duration
+	}
+	resultCh := make(chan connResult, 1)
+	start := time.Now()
+	go func() {
+		conn, err := db.Conn(ctx)
+		resultCh <- connResult{conn: conn, err: err, elapsed: time.Since(start)}
+	}()
+
+	var result connResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("db.Conn(ctx) did not return; possible prelogin timeout regression")
+	}
+
+	if result.err == nil {
+		result.conn.Close()
+		t.Fatal("Expected connection to fail")
+	}
+
+	// Should fail from socket timeout (~1s), not context (30s).
+	if result.elapsed > 5*time.Second {
+		t.Errorf("Connection took %v; expected ~1s from socket timeout", result.elapsed)
+	}
+
+	// The error should be a net timeout, not context.DeadlineExceeded.
+	if errors.Is(result.err, context.DeadlineExceeded) {
+		t.Errorf("Got context.DeadlineExceeded but expected socket timeout error")
+	}
+}
+
+// TestPreloginTimeoutErrorPath verifies that an already-expired context
+// triggers the preloginTimeout error return inside connect().
+func TestPreloginTimeoutErrorPath(t *testing.T) {
+	addr := &net.TCPAddr{IP: net.IP{127, 0, 0, 1}}
+	listener, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Fatal("Cannot start listener:", err)
+	}
+	defer listener.Close()
+	resolved := listener.Addr().(*net.TCPAddr)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			buf := make([]byte, 4096)
+			_, _ = conn.Read(buf)
+			conn.Close()
+		}
+	}()
+
+	// Use a context that will expire very quickly. The dial has its own
+	// timeout so it can succeed even when the parent context expires.
+	// By the time writePrelogin + preloginTimeout run, the context should
+	// be expired, triggering the preloginTimeout → err path.
+	dsn := fmt.Sprintf("sqlserver://sa:unused@%s:%d?connection+timeout=30&dial+timeout=5&protocol=tcp&encrypt=disable",
+		resolved.IP.String(), resolved.Port)
+
+	db, err := sql.Open("sqlserver", dsn)
+	if err != nil {
+		t.Fatal("sql.Open failed:", err)
+	}
+	defer db.Close()
+
+	// Very short context: 1ms. Dial should complete before this expires
+	// (localhost connection), but preloginTimeout should see the expired context.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	// Give the context time to expire before attempting the connection.
+	time.Sleep(5 * time.Millisecond)
+
+	start := time.Now()
+	_, err = db.Conn(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Expected connection to fail with expired context")
+	}
+
+	// Should fail fast (context already expired).
+	if elapsed > 5*time.Second {
+		t.Errorf("Connection took %v; expected fast failure", elapsed)
+	}
+}
+
+// TestRoutingRedirectClosesFirstConnection verifies that when a server
+// sends a routing redirect, the original connection is properly closed
+// and toconn is set to nil before the next connection attempt.
+func TestRoutingRedirectClosesFirstConnection(t *testing.T) {
+	addr := &net.TCPAddr{IP: net.IP{127, 0, 0, 1}}
+	listener, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Fatal("Cannot start listener:", err)
+	}
+	defer listener.Close()
+	resolved := listener.Addr().(*net.TCPAddr)
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		buf := newTdsBuffer(defaultPacketSize, conn)
+
+		// Complete prelogin handshake.
+		goodPreloginSequence(t, buf)
+
+		// Send a login response containing an ENVCHANGE routing token
+		// that redirects to 127.0.0.1:1 (a port nothing listens on).
+		buf.BeginPacket(packReply, false)
+
+		routingServer := "127.0.0.1"
+		serverUTF16Len := len(routingServer) * 2
+		valueLength := 1 + 2 + 2 + serverUTF16Len
+		envPayloadLen := 1 + 2 + valueLength + 2
+
+		buf.WriteByte(byte(tokenEnvChange))
+		binary.Write(buf, binary.LittleEndian, uint16(envPayloadLen))
+		buf.WriteByte(20) // envRouting
+		binary.Write(buf, binary.LittleEndian, uint16(valueLength))
+		buf.WriteByte(0) // TCP
+		binary.Write(buf, binary.LittleEndian, uint16(1)) // port 1
+		binary.Write(buf, binary.LittleEndian, uint16(len(routingServer)))
+		for _, ch := range routingServer {
+			binary.Write(buf, binary.LittleEndian, uint16(ch))
+		}
+		binary.Write(buf, binary.LittleEndian, uint16(0)) // old value
+
+		buf.WriteByte(byte(tokenDone))
+		binary.Write(buf, binary.LittleEndian, uint16(0)) // status
+		binary.Write(buf, binary.LittleEndian, uint16(0)) // curCmd
+		binary.Write(buf, binary.LittleEndian, uint64(0)) // rowCount
+
+		if err := buf.FinishPacket(); err != nil {
+			t.Log("Writing routing response failed:", err)
+		}
+	}()
+
+	tl := testLogger{t: t}
+	defer tl.StopLogging()
+	SetLogger(&tl)
+
+	dsn := fmt.Sprintf("sqlserver://sa:unused@%s:%d?protocol=tcp&encrypt=disable&connection+timeout=5&dial+timeout=2",
+		resolved.IP.String(), resolved.Port)
+	db, err := sql.Open("sqlserver", dsn)
+	if err != nil {
+		t.Fatal("sql.Open failed:", err)
+	}
+	defer db.Close()
+
+	err = db.Ping()
+	if err == nil {
+		t.Fatal("Expected Ping to fail after routing redirect to dead server")
+	}
+
+	t.Logf("Routing redirect correctly failed: %v", err)
 }

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -427,7 +427,7 @@ func TestRoutingRedirectClosesFirstConnection(t *testing.T) {
 		binary.Write(buf, binary.LittleEndian, uint16(envPayloadLen))
 		buf.WriteByte(20) // envRouting
 		binary.Write(buf, binary.LittleEndian, uint16(valueLength))
-		buf.WriteByte(0) // TCP
+		buf.WriteByte(0)                                  // TCP
 		binary.Write(buf, binary.LittleEndian, uint16(1)) // port 1
 		binary.Write(buf, binary.LittleEndian, uint16(len(routingServer)))
 		for _, ch := range routingServer {

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -330,70 +330,19 @@ func TestPreloginSocketTimeoutBeforeContextExpiry(t *testing.T) {
 	if errors.Is(result.err, context.DeadlineExceeded) {
 		t.Errorf("Got context.DeadlineExceeded but expected socket timeout error")
 	}
-}
-
-// TestPreloginTimeoutErrorPath verifies that an already-expired context
-// triggers the preloginTimeout error return inside connect().
-func TestPreloginTimeoutErrorPath(t *testing.T) {
-	addr := &net.TCPAddr{IP: net.IP{127, 0, 0, 1}}
-	listener, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		t.Fatal("Cannot start listener:", err)
-	}
-	defer listener.Close()
-	resolved := listener.Addr().(*net.TCPAddr)
-
-	go func() {
-		for {
-			conn, err := listener.Accept()
-			if err != nil {
-				return
-			}
-			buf := make([]byte, 4096)
-			_, _ = conn.Read(buf)
-			conn.Close()
-		}
-	}()
-
-	// Use a context that will expire very quickly. The dial has its own
-	// timeout so it can succeed even when the parent context expires.
-	// By the time writePrelogin + preloginTimeout run, the context should
-	// be expired, triggering the preloginTimeout → err path.
-	dsn := fmt.Sprintf("sqlserver://sa:unused@%s:%d?connection+timeout=30&dial+timeout=5&protocol=tcp&encrypt=disable",
-		resolved.IP.String(), resolved.Port)
-
-	db, err := sql.Open("sqlserver", dsn)
-	if err != nil {
-		t.Fatal("sql.Open failed:", err)
-	}
-	defer db.Close()
-
-	// Very short context: 1ms. Dial should complete before this expires
-	// (localhost connection), but preloginTimeout should see the expired context.
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
-	defer cancel()
-
-	// Give the context time to expire before attempting the connection.
-	time.Sleep(5 * time.Millisecond)
-
-	start := time.Now()
-	_, err = db.Conn(ctx)
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("Expected connection to fail with expired context")
-	}
-
-	// Should fail fast (context already expired).
-	if elapsed > 5*time.Second {
-		t.Errorf("Connection took %v; expected fast failure", elapsed)
+	var ne net.Error
+	if !errors.As(result.err, &ne) || !ne.Timeout() {
+		t.Errorf("expected net.Error with Timeout()=true, got: %v", result.err)
 	}
 }
 
 // TestRoutingRedirectClosesFirstConnection verifies that when a server
 // sends a routing redirect, the original connection is properly closed
-// and toconn is set to nil before the next connection attempt.
+// before the next connection attempt. The mock server keeps its end open
+// and detects the client-side close by waiting for an EOF on Read.
 func TestRoutingRedirectClosesFirstConnection(t *testing.T) {
+	firstConnClosed := make(chan struct{})
+
 	addr := &net.TCPAddr{IP: net.IP{127, 0, 0, 1}}
 	listener, err := net.ListenTCP("tcp", addr)
 	if err != nil {
@@ -403,10 +352,12 @@ func TestRoutingRedirectClosesFirstConnection(t *testing.T) {
 	resolved := listener.Addr().(*net.TCPAddr)
 
 	go func() {
+		defer close(firstConnClosed)
 		conn, err := listener.Accept()
 		if err != nil {
 			return
 		}
+		// Keep the server side open so we can detect the client close.
 		defer conn.Close()
 
 		buf := newTdsBuffer(defaultPacketSize, conn)
@@ -442,6 +393,24 @@ func TestRoutingRedirectClosesFirstConnection(t *testing.T) {
 
 		if err := buf.FinishPacket(); err != nil {
 			t.Log("Writing routing response failed:", err)
+			return
+		}
+
+		// Drain any remaining client data.
+		for {
+			_ = conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			if _, err := conn.Read(make([]byte, 4096)); err != nil {
+				break
+			}
+		}
+
+		// Wait for the client to close its end of the first connection.
+		_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		_, err = conn.Read(make([]byte, 1))
+		if err == nil {
+			t.Error("expected server-side read to fail after client closed first connection")
+		} else if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			t.Error("server-side read timed out; client did not close the first connection")
 		}
 	}()
 
@@ -460,6 +429,13 @@ func TestRoutingRedirectClosesFirstConnection(t *testing.T) {
 	err = db.Ping()
 	if err == nil {
 		t.Fatal("Expected Ping to fail after routing redirect to dead server")
+	}
+
+	// Wait for the server goroutine to confirm the client closed the first connection.
+	select {
+	case <-firstConnClosed:
+	case <-time.After(15 * time.Second):
+		t.Fatal("server goroutine did not detect client close of first connection")
 	}
 
 	t.Logf("Routing redirect correctly failed: %v", err)

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -1,0 +1,124 @@
+package mssql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestPreloginTimeout(t *testing.T) {
+	t.Run("no deadline keeps connection timeout", func(t *testing.T) {
+		got, err := preloginTimeout(context.Background(), 30*time.Second)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 30*time.Second {
+			t.Fatalf("timeout=%v, want %v", got, 30*time.Second)
+		}
+	})
+
+	t.Run("sooner deadline wins", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		defer cancel()
+
+		got, err := preloginTimeout(ctx, 30*time.Second)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got <= 0 || got > 250*time.Millisecond {
+			t.Fatalf("timeout=%v, want a positive value no greater than %v", got, 250*time.Millisecond)
+		}
+	})
+
+	t.Run("shorter connection timeout stays in effect", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		got, err := preloginTimeout(ctx, 250*time.Millisecond)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 250*time.Millisecond {
+			t.Fatalf("timeout=%v, want %v", got, 250*time.Millisecond)
+		}
+	})
+
+	t.Run("expired deadline returns context error", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+
+		_, err := preloginTimeout(ctx, 30*time.Second)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err != context.DeadlineExceeded {
+			t.Fatalf("error=%v, want %v", err, context.DeadlineExceeded)
+		}
+	})
+}
+
+// TestPreloginRespectsContextDeadline verifies that readPrelogin honors the
+// context deadline rather than hanging for the full ConnTimeout when the
+// server never responds.
+func TestPreloginRespectsContextDeadline(t *testing.T) {
+	// Start a TCP listener that accepts connections but never sends data,
+	// simulating a server that hangs during prelogin.
+	addr := &net.TCPAddr{IP: net.IP{127, 0, 0, 1}}
+	listener, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Fatal("Cannot start listener:", err)
+	}
+	defer listener.Close()
+	resolved := listener.Addr().(*net.TCPAddr)
+
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			// Read the prelogin request but never respond.
+			buf := make([]byte, 4096)
+			_, _ = conn.Read(buf)
+			// Hold connection open until the test finishes.
+			<-done
+			conn.Close()
+		}
+	}()
+
+	// Use a long ConnTimeout (30s) so if the context deadline is NOT
+	// respected, the test will hang noticeably.
+	dsn := fmt.Sprintf("sqlserver://sa:unused@%s:%d?connection+timeout=30&dial+timeout=2&protocol=tcp&encrypt=disable",
+		resolved.IP.String(), resolved.Port)
+
+	db, err := sql.Open("sqlserver", dsn)
+	if err != nil {
+		t.Fatal("sql.Open failed:", err)
+	}
+	defer db.Close()
+
+	// Context with a short deadline — this is the one that should win.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	conn, err := db.Conn(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		conn.Close()
+		t.Fatal("Expected connection to fail, but it succeeded")
+	}
+
+	// The connection should fail within ~2x the context deadline.
+	// If the fix is broken, it would take the full ConnTimeout (30s).
+	if elapsed > 5*time.Second {
+		t.Errorf("Connection took %v, expected it to respect the 500ms context deadline", elapsed)
+	}
+}

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -412,25 +412,28 @@ func TestRoutingRedirectClosesFirstConnection(t *testing.T) {
 		}
 		binary.Write(buf, binary.LittleEndian, uint16(0)) // old value
 
+		// loginAck token so the login-response loop exits and
+		// processes the routing ENVCHANGE.
+		buf.WriteByte(byte(tokenLoginAck))
+		binary.Write(buf, binary.LittleEndian, uint16(10)) // payload size
+		buf.WriteByte(1)                                    // Interface = SQL_TSQL
+		binary.Write(buf, binary.BigEndian, uint32(0x74000004)) // TDSVersion
+		buf.WriteByte(0)                                    // ProgNameLen = 0
+		binary.Write(buf, binary.BigEndian, uint32(0))      // ProgVer
+
 		buf.WriteByte(byte(tokenDone))
 		binary.Write(buf, binary.LittleEndian, uint16(0)) // status
 		binary.Write(buf, binary.LittleEndian, uint16(0)) // curCmd
 		binary.Write(buf, binary.LittleEndian, uint64(0)) // rowCount
 
 		if err := buf.FinishPacket(); err != nil {
-			t.Log("Writing routing response failed:", err)
+			t.Errorf("Writing routing response failed: %v", err)
 			return
 		}
 
-		// Drain any remaining client data.
-		for {
-			_ = conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
-			if _, err := conn.Read(make([]byte, 4096)); err != nil {
-				break
-			}
-		}
-
 		// Wait for the client to close its end of the first connection.
+		// After processing the routing redirect, connect() calls
+		// toconn.Close() and sets toconn = nil before dialing the new host.
 		_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
 		_, err = conn.Read(make([]byte, 1))
 		if err == nil {
@@ -452,7 +455,10 @@ func TestRoutingRedirectClosesFirstConnection(t *testing.T) {
 	}
 	defer db.Close()
 
-	err = db.Ping()
+	pingCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = db.PingContext(pingCtx)
 	if err == nil {
 		t.Fatal("Expected Ping to fail after routing redirect to dead server")
 	}

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -638,9 +638,28 @@ func TestPreloginDeadlineAndSocketTimeoutRace(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	start := time.Now()
-	_, err = db.Conn(ctx)
-	elapsed := time.Since(start)
+	// Run the connect in a goroutine with an independent hard timeout: this
+	// test exercises cancellation, so it must not depend on cancellation
+	// working in order to terminate.
+	type result struct {
+		err     error
+		elapsed time.Duration
+	}
+	connDone := make(chan result, 1)
+	go func() {
+		start := time.Now()
+		_, err := db.Conn(ctx)
+		connDone <- result{err: err, elapsed: time.Since(start)}
+	}()
+
+	var res result
+	select {
+	case res = <-connDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("db.Conn did not return within 30s: the cancellation watcher or deadline propagation regressed")
+	}
+	err = res.err
+	elapsed := res.elapsed
 
 	if err == nil {
 		t.Fatal("Expected connection to fail")

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -280,6 +280,11 @@ func TestStrictEncryptionRespectsContextDeadline(t *testing.T) {
 	if result.elapsed > 5*time.Second {
 		t.Errorf("Connection took %v, expected it to respect the 500ms context deadline", result.elapsed)
 	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("context deadline did not fire")
+	}
 	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		t.Errorf("context error = %v, want DeadlineExceeded", ctx.Err())
 	}

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -202,6 +202,94 @@ func TestPreloginRespectsContextDeadline(t *testing.T) {
 	}
 }
 
+// TestStrictEncryptionRespectsContextDeadline covers the encrypt=strict path,
+// where the TLS handshake runs before prelogin and reads go through tls.Conn
+// rather than timeoutConn. Every other test in this file uses encrypt=disable,
+// so a regression that moved the deadline handling back below getTLSConn would
+// leave a silent strict server hanging and still pass the suite.
+func TestStrictEncryptionRespectsContextDeadline(t *testing.T) {
+	// Accept the TCP connection and read the TLS ClientHello, but never reply,
+	// so the handshake stalls with no bytes coming back.
+	addr := &net.TCPAddr{IP: net.IP{127, 0, 0, 1}}
+	listener, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		t.Fatal("Cannot start listener:", err)
+	}
+	defer listener.Close()
+	resolved := listener.Addr().(*net.TCPAddr)
+
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			buf := make([]byte, 4096)
+			_, _ = conn.Read(buf)
+			<-done
+			conn.Close()
+		}
+	}()
+
+	// A long ConnTimeout so an unbounded handshake would hang conspicuously.
+	dsn := fmt.Sprintf("sqlserver://sa:unused@%s:%d?connection+timeout=30&dial+timeout=2&protocol=tcp&encrypt=strict&TrustServerCertificate=true",
+		resolved.IP.String(), resolved.Port)
+
+	db, err := sql.Open("sqlserver", dsn)
+	if err != nil {
+		t.Fatal("sql.Open failed:", err)
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	type connResult struct {
+		conn    *sql.Conn
+		err     error
+		elapsed time.Duration
+	}
+	resultCh := make(chan connResult, 1)
+	start := time.Now()
+	go func() {
+		conn, err := db.Conn(ctx)
+		resultCh <- connResult{conn: conn, err: err, elapsed: time.Since(start)}
+	}()
+
+	var result connResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("db.Conn(ctx) did not return before hard timeout; strict TLS handshake is not bounded")
+	}
+
+	if result.err == nil {
+		result.conn.Close()
+		t.Fatal("Expected connection to fail, but it succeeded")
+	}
+
+	// Bracket the timing on both sides. Below the deadline would mean the
+	// connection failed for some other reason and proved nothing; far above it
+	// would mean the handshake ran to the 30s ConnTimeout instead.
+	if result.elapsed < 400*time.Millisecond {
+		t.Errorf("Connection failed after %v, before the 500ms deadline could have caused it", result.elapsed)
+	}
+	if result.elapsed > 5*time.Second {
+		t.Errorf("Connection took %v, expected it to respect the 500ms context deadline", result.elapsed)
+	}
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Errorf("context error = %v, want DeadlineExceeded", ctx.Err())
+	}
+
+	// The error itself is not asserted beyond being non-nil. Unlike the
+	// encrypt=disable path, the cancel watcher closes the socket out from under
+	// the handshake, so this surfaces as "use of closed network connection"
+	// rather than a timeout.
+}
+
 // TestPreloginRespectsContextCancel verifies that readPrelogin unblocks
 // when the context is canceled even without a deadline set.
 func TestPreloginRespectsContextCancel(t *testing.T) {

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -474,7 +474,6 @@ func TestRoutingRedirectClosesFirstConnection(t *testing.T) {
 		defer close(firstConnClosed)
 		conn, err := listener.Accept()
 		if err != nil {
-			t.Errorf("listener.Accept failed: %v", err)
 			return
 		}
 		// Keep the server side open so we can detect the client close.

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -124,6 +124,24 @@ func (preloginTimeoutError) Temporary() bool {
 	return true
 }
 
+// preloginWriteDeadlineContext simulates a deadline expiring between timeout
+// selection and handling the blocked write's timeout error.
+type preloginWriteDeadlineContext struct {
+	context.Context
+	deadlineCalls int
+}
+
+func (c *preloginWriteDeadlineContext) Deadline() (time.Time, bool) {
+	c.deadlineCalls++
+	if c.deadlineCalls == 1 {
+		return time.Now().Add(time.Minute), true
+	}
+	return time.Now().Add(-time.Second), true
+}
+
+func (c *preloginWriteDeadlineContext) Err() error            { return nil }
+func (c *preloginWriteDeadlineContext) Done() <-chan struct{} { return nil }
+
 func TestPreloginErrorConvertsTimeoutAfterDeadline(t *testing.T) {
 	ctx := pastDeadlineContext{
 		Context: context.Background(),
@@ -789,6 +807,26 @@ func TestPreloginWriteCancellationReturnsContextError(t *testing.T) {
 	}
 }
 
+func TestPreloginWriteTimeoutAfterDeadlineReturnsContextError(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+
+	connector, err := NewConnector("sqlserver://127.0.0.1?protocol=tcp&encrypt=disable&connection+timeout=30")
+	if err != nil {
+		t.Fatal("NewConnector failed:", err)
+	}
+	connector.params.DialTimeout = -1
+	connector.Dialer = singleConnDialer{
+		conn: preloginTimeoutWriteConn{Conn: client},
+	}
+
+	ctx := &preloginWriteDeadlineContext{Context: context.Background()}
+	_, err = connector.Connect(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error=%v, want %v", err, context.DeadlineExceeded)
+	}
+}
+
 // TestPreloginZeroConnectionTimeoutRespectsContextDeadline verifies that the
 // context deadline bounds prelogin when no connection timeout is configured.
 func TestPreloginZeroConnectionTimeoutRespectsContextDeadline(t *testing.T) {
@@ -904,6 +942,14 @@ func (c notifyWriteConn) Write(p []byte) (int, error) {
 	default:
 	}
 	return c.Conn.Write(p)
+}
+
+type preloginTimeoutWriteConn struct {
+	net.Conn
+}
+
+func (preloginTimeoutWriteConn) Write([]byte) (int, error) {
+	return 0, preloginTimeoutError{}
 }
 
 func startLoginAndQueryServer(t *testing.T) (*net.TCPAddr, <-chan error) {

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -719,6 +719,83 @@ func TestConnectSuccessfulPreloginAndLogin(t *testing.T) {
 	}
 }
 
+func TestConnectClearsContextDeadlineAfterPrelogin(t *testing.T) {
+	resolved, serverErr := startLoginAndQueryServer(t)
+	dsn := fmt.Sprintf("sqlserver://%s:%d?protocol=tcp&encrypt=disable&connection+timeout=0&dial+timeout=2",
+		resolved.IP.String(), resolved.Port)
+	connector, err := NewConnector(dsn)
+	if err != nil {
+		t.Fatal("NewConnector failed:", err)
+	}
+	deadlineCleared := make(chan struct{}, 1)
+	connector.Dialer = recordZeroDeadlineDialer{deadlineCleared: deadlineCleared}
+	db := sql.OpenDB(connector)
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Expected successful connection, got: %v", err)
+	}
+	defer conn.Close()
+
+	select {
+	case <-deadlineCleared:
+	default:
+		t.Fatal("context-derived prelogin deadline was not cleared")
+	}
+
+	<-ctx.Done()
+	if _, err := conn.ExecContext(context.Background(), "select 1"); err != nil {
+		t.Fatalf("query after prelogin context deadline failed: %v", err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("Mock server error: %v", err)
+	}
+}
+
+func TestPreloginWriteCancellationReturnsContextError(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+	writeStarted := make(chan struct{})
+	connector, err := NewConnector("sqlserver://127.0.0.1?protocol=tcp&encrypt=disable&connection+timeout=0&dial+timeout=2")
+	if err != nil {
+		t.Fatal("NewConnector failed:", err)
+	}
+	connector.Dialer = singleConnDialer{
+		conn: notifyWriteConn{
+			Conn:         client,
+			writeStarted: writeStarted,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	connectDone := make(chan error, 1)
+	go func() {
+		_, err := connector.Connect(ctx)
+		connectDone <- err
+	}()
+
+	select {
+	case <-writeStarted:
+	case err := <-connectDone:
+		t.Fatalf("Connect returned before prelogin write: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("prelogin write did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-connectDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error=%v, want %v", err, context.Canceled)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Connect did not return after context cancellation")
+	}
+}
+
 // TestPreloginZeroConnectionTimeoutRespectsContextDeadline verifies that the
 // context deadline bounds prelogin when no connection timeout is configured.
 func TestPreloginZeroConnectionTimeoutRespectsContextDeadline(t *testing.T) {
@@ -813,4 +890,120 @@ func (c rejectZeroDeadlineConn) SetDeadline(deadline time.Time) error {
 		return errors.New("zero deadline is unsupported")
 	}
 	return c.Conn.SetDeadline(deadline)
+}
+
+type recordZeroDeadlineDialer struct {
+	deadlineCleared chan<- struct{}
+}
+
+func (d recordZeroDeadlineDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, network, address)
+	if err != nil {
+		return nil, err
+	}
+	return recordZeroDeadlineConn{Conn: conn, deadlineCleared: d.deadlineCleared}, nil
+}
+
+type recordZeroDeadlineConn struct {
+	net.Conn
+	deadlineCleared chan<- struct{}
+}
+
+func (c recordZeroDeadlineConn) SetDeadline(deadline time.Time) error {
+	if deadline.IsZero() {
+		select {
+		case c.deadlineCleared <- struct{}{}:
+		default:
+		}
+	}
+	return c.Conn.SetDeadline(deadline)
+}
+
+type singleConnDialer struct {
+	conn net.Conn
+}
+
+func (d singleConnDialer) DialContext(context.Context, string, string) (net.Conn, error) {
+	return d.conn, nil
+}
+
+type notifyWriteConn struct {
+	net.Conn
+	writeStarted chan<- struct{}
+}
+
+func (c notifyWriteConn) Write(p []byte) (int, error) {
+	select {
+	case c.writeStarted <- struct{}{}:
+	default:
+	}
+	return c.Conn.Write(p)
+}
+
+func startLoginAndQueryServer(t *testing.T) (*net.TCPAddr, <-chan error) {
+	t.Helper()
+	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.IP{127, 0, 0, 1}})
+	if err != nil {
+		t.Fatal("Cannot start listener:", err)
+	}
+	t.Cleanup(func() { listener.Close() })
+
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer conn.Close()
+		buf := newTdsBuffer(defaultPacketSize, conn)
+
+		packetType, err := buf.BeginRead()
+		if err != nil {
+			serverErr <- fmt.Errorf("read PRELOGIN request: %w", err)
+			return
+		}
+		if packetType != packPrelogin {
+			serverErr <- fmt.Errorf("expected PRELOGIN packet, got %d", packetType)
+			return
+		}
+		if err := writePrelogin(packReply, buf, map[uint8][]byte{
+			preloginENCRYPTION: {encryptNotSup},
+		}); err != nil {
+			serverErr <- fmt.Errorf("write PRELOGIN response: %w", err)
+			return
+		}
+
+		packetType, err = buf.BeginRead()
+		if err != nil {
+			serverErr <- fmt.Errorf("read LOGIN request: %w", err)
+			return
+		}
+		if packetType != packLogin7 {
+			serverErr <- fmt.Errorf("expected LOGIN packet, got %d", packetType)
+			return
+		}
+		if err := sendLoginResponse(buf); err != nil {
+			serverErr <- err
+			return
+		}
+
+		packetType, err = buf.BeginRead()
+		if err != nil {
+			serverErr <- fmt.Errorf("read query: %w", err)
+			return
+		}
+		if packetType != packSQLBatch {
+			serverErr <- fmt.Errorf("expected SQL batch, got %d", packetType)
+			return
+		}
+		buf.BeginPacket(packReply, false)
+		buf.WriteByte(byte(tokenDone))
+		binary.Write(buf, binary.LittleEndian, uint16(0))
+		binary.Write(buf, binary.LittleEndian, uint16(0))
+		binary.Write(buf, binary.LittleEndian, uint64(0))
+		serverErr <- buf.FinishPacket()
+	}()
+
+	return listener.Addr().(*net.TCPAddr), serverErr
 }

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -114,6 +114,37 @@ func (c pastDeadlineContext) Deadline() (time.Time, bool) { return c.dl, true }
 func (c pastDeadlineContext) Err() error                  { return nil }
 func (c pastDeadlineContext) Done() <-chan struct{}       { return nil }
 
+type preloginTimeoutError struct{}
+
+var _ net.Error = preloginTimeoutError{}
+
+func (preloginTimeoutError) Error() string { return "i/o timeout" }
+func (preloginTimeoutError) Timeout() bool { return true }
+func (preloginTimeoutError) Temporary() bool {
+	return true
+}
+
+func TestPreloginErrorConvertsTimeoutAfterDeadline(t *testing.T) {
+	ctx := pastDeadlineContext{
+		Context: context.Background(),
+		dl:      time.Now().Add(-time.Second),
+	}
+
+	if err := preloginError(ctx, preloginTimeoutError{}); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error=%v, want %v", err, context.DeadlineExceeded)
+	}
+}
+
+func TestPreloginErrorPreservesTimeoutBeforeDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	timeoutErr := preloginTimeoutError{}
+
+	if err := preloginError(ctx, timeoutErr); !errors.Is(err, timeoutErr) {
+		t.Fatalf("error=%v, want %v", err, timeoutErr)
+	}
+}
+
 // TestPreloginRespectsContextDeadline verifies that readPrelogin honors the
 // context deadline rather than hanging for the full ConnTimeout when the
 // server never responds.
@@ -666,10 +697,12 @@ func TestConnectSuccessfulPreloginAndLogin(t *testing.T) {
 
 	dsn := fmt.Sprintf("sqlserver://sa:unused@%s:%d?protocol=tcp&encrypt=disable&connection+timeout=5&dial+timeout=2",
 		resolved.IP.String(), resolved.Port)
-	db, err := sql.Open("sqlserver", dsn)
+	connector, err := NewConnector(dsn)
 	if err != nil {
-		t.Fatal("sql.Open failed:", err)
+		t.Fatal("NewConnector failed:", err)
 	}
+	connector.Dialer = rejectZeroDeadlineDialer{}
+	db := sql.OpenDB(connector)
 	defer db.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -686,11 +719,9 @@ func TestConnectSuccessfulPreloginAndLogin(t *testing.T) {
 	}
 }
 
-// TestPreloginDeadlineAndSocketTimeoutRace exercises the path where the
-// connection timeout and context deadline fire at nearly the same instant.
-// Using identical values for both maximizes the chance of exercising the
-// net.Error-to-DeadlineExceeded conversion path in connect().
-func TestPreloginDeadlineAndSocketTimeoutRace(t *testing.T) {
+// TestPreloginZeroConnectionTimeoutRespectsContextDeadline verifies that the
+// context deadline bounds prelogin when no connection timeout is configured.
+func TestPreloginZeroConnectionTimeoutRespectsContextDeadline(t *testing.T) {
 	addr := &net.TCPAddr{IP: net.IP{127, 0, 0, 1}}
 	listener, err := net.ListenTCP("tcp", addr)
 	if err != nil {
@@ -715,8 +746,6 @@ func TestPreloginDeadlineAndSocketTimeoutRace(t *testing.T) {
 		}
 	}()
 
-	// Use the same value for both timeouts so the socket timeout and context
-	// deadline fire at approximately the same instant.
 	const timeout = 300 * time.Millisecond
 	dsn := fmt.Sprintf("sqlserver://sa:unused@%s:%d?connection+timeout=0&dial+timeout=2&protocol=tcp&encrypt=disable",
 		resolved.IP.String(), resolved.Port)
@@ -760,11 +789,28 @@ func TestPreloginDeadlineAndSocketTimeoutRace(t *testing.T) {
 		t.Errorf("Connection took %v, expected ~%v", elapsed, timeout)
 	}
 
-	// Either error is acceptable; both prove the timeout was respected.
 	if !errors.Is(err, context.DeadlineExceeded) {
-		var ne net.Error
-		if !errors.As(err, &ne) || !ne.Timeout() {
-			t.Errorf("expected DeadlineExceeded or net timeout, got: %v", err)
-		}
+		t.Errorf("expected DeadlineExceeded, got: %v", err)
 	}
+}
+
+type rejectZeroDeadlineDialer struct{}
+
+func (rejectZeroDeadlineDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, network, address)
+	if err != nil {
+		return nil, err
+	}
+	return rejectZeroDeadlineConn{Conn: conn}, nil
+}
+
+type rejectZeroDeadlineConn struct {
+	net.Conn
+}
+
+func (c rejectZeroDeadlineConn) SetDeadline(deadline time.Time) error {
+	if deadline.IsZero() {
+		return errors.New("zero deadline is unsupported")
+	}
+	return c.Conn.SetDeadline(deadline)
 }

--- a/prelogin_deadline_test.go
+++ b/prelogin_deadline_test.go
@@ -48,7 +48,7 @@ func TestPreloginTimeout(t *testing.T) {
 		}
 	})
 
-	t.Run("zero connection timeout uses context deadline", func(t *testing.T) {
+	t.Run("zero connection timeout relies on context watcher", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 		defer cancel()
 
@@ -56,8 +56,8 @@ func TestPreloginTimeout(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got <= 0 || got > 250*time.Millisecond {
-			t.Fatalf("timeout=%v, want a positive value no greater than %v", got, 250*time.Millisecond)
+		if got != 0 {
+			t.Fatalf("timeout=%v, want 0", got)
 		}
 	})
 
@@ -719,7 +719,7 @@ func TestConnectSuccessfulPreloginAndLogin(t *testing.T) {
 	}
 }
 
-func TestConnectClearsContextDeadlineAfterPrelogin(t *testing.T) {
+func TestConnectZeroTimeoutDoesNotRequireDeadlineReset(t *testing.T) {
 	resolved, serverErr := startLoginAndQueryServer(t)
 	dsn := fmt.Sprintf("sqlserver://%s:%d?protocol=tcp&encrypt=disable&connection+timeout=0&dial+timeout=2",
 		resolved.IP.String(), resolved.Port)
@@ -727,8 +727,7 @@ func TestConnectClearsContextDeadlineAfterPrelogin(t *testing.T) {
 	if err != nil {
 		t.Fatal("NewConnector failed:", err)
 	}
-	deadlineCleared := make(chan struct{}, 1)
-	connector.Dialer = recordZeroDeadlineDialer{deadlineCleared: deadlineCleared}
+	connector.Dialer = rejectZeroDeadlineDialer{}
 	db := sql.OpenDB(connector)
 	defer db.Close()
 
@@ -739,12 +738,6 @@ func TestConnectClearsContextDeadlineAfterPrelogin(t *testing.T) {
 		t.Fatalf("Expected successful connection, got: %v", err)
 	}
 	defer conn.Close()
-
-	select {
-	case <-deadlineCleared:
-	default:
-		t.Fatal("context-derived prelogin deadline was not cleared")
-	}
 
 	<-ctx.Done()
 	if _, err := conn.ExecContext(context.Background(), "select 1"); err != nil {
@@ -888,33 +881,6 @@ type rejectZeroDeadlineConn struct {
 func (c rejectZeroDeadlineConn) SetDeadline(deadline time.Time) error {
 	if deadline.IsZero() {
 		return errors.New("zero deadline is unsupported")
-	}
-	return c.Conn.SetDeadline(deadline)
-}
-
-type recordZeroDeadlineDialer struct {
-	deadlineCleared chan<- struct{}
-}
-
-func (d recordZeroDeadlineDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	conn, err := (&net.Dialer{}).DialContext(ctx, network, address)
-	if err != nil {
-		return nil, err
-	}
-	return recordZeroDeadlineConn{Conn: conn, deadlineCleared: d.deadlineCleared}, nil
-}
-
-type recordZeroDeadlineConn struct {
-	net.Conn
-	deadlineCleared chan<- struct{}
-}
-
-func (c recordZeroDeadlineConn) SetDeadline(deadline time.Time) error {
-	if deadline.IsZero() {
-		select {
-		case c.deadlineCleared <- struct{}{}:
-		default:
-		}
 	}
 	return c.Conn.SetDeadline(deadline)
 }

--- a/queries_test.go
+++ b/queries_test.go
@@ -2290,6 +2290,17 @@ func isAcceptableTimeoutErr(err error) bool {
 		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
 		return true
 	}
+	// StreamError wraps low-level errors without implementing Unwrap, so
+	// errors.As/errors.Is won't see through it. Check the inner error
+	// directly for a net timeout or timeout indicator string.
+	if se := (StreamError{}); errors.As(err, &se) {
+		if ne := (net.Error)(nil); errors.As(se.InnerError, &ne) && ne.Timeout() {
+			return true
+		}
+		if strings.Contains(se.InnerError.Error(), "timeout") {
+			return true
+		}
+	}
 	return false
 }
 

--- a/queries_test.go
+++ b/queries_test.go
@@ -2292,12 +2292,9 @@ func isAcceptableTimeoutErr(err error) bool {
 	}
 	// StreamError wraps low-level errors without implementing Unwrap, so
 	// errors.As/errors.Is won't see through it. Check the inner error
-	// directly for a net timeout or timeout indicator string.
+	// directly for a net timeout.
 	if se := (StreamError{}); errors.As(err, &se) {
 		if ne := (net.Error)(nil); errors.As(se.InnerError, &ne) && ne.Timeout() {
-			return true
-		}
-		if strings.Contains(se.InnerError.Error(), "timeout") {
 			return true
 		}
 	}

--- a/queries_test.go
+++ b/queries_test.go
@@ -2267,6 +2267,32 @@ func getLatency(t *testing.T) time.Duration {
 	return time.Since(now)
 }
 
+// isAcceptableTimeoutErr reports whether err is one of the expected outcomes
+// after a context deadline fires during query execution.
+//
+// After the context deadline, the driver sends ATTENTION to cancel.
+// Depending on timing, OS, and SQL Server version the surfaced error
+// can be any of:
+//   - context.DeadlineExceeded
+//   - a net.Error with Timeout() (i/o timeout on read/write)
+//   - SQL Server error 3980 ("batch aborted") when the server
+//     acknowledges ATTENTION before the client sees the timeout
+//   - the driver's explicit cancel-confirmation failure when ATTENTION
+//     was sent but the server never completed the cancellation handshake
+func isAcceptableTimeoutErr(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if ne := (net.Error)(nil); errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	if sqlErr := (Error{}); errors.As(err, &sqlErr) &&
+		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
+		return true
+	}
+	return false
+}
+
 func TestQueryTimeout(t *testing.T) {
 	conn, logger := open(t)
 	defer conn.Close()
@@ -2279,23 +2305,7 @@ func TestQueryTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("ExecContext expected to fail but succeeded")
 	}
-	// After the context deadline, the driver sends ATTENTION to cancel.
-	// Depending on timing, OS, and SQL Server version the surfaced error
-	// can be any of:
-	//   - context.DeadlineExceeded
-	//   - a net.Error with Timeout() (i/o timeout on read/write)
-	//   - SQL Server error 3980 ("batch aborted") when the server
-	//     acknowledges ATTENTION before the client sees the timeout
-	//   - the driver's explicit cancel-confirmation failure when ATTENTION
-	//     was sent but the server never completed the cancellation handshake
-	if errors.Is(err, context.DeadlineExceeded) {
-		// ok
-	} else if ne := (net.Error)(nil); errors.As(err, &ne) && ne.Timeout() {
-		// ok: net-level timeout
-	} else if sqlErr := (Error{}); errors.As(err, &sqlErr) &&
-		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
-		// ok: server aborted the batch after receiving ATTENTION
-	} else {
+	if !isAcceptableTimeoutErr(err) {
 		t.Fatalf("wrong kind of error for query timeout: %T: %v", err, err)
 	}
 
@@ -2324,16 +2334,8 @@ func TestLoginTimeout(t *testing.T) {
 		t.Fatal("ExecContext expected to fail but succeeded")
 	}
 	// With very low latency, the login completes before the deadline and
-	// this degenerates into a query-timeout scenario.  The same set of
-	// acceptable errors applies as in TestQueryTimeout.
-	if errors.Is(err, context.DeadlineExceeded) {
-		// ok
-	} else if ne := (net.Error)(nil); errors.As(err, &ne) && ne.Timeout() {
-		// ok: net-level timeout
-	} else if sqlErr := (Error{}); errors.As(err, &sqlErr) &&
-		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
-		// ok: server aborted the batch after receiving ATTENTION
-	} else {
+	// this degenerates into a query-timeout scenario.
+	if !isAcceptableTimeoutErr(err) {
 		t.Fatalf("wrong kind of error for login or query timeout: %T: %v", err, err)
 	}
 

--- a/queries_test.go
+++ b/queries_test.go
@@ -2320,14 +2320,21 @@ func TestLoginTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), latency+200*time.Millisecond)
 	defer cancel()
 	_, err := conn.ExecContext(ctx, "waitfor delay '00:00:03'")
-	t.Logf("Got error type %v: %s ", reflect.TypeOf(err), err.Error())
-	if oe, ok := err.(*net.OpError); ok {
-		if !oe.Timeout() {
-			t.Fatalf("Got non-timeout error %s", oe.Error())
-		}
-		// The type of error is not guaranteed so just look for "timeout"
-	} else if err != context.DeadlineExceeded && !strings.Contains(err.Error(), "timeout") {
-		t.Fatalf("wrong kind of error for login or query timeout: %+v", err)
+	if err == nil {
+		t.Fatal("ExecContext expected to fail but succeeded")
+	}
+	// With very low latency, the login completes before the deadline and
+	// this degenerates into a query-timeout scenario.  The same set of
+	// acceptable errors applies as in TestQueryTimeout.
+	if errors.Is(err, context.DeadlineExceeded) {
+		// ok
+	} else if ne := (net.Error)(nil); errors.As(err, &ne) && ne.Timeout() {
+		// ok: net-level timeout
+	} else if sqlErr := (Error{}); errors.As(err, &sqlErr) &&
+		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
+		// ok: server aborted the batch after receiving ATTENTION
+	} else {
+		t.Fatalf("wrong kind of error for login or query timeout: %T: %v", err, err)
 	}
 
 	// connection should be usable after timeout

--- a/queries_test.go
+++ b/queries_test.go
@@ -2276,8 +2276,27 @@ func TestQueryTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), latency+2000*time.Millisecond)
 	defer cancel()
 	_, err := conn.ExecContext(ctx, "waitfor delay '00:00:20'")
-	if err != context.DeadlineExceeded {
-		t.Errorf("ExecContext expected to fail with DeadlineExceeded but it returned %v", err)
+	if err == nil {
+		t.Fatal("ExecContext expected to fail but succeeded")
+	}
+	// After the context deadline, the driver sends ATTENTION to cancel.
+	// Depending on timing, OS, and SQL Server version the surfaced error
+	// can be any of:
+	//   - context.DeadlineExceeded
+	//   - a net.Error with Timeout() (i/o timeout on read/write)
+	//   - SQL Server error 3980 ("batch aborted") when the server
+	//     acknowledges ATTENTION before the client sees the timeout
+	//   - the driver's explicit cancel-confirmation failure when ATTENTION
+	//     was sent but the server never completed the cancellation handshake
+	if errors.Is(err, context.DeadlineExceeded) {
+		// ok
+	} else if ne := (net.Error)(nil); errors.As(err, &ne) && ne.Timeout() {
+		// ok: net-level timeout
+	} else if sqlErr := (Error{}); errors.As(err, &sqlErr) &&
+		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
+		// ok: server aborted the batch after receiving ATTENTION
+	} else {
+		t.Fatalf("wrong kind of error for query timeout: %T: %v", err, err)
 	}
 
 	// connection should be usable after timeout

--- a/queries_test.go
+++ b/queries_test.go
@@ -2327,6 +2327,17 @@ func isAcceptableTimeoutErr(err error) bool {
 		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
 		return true
 	}
+	// StreamError wraps low-level errors without implementing Unwrap, so
+	// errors.As/errors.Is won't see through it. Check the inner error
+	// directly for a net timeout or timeout indicator string.
+	if se := (StreamError{}); errors.As(err, &se) {
+		if ne := (net.Error)(nil); errors.As(se.InnerError, &ne) && ne.Timeout() {
+			return true
+		}
+		if strings.Contains(se.InnerError.Error(), "timeout") {
+			return true
+		}
+	}
 	return false
 }
 

--- a/queries_test.go
+++ b/queries_test.go
@@ -2304,6 +2304,32 @@ func getLatency(t *testing.T) time.Duration {
 	return time.Since(now)
 }
 
+// isAcceptableTimeoutErr reports whether err is one of the expected outcomes
+// after a context deadline fires during query execution.
+//
+// After the context deadline, the driver sends ATTENTION to cancel.
+// Depending on timing, OS, and SQL Server version the surfaced error
+// can be any of:
+//   - context.DeadlineExceeded
+//   - a net.Error with Timeout() (i/o timeout on read/write)
+//   - SQL Server error 3980 ("batch aborted") when the server
+//     acknowledges ATTENTION before the client sees the timeout
+//   - the driver's explicit cancel-confirmation failure when ATTENTION
+//     was sent but the server never completed the cancellation handshake
+func isAcceptableTimeoutErr(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if ne := (net.Error)(nil); errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	if sqlErr := (Error{}); errors.As(err, &sqlErr) &&
+		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
+		return true
+	}
+	return false
+}
+
 func TestQueryTimeout(t *testing.T) {
 	conn, logger := open(t)
 	defer conn.Close()
@@ -2316,23 +2342,7 @@ func TestQueryTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("ExecContext expected to fail but succeeded")
 	}
-	// After the context deadline, the driver sends ATTENTION to cancel.
-	// Depending on timing, OS, and SQL Server version the surfaced error
-	// can be any of:
-	//   - context.DeadlineExceeded
-	//   - a net.Error with Timeout() (i/o timeout on read/write)
-	//   - SQL Server error 3980 ("batch aborted") when the server
-	//     acknowledges ATTENTION before the client sees the timeout
-	//   - the driver's explicit cancel-confirmation failure when ATTENTION
-	//     was sent but the server never completed the cancellation handshake
-	if errors.Is(err, context.DeadlineExceeded) {
-		// ok
-	} else if ne := (net.Error)(nil); errors.As(err, &ne) && ne.Timeout() {
-		// ok: net-level timeout
-	} else if sqlErr := (Error{}); errors.As(err, &sqlErr) &&
-		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
-		// ok: server aborted the batch after receiving ATTENTION
-	} else {
+	if !isAcceptableTimeoutErr(err) {
 		t.Fatalf("wrong kind of error for query timeout: %T: %v", err, err)
 	}
 
@@ -2361,16 +2371,8 @@ func TestLoginTimeout(t *testing.T) {
 		t.Fatal("ExecContext expected to fail but succeeded")
 	}
 	// With very low latency, the login completes before the deadline and
-	// this degenerates into a query-timeout scenario.  The same set of
-	// acceptable errors applies as in TestQueryTimeout.
-	if errors.Is(err, context.DeadlineExceeded) {
-		// ok
-	} else if ne := (net.Error)(nil); errors.As(err, &ne) && ne.Timeout() {
-		// ok: net-level timeout
-	} else if sqlErr := (Error{}); errors.As(err, &sqlErr) &&
-		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
-		// ok: server aborted the batch after receiving ATTENTION
-	} else {
+	// this degenerates into a query-timeout scenario.
+	if !isAcceptableTimeoutErr(err) {
 		t.Fatalf("wrong kind of error for login or query timeout: %T: %v", err, err)
 	}
 

--- a/queries_test.go
+++ b/queries_test.go
@@ -2327,14 +2327,6 @@ func isAcceptableTimeoutErr(err error) bool {
 		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
 		return true
 	}
-	// StreamError wraps low-level errors without implementing Unwrap, so
-	// errors.As/errors.Is won't see through it. Check the inner error
-	// directly for a net timeout.
-	if se := (StreamError{}); errors.As(err, &se) {
-		if ne := (net.Error)(nil); errors.As(se.InnerError, &ne) && ne.Timeout() {
-			return true
-		}
-	}
 	return false
 }
 

--- a/queries_test.go
+++ b/queries_test.go
@@ -2329,12 +2329,9 @@ func isAcceptableTimeoutErr(err error) bool {
 	}
 	// StreamError wraps low-level errors without implementing Unwrap, so
 	// errors.As/errors.Is won't see through it. Check the inner error
-	// directly for a net timeout or timeout indicator string.
+	// directly for a net timeout.
 	if se := (StreamError{}); errors.As(err, &se) {
 		if ne := (net.Error)(nil); errors.As(se.InnerError, &ne) && ne.Timeout() {
-			return true
-		}
-		if strings.Contains(se.InnerError.Error(), "timeout") {
 			return true
 		}
 	}

--- a/queries_test.go
+++ b/queries_test.go
@@ -2313,8 +2313,27 @@ func TestQueryTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), latency+2000*time.Millisecond)
 	defer cancel()
 	_, err := conn.ExecContext(ctx, "waitfor delay '00:00:20'")
-	if err != context.DeadlineExceeded {
-		t.Errorf("ExecContext expected to fail with DeadlineExceeded but it returned %v", err)
+	if err == nil {
+		t.Fatal("ExecContext expected to fail but succeeded")
+	}
+	// After the context deadline, the driver sends ATTENTION to cancel.
+	// Depending on timing, OS, and SQL Server version the surfaced error
+	// can be any of:
+	//   - context.DeadlineExceeded
+	//   - a net.Error with Timeout() (i/o timeout on read/write)
+	//   - SQL Server error 3980 ("batch aborted") when the server
+	//     acknowledges ATTENTION before the client sees the timeout
+	//   - the driver's explicit cancel-confirmation failure when ATTENTION
+	//     was sent but the server never completed the cancellation handshake
+	if errors.Is(err, context.DeadlineExceeded) {
+		// ok
+	} else if ne := (net.Error)(nil); errors.As(err, &ne) && ne.Timeout() {
+		// ok: net-level timeout
+	} else if sqlErr := (Error{}); errors.As(err, &sqlErr) &&
+		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
+		// ok: server aborted the batch after receiving ATTENTION
+	} else {
+		t.Fatalf("wrong kind of error for query timeout: %T: %v", err, err)
 	}
 
 	// connection should be usable after timeout

--- a/queries_test.go
+++ b/queries_test.go
@@ -2357,14 +2357,21 @@ func TestLoginTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), latency+200*time.Millisecond)
 	defer cancel()
 	_, err := conn.ExecContext(ctx, "waitfor delay '00:00:03'")
-	t.Logf("Got error type %v: %s ", reflect.TypeOf(err), err.Error())
-	if oe, ok := err.(*net.OpError); ok {
-		if !oe.Timeout() {
-			t.Fatalf("Got non-timeout error %s", oe.Error())
-		}
-		// The type of error is not guaranteed so just look for "timeout"
-	} else if err != context.DeadlineExceeded && !strings.Contains(err.Error(), "timeout") {
-		t.Fatalf("wrong kind of error for login or query timeout: %+v", err)
+	if err == nil {
+		t.Fatal("ExecContext expected to fail but succeeded")
+	}
+	// With very low latency, the login completes before the deadline and
+	// this degenerates into a query-timeout scenario.  The same set of
+	// acceptable errors applies as in TestQueryTimeout.
+	if errors.Is(err, context.DeadlineExceeded) {
+		// ok
+	} else if ne := (net.Error)(nil); errors.As(err, &ne) && ne.Timeout() {
+		// ok: net-level timeout
+	} else if sqlErr := (Error{}); errors.As(err, &sqlErr) &&
+		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
+		// ok: server aborted the batch after receiving ATTENTION
+	} else {
+		t.Fatalf("wrong kind of error for login or query timeout: %T: %v", err, err)
 	}
 
 	// connection should be usable after timeout

--- a/queries_test.go
+++ b/queries_test.go
@@ -2323,11 +2323,20 @@ func isAcceptableTimeoutErr(err error) bool {
 	if ne := (net.Error)(nil); errors.As(err, &ne) && ne.Timeout() {
 		return true
 	}
-	if sqlErr := (Error{}); errors.As(err, &sqlErr) &&
-		(sqlErr.Number == 3980 || sqlErr.Message == "did not get cancellation confirmation from the server") {
+	if errors.Is(err, errCancelConfirmation) {
+		return true
+	}
+	if sqlErr := (Error{}); errors.As(err, &sqlErr) && sqlErr.Number == 3980 {
 		return true
 	}
 	return false
+}
+
+func TestIsAcceptableTimeoutErrAcceptsCancelConfirmationFailure(t *testing.T) {
+	err := cancelDrainError("current response", context.Background(), nil)
+	if !isAcceptableTimeoutErr(err) {
+		t.Fatalf("cancel confirmation failure should be accepted: %v", err)
+	}
 }
 
 func TestQueryTimeout(t *testing.T) {

--- a/tds.go
+++ b/tds.go
@@ -1240,10 +1240,31 @@ initiate_connection:
 		return nil, err
 	}
 
+	// If the context has no deadline but is cancelable and connTimeout is 0,
+	// the read could block indefinitely. Watch ctx.Done() and close the
+	// connection to unblock readPrelogin on cancellation.
+	cancelDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			toconn.Close()
+		case <-cancelDone:
+		}
+	}()
+
 	fields, err = readPrelogin(outbuf)
+	close(cancelDone)
 
 	// Restore the original timeout for subsequent reads.
 	toconn.timeout = origTimeout
+
+	// If the context was canceled, the watcher goroutine may have closed
+	// the connection. Return the context error regardless of whether the
+	// read itself succeeded to avoid using a potentially closed conn.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		toconn.Close()
+		return nil, ctxErr
+	}
 
 	if err != nil {
 		toconn.Close()

--- a/tds.go
+++ b/tds.go
@@ -1199,6 +1199,7 @@ initiate_connection:
 	defer func() {
 		if toconn != nil {
 			toconn.Close()
+			toconn = nil
 		}
 	}()
 	outbuf := newTdsBuffer(packetSize, toconn)
@@ -1263,15 +1264,19 @@ initiate_connection:
 	fields, err = readPrelogin(outbuf)
 	close(cancelDone)
 
-	// Restore the original timeout for subsequent reads.
-	toconn.timeout = origTimeout
-
 	// If the context was canceled, the watcher goroutine may have closed
 	// the connection. Return the context error regardless of whether the
 	// read itself succeeded to avoid using a potentially closed conn.
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, ctxErr
 	}
+
+	// Restore the original timeout for subsequent reads. This must happen
+	// after the ctx.Err() check: if the context was canceled, the watcher
+	// goroutine may still be calling toconn.Close() (value-receiver copies
+	// the struct, reading the timeout field). By returning above in that
+	// case, we avoid a data race on toconn.timeout.
+	toconn.timeout = origTimeout
 
 	if err != nil {
 		return nil, err

--- a/tds.go
+++ b/tds.go
@@ -1253,7 +1253,9 @@ initiate_connection:
 	// the read could block indefinitely. Watch ctx.Done() and close the
 	// connection to unblock readPrelogin on cancellation.
 	cancelDone := make(chan struct{})
+	watcherDone := make(chan struct{})
 	go func() {
+		defer close(watcherDone)
 		select {
 		case <-ctx.Done():
 			toconn.Close()
@@ -1263,19 +1265,17 @@ initiate_connection:
 
 	fields, err = readPrelogin(outbuf)
 	close(cancelDone)
+	<-watcherDone // wait for goroutine to exit before touching toconn
 
-	// If the context was canceled, the watcher goroutine may have closed
-	// the connection. Return the context error regardless of whether the
-	// read itself succeeded to avoid using a potentially closed conn.
+	// If the context was canceled, the watcher goroutine closed the
+	// connection. Return the context error regardless of whether the
+	// read itself succeeded to avoid using a closed conn.
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, ctxErr
 	}
 
-	// Restore the original timeout for subsequent reads. This must happen
-	// after the ctx.Err() check: if the context was canceled, the watcher
-	// goroutine may still be calling toconn.Close() (value-receiver copies
-	// the struct, reading the timeout field). By returning above in that
-	// case, we avoid a data race on toconn.timeout.
+	// Restore the original timeout for subsequent reads. Safe because the
+	// watcher goroutine has exited (watcherDone is closed above).
 	toconn.timeout = origTimeout
 
 	if err != nil {

--- a/tds.go
+++ b/tds.go
@@ -1192,6 +1192,15 @@ initiate_connection:
 	}
 
 	toconn := newTimeoutConn(conn, p.ConnTimeout)
+
+	// Ensure the connection is closed on any error path after dial.
+	// On success (or server-initiated reroute), we set toconn to nil
+	// before returning so the deferred close becomes a no-op.
+	defer func() {
+		if toconn != nil {
+			toconn.Close()
+		}
+	}()
 	outbuf := newTdsBuffer(packetSize, toconn)
 
 	if p.Encryption == msdsn.EncryptionStrict {
@@ -1236,7 +1245,6 @@ initiate_connection:
 	origTimeout := toconn.timeout
 	toconn.timeout, err = preloginTimeout(ctx, origTimeout)
 	if err != nil {
-		toconn.Close()
 		return nil, err
 	}
 
@@ -1262,12 +1270,10 @@ initiate_connection:
 	// the connection. Return the context error regardless of whether the
 	// read itself succeeded to avoid using a potentially closed conn.
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		toconn.Close()
 		return nil, ctxErr
 	}
 
 	if err != nil {
-		toconn.Close()
 		return nil, err
 	}
 
@@ -1436,7 +1442,6 @@ initiate_connection:
 				if token.isError() {
 					tokenErr := token.getError()
 					tokenErr.Message = "login error: " + tokenErr.Message
-					conn.Close()
 					return nil, tokenErr
 				}
 			case error:
@@ -1447,6 +1452,7 @@ initiate_connection:
 
 	if sess.routedServer != "" {
 		toconn.Close()
+		toconn = nil // prevent deferred double close
 		// Need to handle case when routedServer is in "host\instance" format.
 		routedParts := strings.SplitN(sess.routedServer, "\\", 2)
 		p.Host = routedParts[0]
@@ -1460,6 +1466,7 @@ initiate_connection:
 		}
 		goto initiate_connection
 	}
+	toconn = nil // success: prevent deferred close
 	return sess, nil
 }
 

--- a/tds.go
+++ b/tds.go
@@ -1136,10 +1136,7 @@ func preloginTimeout(ctx context.Context, connTimeout time.Duration) (time.Durat
 
 	ctxTimeout := time.Until(deadline)
 	if ctxTimeout <= 0 {
-		if err := ctx.Err(); err != nil {
-			return connTimeout, err
-		}
-		return connTimeout, context.DeadlineExceeded
+		return 0, ctx.Err()
 	}
 
 	if connTimeout == 0 || ctxTimeout < connTimeout {
@@ -1235,6 +1232,7 @@ initiate_connection:
 	origTimeout := toconn.timeout
 	toconn.timeout, err = preloginTimeout(ctx, origTimeout)
 	if err != nil {
+		toconn.Close()
 		return nil, err
 	}
 
@@ -1244,6 +1242,7 @@ initiate_connection:
 	toconn.timeout = origTimeout
 
 	if err != nil {
+		toconn.Close()
 		return nil, err
 	}
 

--- a/tds.go
+++ b/tds.go
@@ -1129,6 +1129,10 @@ func getTLSConn(conn *timeoutConn, p msdsn.Config, alpnSeq string) (tlsConn *tls
 }
 
 func preloginTimeout(ctx context.Context, connTimeout time.Duration) (time.Duration, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		return connTimeout, nil
@@ -1136,7 +1140,7 @@ func preloginTimeout(ctx context.Context, connTimeout time.Duration) (time.Durat
 
 	ctxTimeout := time.Until(deadline)
 	if ctxTimeout <= 0 {
-		return 0, ctx.Err()
+		return 0, context.DeadlineExceeded
 	}
 
 	if connTimeout == 0 || ctxTimeout < connTimeout {

--- a/tds.go
+++ b/tds.go
@@ -1277,13 +1277,21 @@ initiate_connection:
 		return nil, ctxErr
 	}
 
+	// The socket timeout from preloginTimeout and the context deadline
+	// can fire at nearly the same instant. If the read timed out and
+	// the context deadline has since passed (even though ctx.Err() had
+	// not yet propagated above), return the context error instead of
+	// a raw "i/o timeout".
+	if err != nil {
+		if dl, ok := ctx.Deadline(); ok && !time.Now().Before(dl) {
+			return nil, context.DeadlineExceeded
+		}
+		return nil, err
+	}
+
 	// Restore the original timeout for subsequent reads. Safe because the
 	// watcher goroutine has exited (watcherDone is closed above).
 	toconn.timeout = origTimeout
-
-	if err != nil {
-		return nil, err
-	}
 
 	encrypt, err := interpretPreloginResponse(p, fedAuth, fields)
 	if err != nil {

--- a/tds.go
+++ b/tds.go
@@ -1281,10 +1281,14 @@ initiate_connection:
 	// can fire at nearly the same instant. If the read timed out and
 	// the context deadline has since passed (even though ctx.Err() had
 	// not yet propagated above), return the context error instead of
-	// a raw "i/o timeout".
+	// a raw "i/o timeout". Only override when the error is actually a
+	// timeout to avoid masking unrelated failures (EOF, connection reset).
 	if err != nil {
-		if dl, ok := ctx.Deadline(); ok && !time.Now().Before(dl) {
-			return nil, context.DeadlineExceeded
+		var ne net.Error
+		if errors.As(err, &ne) && ne.Timeout() {
+			if dl, ok := ctx.Deadline(); ok && !time.Now().Before(dl) {
+				return nil, context.DeadlineExceeded
+			}
 		}
 		return nil, err
 	}

--- a/tds.go
+++ b/tds.go
@@ -1249,9 +1249,12 @@ initiate_connection:
 		return nil, err
 	}
 
-	// If the context has no deadline but is cancelable and connTimeout is 0,
-	// the read could block indefinitely. Watch ctx.Done() and close the
-	// connection to unblock readPrelogin on cancellation.
+	// Watch ctx.Done() for every prelogin read and close the connection to
+	// unblock readPrelogin on any context cancellation or deadline expiry.
+	// This is needed even though preloginTimeout may reduce toconn.timeout,
+	// because ctx can be canceled after that timeout is computed but before
+	// or during the read, and because without a deadline and with
+	// connTimeout == 0 the read could otherwise block indefinitely.
 	cancelDone := make(chan struct{})
 	watcherDone := make(chan struct{})
 	go func() {

--- a/tds.go
+++ b/tds.go
@@ -1128,6 +1128,27 @@ func getTLSConn(conn *timeoutConn, p msdsn.Config, alpnSeq string) (tlsConn *tls
 	return tlsConn, nil
 }
 
+func preloginTimeout(ctx context.Context, connTimeout time.Duration) (time.Duration, error) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return connTimeout, nil
+	}
+
+	ctxTimeout := time.Until(deadline)
+	if ctxTimeout <= 0 {
+		if err := ctx.Err(); err != nil {
+			return connTimeout, err
+		}
+		return connTimeout, context.DeadlineExceeded
+	}
+
+	if connTimeout == 0 || ctxTimeout < connTimeout {
+		return ctxTimeout, nil
+	}
+
+	return connTimeout, nil
+}
+
 func connect(ctx context.Context, c *Connector, logger ContextLogger, p msdsn.Config) (res *tdsSession, err error) {
 	var cbt *integratedauth.ChannelBindings
 	isTransportEncrypted := false
@@ -1206,7 +1227,22 @@ initiate_connection:
 		return nil, err
 	}
 
+	// Ensure the prelogin read respects the context deadline so connect()
+	// does not hang indefinitely when the server never responds.
+	// We temporarily reduce toconn.timeout rather than using SetReadDeadline
+	// because timeoutConn.Read() calls SetDeadline(now+timeout) on every
+	// read, which would overwrite a SetReadDeadline value.
+	origTimeout := toconn.timeout
+	toconn.timeout, err = preloginTimeout(ctx, origTimeout)
+	if err != nil {
+		return nil, err
+	}
+
 	fields, err = readPrelogin(outbuf)
+
+	// Restore the original timeout for subsequent reads.
+	toconn.timeout = origTimeout
+
 	if err != nil {
 		return nil, err
 	}

--- a/tds.go
+++ b/tds.go
@@ -1164,6 +1164,27 @@ func getTLSConn(conn *timeoutConn, p msdsn.Config, alpnSeq string) (tlsConn *tls
 	return tlsConn, nil
 }
 
+func preloginTimeout(ctx context.Context, connTimeout time.Duration) (time.Duration, error) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return connTimeout, nil
+	}
+
+	ctxTimeout := time.Until(deadline)
+	if ctxTimeout <= 0 {
+		if err := ctx.Err(); err != nil {
+			return connTimeout, err
+		}
+		return connTimeout, context.DeadlineExceeded
+	}
+
+	if connTimeout == 0 || ctxTimeout < connTimeout {
+		return ctxTimeout, nil
+	}
+
+	return connTimeout, nil
+}
+
 func connect(ctx context.Context, c *Connector, logger ContextLogger, p msdsn.Config) (res *tdsSession, err error) {
 	var cbt *integratedauth.ChannelBindings
 	isTransportEncrypted := false
@@ -1249,7 +1270,22 @@ initiate_connection:
 		return nil, err
 	}
 
+	// Ensure the prelogin read respects the context deadline so connect()
+	// does not hang indefinitely when the server never responds.
+	// We temporarily reduce toconn.timeout rather than using SetReadDeadline
+	// because timeoutConn.Read() calls SetDeadline(now+timeout) on every
+	// read, which would overwrite a SetReadDeadline value.
+	origTimeout := toconn.timeout
+	toconn.timeout, err = preloginTimeout(ctx, origTimeout)
+	if err != nil {
+		return nil, err
+	}
+
 	fields, err = readPrelogin(outbuf)
+
+	// Restore the original timeout for subsequent reads.
+	toconn.timeout = origTimeout
+
 	if err != nil {
 		return nil, err
 	}

--- a/tds.go
+++ b/tds.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf16"
 	"unicode/utf8"
@@ -1239,6 +1240,43 @@ initiate_connection:
 	toconn = newTimeoutConn(conn, p.ConnTimeout)
 	outbuf := newTdsBuffer(packetSize, toconn)
 
+	// Bound every server read up to and including prelogin by the context.
+	// This has to be installed before the strict-encryption TLS handshake,
+	// which also reads from the server and would otherwise be unbounded.
+	//
+	// We temporarily reduce toconn.timeout rather than using SetReadDeadline
+	// because timeoutConn.Read() calls SetDeadline(now+timeout) on every read,
+	// which would overwrite a SetReadDeadline value.
+	origTimeout := toconn.timeout
+	toconn.timeout, err = preloginTimeout(ctx, origTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	// Watch ctx.Done() and close the connection to unblock a read on any
+	// cancellation or deadline expiry. This is needed even though
+	// preloginTimeout may reduce toconn.timeout, because ctx can be canceled
+	// after that timeout is computed but before or during a read, and because
+	// without a deadline and with connTimeout == 0 a read could otherwise
+	// block indefinitely.
+	cancelDone := make(chan struct{})
+	watcherDone := make(chan struct{})
+	go func() {
+		defer close(watcherDone)
+		select {
+		case <-ctx.Done():
+			toconn.Close()
+		case <-cancelDone:
+		}
+	}()
+	// Idempotent so the deferred call is a no-op once the handshake has
+	// explicitly stopped the watcher; covers every early return below.
+	stopWatcher := sync.OnceFunc(func() {
+		close(cancelDone)
+		<-watcherDone
+	})
+	defer stopWatcher()
+
 	if p.Encryption == msdsn.EncryptionStrict {
 		tlsConn, err := getTLSConn(toconn, p, "tds/8.0")
 		if err != nil {
@@ -1273,37 +1311,8 @@ initiate_connection:
 		return nil, err
 	}
 
-	// Ensure the prelogin read respects the context deadline so connect()
-	// does not hang indefinitely when the server never responds.
-	// We temporarily reduce toconn.timeout rather than using SetReadDeadline
-	// because timeoutConn.Read() calls SetDeadline(now+timeout) on every
-	// read, which would overwrite a SetReadDeadline value.
-	origTimeout := toconn.timeout
-	toconn.timeout, err = preloginTimeout(ctx, origTimeout)
-	if err != nil {
-		return nil, err
-	}
-
-	// Watch ctx.Done() for every prelogin read and close the connection to
-	// unblock readPrelogin on any context cancellation or deadline expiry.
-	// This is needed even though preloginTimeout may reduce toconn.timeout,
-	// because ctx can be canceled after that timeout is computed but before
-	// or during the read, and because without a deadline and with
-	// connTimeout == 0 the read could otherwise block indefinitely.
-	cancelDone := make(chan struct{})
-	watcherDone := make(chan struct{})
-	go func() {
-		defer close(watcherDone)
-		select {
-		case <-ctx.Done():
-			toconn.Close()
-		case <-cancelDone:
-		}
-	}()
-
 	fields, err = readPrelogin(outbuf)
-	close(cancelDone)
-	<-watcherDone // wait for goroutine to exit before touching toconn
+	stopWatcher() // wait for the goroutine to exit before touching toconn
 
 	// If the context was canceled, the watcher goroutine closed the
 	// connection. Return the context error regardless of whether the
@@ -1329,8 +1338,14 @@ initiate_connection:
 	}
 
 	// Restore the original timeout for subsequent reads. Safe because the
-	// watcher goroutine has exited (watcherDone is closed above).
+	// watcher goroutine has exited (stopWatcher returned above).
 	toconn.timeout = origTimeout
+	// timeoutConn only calls SetDeadline when timeout > 0, so with a zero
+	// ConnTimeout the absolute deadline left by the prelogin reads would
+	// persist and expire under later operations that never asked for one.
+	if err := toconn.SetDeadline(time.Time{}); err != nil {
+		return nil, err
+	}
 
 	encrypt, err := interpretPreloginResponse(p, fedAuth, fields)
 	if err != nil {

--- a/tds.go
+++ b/tds.go
@@ -1283,10 +1283,31 @@ initiate_connection:
 		return nil, err
 	}
 
+	// If the context has no deadline but is cancelable and connTimeout is 0,
+	// the read could block indefinitely. Watch ctx.Done() and close the
+	// connection to unblock readPrelogin on cancellation.
+	cancelDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			toconn.Close()
+		case <-cancelDone:
+		}
+	}()
+
 	fields, err = readPrelogin(outbuf)
+	close(cancelDone)
 
 	// Restore the original timeout for subsequent reads.
 	toconn.timeout = origTimeout
+
+	// If the context was canceled, the watcher goroutine may have closed
+	// the connection. Return the context error regardless of whether the
+	// read itself succeeded to avoid using a potentially closed conn.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		toconn.Close()
+		return nil, ctxErr
+	}
 
 	if err != nil {
 		toconn.Close()

--- a/tds.go
+++ b/tds.go
@@ -1282,9 +1282,12 @@ initiate_connection:
 		return nil, err
 	}
 
-	// If the context has no deadline but is cancelable and connTimeout is 0,
-	// the read could block indefinitely. Watch ctx.Done() and close the
-	// connection to unblock readPrelogin on cancellation.
+	// Watch ctx.Done() for every prelogin read and close the connection to
+	// unblock readPrelogin on any context cancellation or deadline expiry.
+	// This is needed even though preloginTimeout may reduce toconn.timeout,
+	// because ctx can be canceled after that timeout is computed but before
+	// or during the read, and because without a deadline and with
+	// connTimeout == 0 the read could otherwise block indefinitely.
 	cancelDone := make(chan struct{})
 	watcherDone := make(chan struct{})
 	go func() {

--- a/tds.go
+++ b/tds.go
@@ -1172,10 +1172,7 @@ func preloginTimeout(ctx context.Context, connTimeout time.Duration) (time.Durat
 
 	ctxTimeout := time.Until(deadline)
 	if ctxTimeout <= 0 {
-		if err := ctx.Err(); err != nil {
-			return connTimeout, err
-		}
-		return connTimeout, context.DeadlineExceeded
+		return 0, ctx.Err()
 	}
 
 	if connTimeout == 0 || ctxTimeout < connTimeout {
@@ -1278,6 +1275,7 @@ initiate_connection:
 	origTimeout := toconn.timeout
 	toconn.timeout, err = preloginTimeout(ctx, origTimeout)
 	if err != nil {
+		toconn.Close()
 		return nil, err
 	}
 
@@ -1287,6 +1285,7 @@ initiate_connection:
 	toconn.timeout = origTimeout
 
 	if err != nil {
+		toconn.Close()
 		return nil, err
 	}
 

--- a/tds.go
+++ b/tds.go
@@ -1314,10 +1314,14 @@ initiate_connection:
 	// can fire at nearly the same instant. If the read timed out and
 	// the context deadline has since passed (even though ctx.Err() had
 	// not yet propagated above), return the context error instead of
-	// a raw "i/o timeout".
+	// a raw "i/o timeout". Only override when the error is actually a
+	// timeout to avoid masking unrelated failures (EOF, connection reset).
 	if err != nil {
-		if dl, ok := ctx.Deadline(); ok && !time.Now().Before(dl) {
-			return nil, context.DeadlineExceeded
+		var ne net.Error
+		if errors.As(err, &ne) && ne.Timeout() {
+			if dl, ok := ctx.Deadline(); ok && !time.Now().Before(dl) {
+				return nil, context.DeadlineExceeded
+			}
 		}
 		return nil, err
 	}

--- a/tds.go
+++ b/tds.go
@@ -1156,7 +1156,9 @@ func getTLSConn(conn *timeoutConn, p msdsn.Config, alpnSeq string) (tlsConn *tls
 	}
 	//Set ALPN Sequence
 	config.NextProtos = []string{alpnSeq}
-	tlsConn = tls.Client(conn.c, config)
+	// Wrap the timeoutConn rather than the raw socket so the handshake and every
+	// subsequent TLS read honour the connection timeout instead of bypassing it.
+	tlsConn = tls.Client(conn, config)
 	err = tlsConn.Handshake()
 	if err != nil {
 		return nil, fmt.Errorf("TLS Handshake failed: %w", err)

--- a/tds.go
+++ b/tds.go
@@ -1310,13 +1310,21 @@ initiate_connection:
 		return nil, ctxErr
 	}
 
+	// The socket timeout from preloginTimeout and the context deadline
+	// can fire at nearly the same instant. If the read timed out and
+	// the context deadline has since passed (even though ctx.Err() had
+	// not yet propagated above), return the context error instead of
+	// a raw "i/o timeout".
+	if err != nil {
+		if dl, ok := ctx.Deadline(); ok && !time.Now().Before(dl) {
+			return nil, context.DeadlineExceeded
+		}
+		return nil, err
+	}
+
 	// Restore the original timeout for subsequent reads. Safe because the
 	// watcher goroutine has exited (watcherDone is closed above).
 	toconn.timeout = origTimeout
-
-	if err != nil {
-		return nil, err
-	}
 
 	encrypt, err := interpretPreloginResponse(p, fedAuth, fields)
 	if err != nil {

--- a/tds.go
+++ b/tds.go
@@ -1279,7 +1279,6 @@ initiate_connection:
 	origTimeout := toconn.timeout
 	toconn.timeout, err = preloginTimeout(ctx, origTimeout)
 	if err != nil {
-		toconn.Close()
 		return nil, err
 	}
 
@@ -1305,12 +1304,10 @@ initiate_connection:
 	// the connection. Return the context error regardless of whether the
 	// read itself succeeded to avoid using a potentially closed conn.
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		toconn.Close()
 		return nil, ctxErr
 	}
 
 	if err != nil {
-		toconn.Close()
 		return nil, err
 	}
 
@@ -1503,6 +1500,7 @@ initiate_connection:
 		}
 		goto initiate_connection
 	}
+	toconn = nil // success: prevent deferred close
 	return sess, nil
 }
 

--- a/tds.go
+++ b/tds.go
@@ -1286,7 +1286,9 @@ initiate_connection:
 	// the read could block indefinitely. Watch ctx.Done() and close the
 	// connection to unblock readPrelogin on cancellation.
 	cancelDone := make(chan struct{})
+	watcherDone := make(chan struct{})
 	go func() {
+		defer close(watcherDone)
 		select {
 		case <-ctx.Done():
 			toconn.Close()
@@ -1296,19 +1298,17 @@ initiate_connection:
 
 	fields, err = readPrelogin(outbuf)
 	close(cancelDone)
+	<-watcherDone // wait for goroutine to exit before touching toconn
 
-	// If the context was canceled, the watcher goroutine may have closed
-	// the connection. Return the context error regardless of whether the
-	// read itself succeeded to avoid using a potentially closed conn.
+	// If the context was canceled, the watcher goroutine closed the
+	// connection. Return the context error regardless of whether the
+	// read itself succeeded to avoid using a closed conn.
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, ctxErr
 	}
 
-	// Restore the original timeout for subsequent reads. This must happen
-	// after the ctx.Err() check: if the context was canceled, the watcher
-	// goroutine may still be calling toconn.Close() (value-receiver copies
-	// the struct, reading the timeout field). By returning above in that
-	// case, we avoid a data race on toconn.timeout.
+	// Restore the original timeout for subsequent reads. Safe because the
+	// watcher goroutine has exited (watcherDone is closed above).
 	toconn.timeout = origTimeout
 
 	if err != nil {

--- a/tds.go
+++ b/tds.go
@@ -1165,6 +1165,10 @@ func getTLSConn(conn *timeoutConn, p msdsn.Config, alpnSeq string) (tlsConn *tls
 }
 
 func preloginTimeout(ctx context.Context, connTimeout time.Duration) (time.Duration, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		return connTimeout, nil
@@ -1172,7 +1176,7 @@ func preloginTimeout(ctx context.Context, connTimeout time.Duration) (time.Durat
 
 	ctxTimeout := time.Until(deadline)
 	if ctxTimeout <= 0 {
-		return 0, ctx.Err()
+		return 0, context.DeadlineExceeded
 	}
 
 	if connTimeout == 0 || ctxTimeout < connTimeout {

--- a/tds.go
+++ b/tds.go
@@ -1297,15 +1297,19 @@ initiate_connection:
 	fields, err = readPrelogin(outbuf)
 	close(cancelDone)
 
-	// Restore the original timeout for subsequent reads.
-	toconn.timeout = origTimeout
-
 	// If the context was canceled, the watcher goroutine may have closed
 	// the connection. Return the context error regardless of whether the
 	// read itself succeeded to avoid using a potentially closed conn.
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, ctxErr
 	}
+
+	// Restore the original timeout for subsequent reads. This must happen
+	// after the ctx.Err() check: if the context was canceled, the watcher
+	// goroutine may still be calling toconn.Close() (value-receiver copies
+	// the struct, reading the timeout field). By returning above in that
+	// case, we avoid a data race on toconn.timeout.
+	toconn.timeout = origTimeout
 
 	if err != nil {
 		return nil, err

--- a/tds.go
+++ b/tds.go
@@ -1182,7 +1182,13 @@ func preloginTimeout(ctx context.Context, connTimeout time.Duration) (time.Durat
 		return 0, context.DeadlineExceeded
 	}
 
-	if connTimeout == 0 || ctxTimeout < connTimeout {
+	// With no connection timeout, the cancellation watcher below bounds
+	// prelogin without installing a deadline that must later be cleared.
+	if connTimeout == 0 {
+		return 0, nil
+	}
+
+	if ctxTimeout < connTimeout {
 		return ctxTimeout, nil
 	}
 
@@ -1262,14 +1268,12 @@ initiate_connection:
 	if err != nil {
 		return nil, err
 	}
-	clearPreloginDeadline := origTimeout == 0 && toconn.timeout > 0
 
 	// Watch ctx.Done() and close the connection to unblock a read on any
 	// cancellation or deadline expiry. This is needed even though
 	// preloginTimeout may reduce toconn.timeout, because ctx can be canceled
-	// after that timeout is computed but before or during a read, and because
-	// without a deadline and with connTimeout == 0 a read could otherwise
-	// block indefinitely.
+	// after that timeout is computed but before or during a read. It also
+	// provides the only bound when connTimeout == 0.
 	cancelDone := make(chan struct{})
 	watcherDone := make(chan struct{})
 	go func() {
@@ -1342,13 +1346,6 @@ initiate_connection:
 	// Restore the original timeout for subsequent reads. Safe because the
 	// watcher goroutine has exited (stopWatcher returned above).
 	toconn.timeout = origTimeout
-	if clearPreloginDeadline {
-		// timeoutConn will not replace the temporary deadline after restoring
-		// a zero connection timeout, so clear the deadline installed above.
-		if err := toconn.SetDeadline(time.Time{}); err != nil {
-			return nil, err
-		}
-	}
 
 	encrypt, err := interpretPreloginResponse(p, fedAuth, fields)
 	if err != nil {

--- a/tds.go
+++ b/tds.go
@@ -1326,7 +1326,7 @@ initiate_connection:
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		return nil, err
+		return nil, preloginError(ctx, err)
 	}
 
 	fields, err = readPrelogin(outbuf)

--- a/tds.go
+++ b/tds.go
@@ -1189,6 +1189,16 @@ func preloginTimeout(ctx context.Context, connTimeout time.Duration) (time.Durat
 	return connTimeout, nil
 }
 
+func preloginError(ctx context.Context, err error) error {
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		if deadline, ok := ctx.Deadline(); ok && !time.Now().Before(deadline) {
+			return context.DeadlineExceeded
+		}
+	}
+	return err
+}
+
 func connect(ctx context.Context, c *Connector, logger ContextLogger, p msdsn.Config) (res *tdsSession, err error) {
 	var cbt *integratedauth.ChannelBindings
 	isTransportEncrypted := false
@@ -1252,6 +1262,7 @@ initiate_connection:
 	if err != nil {
 		return nil, err
 	}
+	clearPreloginDeadline := origTimeout == 0 && toconn.timeout > 0
 
 	// Watch ctx.Done() and close the connection to unblock a read on any
 	// cancellation or deadline expiry. This is needed even though
@@ -1321,30 +1332,19 @@ initiate_connection:
 		return nil, ctxErr
 	}
 
-	// The socket timeout from preloginTimeout and the context deadline
-	// can fire at nearly the same instant. If the read timed out and
-	// the context deadline has since passed (even though ctx.Err() had
-	// not yet propagated above), return the context error instead of
-	// a raw "i/o timeout". Only override when the error is actually a
-	// timeout to avoid masking unrelated failures (EOF, connection reset).
 	if err != nil {
-		var ne net.Error
-		if errors.As(err, &ne) && ne.Timeout() {
-			if dl, ok := ctx.Deadline(); ok && !time.Now().Before(dl) {
-				return nil, context.DeadlineExceeded
-			}
-		}
-		return nil, err
+		return nil, preloginError(ctx, err)
 	}
 
 	// Restore the original timeout for subsequent reads. Safe because the
 	// watcher goroutine has exited (stopWatcher returned above).
 	toconn.timeout = origTimeout
-	// timeoutConn only calls SetDeadline when timeout > 0, so with a zero
-	// ConnTimeout the absolute deadline left by the prelogin reads would
-	// persist and expire under later operations that never asked for one.
-	if err := toconn.SetDeadline(time.Time{}); err != nil {
-		return nil, err
+	if clearPreloginDeadline {
+		// timeoutConn will not replace the temporary deadline after restoring
+		// a zero connection timeout, so clear the deadline installed above.
+		if err := toconn.SetDeadline(time.Time{}); err != nil {
+			return nil, err
+		}
 	}
 
 	encrypt, err := interpretPreloginResponse(p, fedAuth, fields)

--- a/tds.go
+++ b/tds.go
@@ -1319,6 +1319,9 @@ initiate_connection:
 
 	err = writePrelogin(packPrelogin, outbuf, fields)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, err
 	}
 

--- a/token.go
+++ b/token.go
@@ -142,6 +142,8 @@ func sendAttentionWithTimeout(transport io.ReadWriteCloser, timeout time.Duratio
 	}
 }
 
+var errCancelConfirmation = errors.New("did not get cancellation confirmation from the server")
+
 type cancelConfirmationResult uint8
 
 const (
@@ -158,15 +160,14 @@ type tokenStruct interface{}
 // drain failure, not a server internal error, and StreamError.Error()
 // surfaces the diagnostic message whereas ServerError.Error() is a fixed string.
 func cancelDrainError(phase string, drainCtx context.Context, tokErr error) error {
-	msg := "did not get cancellation confirmation from the server"
 	cause := tokErr
 	if cause == nil {
 		cause = drainCtx.Err()
 	}
 	if cause != nil {
-		return StreamError{InnerError: fmt.Errorf("%s (%s: %w)", msg, phase, cause)}
+		return StreamError{InnerError: fmt.Errorf("%w (%s: %w)", errCancelConfirmation, phase, cause)}
 	}
-	return StreamError{InnerError: fmt.Errorf("%s (%s)", msg, phase)}
+	return StreamError{InnerError: fmt.Errorf("%w (%s)", errCancelConfirmation, phase)}
 }
 
 type orderStruct struct {


### PR DESCRIPTION
## Problem

A connection could outlive the caller's context while waiting for a PRELOGIN or strict TLS response. With `connection timeout=0`, the read could block indefinitely. Cancellation during the PRELOGIN write could also surface a raw closed-connection error instead of the context error.

The timeout tests accepted overly broad outcomes, and cancel-drain failures were not reliably identifiable through the error chain.

## Root Cause

The context deadline was not enforced before every server read in connection setup, including the strict TLS handshake. The cancellation watcher did not normalize errors from the PRELOGIN write. Using a context-derived socket deadline when the configured connection timeout was zero would require custom `net.Conn` implementations to support clearing that deadline after PRELOGIN. The cancel-confirmation failure also had no typed identity when no underlying timeout or context error existed.

## Solution

- Reduce a nonzero connection timeout when the context deadline expires sooner.
- Apply the effective connection timeout before strict TLS and PRELOGIN reads.
- Close the connection on context cancellation to unblock reads and writes, then wait for the watcher before reusing connection state.
- Rely on the cancellation watcher when the connection timeout is zero, avoiding a socket deadline that custom connections would need to clear.
- Return the context error when cancellation closes the connection during the PRELOGIN write or read.
- Normalize a socket timeout to `context.DeadlineExceeded` only after the context deadline has elapsed.
- Add `StreamError.Unwrap` and a typed cancel-confirmation sentinel for standard `errors.Is` and `errors.As` handling.
- Restrict timeout-test acceptance to documented driver outcomes.

## Changes

| File | Change |
|---|---|
| `tds.go` | Enforces context cancellation through strict TLS and PRELOGIN, synchronizes cancellation cleanup, normalizes timeout errors, and avoids requiring custom connections to clear deadlines. |
| `token.go` | Adds a typed cancel-confirmation sentinel while preserving underlying timeout and context causes. |
| `error.go` | Adds `StreamError.Unwrap`. |
| `prelogin_deadline_test.go` | Covers timeout selection, strict TLS, cancellation, PRELOGIN writes, successful login, routing cleanup, custom dialers, zero-timeout behavior, and post-deadline connection reuse. |
| `queries_test.go` | Classifies the expected query and login timeout outcomes through typed error checks. |
| `error_test.go` | Covers the `StreamError` unwrapping contract. |

## Testing

- `go build ./...`
- `go test ./msdsn ./internal/... ./integratedauth ./azuread`
- `go test -run 'TestPreloginTimeout|TestConnectZeroTimeoutDoesNotRequireDeadlineReset|TestPreloginZeroConnectionTimeoutRespectsContextDeadline|TestPreloginWriteCancellationReturnsContextError' -count=20 .`
- `go test ./...` was run locally. It reached unrelated environment-dependent failures in `TestConnectError/bad_port_-_refused_connection` and the Windows certificate-store tests under `aecmk/localcert`; the changed PRELOGIN tests passed.
- `go vet ./...` reached the existing `integratedauth/winsspi` `unsafe.Pointer` warning.

The race detector was not run locally because CGO is disabled in this environment. Fresh CI is running against the latest commit.

## Platform Impact

The behavior applies to all network transports. Windows-specific named pipe and shared memory validation remains covered by AppVeyor.

## Related Issues

Fixes #254