### PR TITLE
fix: surface server errors from Rows.Close() during token drain

### DIFF
--- a/mssql.go
+++ b/mssql.go
@@ -845,18 +845,23 @@ func (rc *Rows) Close() error {
 	// and check closing after reading only few rows
 	rc.cancel()
 
+	var closeErr error
 	for {
 		tok, err := rc.reader.nextToken()
 		if err == nil {
 			if tok == nil {
-				return nil
-			} else {
-				// continue consuming tokens
-				continue
+				return closeErr
 			}
+			// Check for server errors in done tokens so that errors
+			// arriving after result rows (e.g. XACT_ABORT rollbacks)
+			// are not silently swallowed.
+			if done, ok := tok.(doneStruct); ok && done.isError() {
+				closeErr = rc.stmt.c.checkBadConn(rc.reader.ctx, done.getError(), false)
+			}
+			continue
 		} else {
 			if err == rc.reader.ctx.Err() {
-				return nil
+				return closeErr
 			} else {
 				return err
 			}

--- a/mssql_go110_unit_test.go
+++ b/mssql_go110_unit_test.go
@@ -4,8 +4,10 @@
 package mssql
 
 import (
+	"context"
 	"testing"
 
+	"github.com/microsoft/go-mssqldb/msdsn"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,4 +32,78 @@ func TestConnector_Driver(t *testing.T) {
 	
 	result := c.Driver()
 	assert.Same(t, drv, result, "Driver() should return the same driver instance")
+}
+
+// TestRowsClose_SurfacesDoneStructErrors verifies that Rows.Close() returns
+// errors from doneStruct tokens instead of silently discarding them.
+// This is the unit test counterpart of the integration test
+// TestIssue244_XactAbortErrorSurfaced.
+func TestRowsClose_SurfacesDoneStructErrors(t *testing.T) {
+	sess := &tdsSession{}
+	conn := &Conn{
+		sess:           sess,
+		connectionGood: true,
+		connector:      &Connector{params: msdsn.Config{}},
+	}
+	stmt := &Stmt{c: conn}
+
+	ctx := context.Background()
+	tokChan := make(chan tokenStruct, 5)
+	reader := &tokenProcessor{
+		tokChan: tokChan,
+		ctx:     ctx,
+		sess:    sess,
+	}
+
+	rows := &Rows{
+		stmt:   stmt,
+		reader: reader,
+		cancel: func() {},
+	}
+
+	// Simulate the token stream: a row followed by an error-bearing doneStruct,
+	// then close the channel to signal end of response.
+	serverErr := Error{Number: 245, Message: "Conversion failed"}
+	tokChan <- doneStruct{
+		Status: doneError,
+		errors: []Error{serverErr},
+	}
+	close(tokChan)
+
+	err := rows.Close()
+	assert.Error(t, err, "Close() should return an error from doneStruct")
+	assert.Contains(t, err.Error(), "Conversion failed")
+}
+
+// TestRowsClose_NoErrorWhenClean verifies that Rows.Close() returns nil
+// when the token stream has no errors.
+func TestRowsClose_NoErrorWhenClean(t *testing.T) {
+	sess := &tdsSession{}
+	conn := &Conn{
+		sess:           sess,
+		connectionGood: true,
+		connector:      &Connector{params: msdsn.Config{}},
+	}
+	stmt := &Stmt{c: conn}
+
+	ctx := context.Background()
+	tokChan := make(chan tokenStruct, 5)
+	reader := &tokenProcessor{
+		tokChan: tokChan,
+		ctx:     ctx,
+		sess:    sess,
+	}
+
+	rows := &Rows{
+		stmt:   stmt,
+		reader: reader,
+		cancel: func() {},
+	}
+
+	// Simulate clean token stream: a done token with no error, then close.
+	tokChan <- doneStruct{Status: doneCount, RowCount: 1}
+	close(tokChan)
+
+	err := rows.Close()
+	assert.NoError(t, err, "Close() should return nil when no errors in token stream")
 }


### PR DESCRIPTION
## Summary

When `Rows.Close()` drains remaining tokens after a partial read (e.g., `QueryRow().Scan()`), error-bearing `doneStruct` tokens were silently discarded. This caused `XACT_ABORT` transaction rollback errors to go unnoticed -- the caller would see a successful `Scan()` result while the transaction was actually rolled back.

## Root Cause

In `Rows.Close()`, the drain loop consumed all remaining tokens from the response channel but never inspected them for errors:

```go
// Before: all tokens silently discarded
tok, err := rc.reader.nextToken()
if err == nil {
    if tok == nil {
        return nil  // <-- always returned nil
    }
    continue  // <-- error-bearing doneStruct discarded here
}
```

When SQL Server processes a query with `XACT_ABORT ON` and encounters an implicit conversion error, it sends:
1. Column metadata + row data (the partial result)
2. An ERROR token describing the conversion failure
3. A DONE token with `doneError` flag set

`QueryRow().Scan()` reads the first row via `Next()`, then calls `Close()` to drain the rest. The error-bearing `doneStruct` was consumed and discarded, so `Scan()` returned `nil` error despite the transaction being rolled back.

## Fix

`Rows.Close()` now inspects `doneStruct` tokens during the drain loop. If a `doneStruct` has `isError() == true`, the error is captured via `checkBadConn()` (which also marks the connection as bad for `ServerError`) and returned to the caller.

```go
// After: errors in doneStruct are captured and returned
if done, ok := tok.(doneStruct); ok && done.isError() {
    closeErr = rc.stmt.c.checkBadConn(rc.reader.ctx, done.getError(), false)
}
```

This allows `database/sql` to surface the error via `Row.Scan()` and `Rows.Err()`.

## Testing

- **Unit tests** (`TestRowsClose_SurfacesDoneStructErrors`, `TestRowsClose_NoErrorWhenClean`): Directly construct a `Rows` with a mock token channel to verify `Close()` returns errors from `doneStruct` tokens and returns nil for clean streams.
- **Integration test** (`TestIssue244_XactAbortErrorSurfaced`): Reproduces the exact scenario from the issue -- `XACT_ABORT ON`, implicit conversion error in a `SELECT` within a transaction, verifying the error is surfaced rather than silently swallowed.

## Affected Scenarios

This fix affects any code path where:
- A query returns partial results followed by a server error
- The caller reads fewer rows than available (e.g., `QueryRow`, `rows.Next()` followed by early `rows.Close()`)
- `XACT_ABORT ON` causes an implicit rollback after partial result delivery

Previously silent errors will now be surfaced, which is the correct behavior but may cause previously "working" code to start seeing errors it should have been handling.

Fixes #244