### PR TITLE
fix: return interface{} scanType for sql_variant instead of nil

### DIFF
--- a/queries_test.go
+++ b/queries_test.go
@@ -1826,7 +1826,7 @@ func TestColumnTypeIntrospection(t *testing.T) {
 		{"cast('abc' as image)", "IMAGE", reflect.TypeOf([]byte{}), true, 2147483647, false, 0, 0},
 		{"cast('abc' as char(3))", "CHAR", reflect.TypeOf(""), true, 3, false, 0, 0},
 		{"cast(N'abc' as nchar(3))", "NCHAR", reflect.TypeOf(""), true, 3, false, 0, 0},
-		{"cast(1 as sql_variant)", "SQL_VARIANT", reflect.TypeOf(nil), false, 0, false, 0, 0},
+		{"cast(1 as sql_variant)", "SQL_VARIANT", reflect.TypeOf((*interface{})(nil)).Elem(), false, 0, false, 0, 0},
 		{"geometry::STGeomFromText('LINESTRING (100 100, 20 180, 180 180)', 0)", "GEOMETRY", reflect.TypeOf([]byte{}), true, 2147483647, false, 0, 0},
 		{"geography::STGeomFromText('LINESTRING(-122.360 47.656, -122.343 47.656 )', 4326)", "GEOGRAPHY", reflect.TypeOf([]byte{}), false, 2147483647, false, 0, 0},
 		{"cast('/1/2/3/' as hierarchyid)", "HIERARCHYID", reflect.TypeOf([]byte{}), true, 892, false, 0, 0},

--- a/types.go
+++ b/types.go
@@ -1210,7 +1210,7 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 	case typeBigBinary:
 		return reflect.TypeOf([]byte{})
 	case typeVariant:
-		return reflect.TypeOf(nil)
+		return reflect.TypeOf((*interface{})(nil)).Elem()
 	case typeUdt:
 		return reflect.TypeOf([]byte{})
 	default:

--- a/types_test.go
+++ b/types_test.go
@@ -54,7 +54,7 @@ func TestMakeGoLangScanType(t *testing.T) {
 		{"typeNText", typeInfo{TypeId: typeNText}, reflect.TypeOf("")},
 		{"typeImage", typeInfo{TypeId: typeImage}, reflect.TypeOf([]byte{})},
 		{"typeBigBinary", typeInfo{TypeId: typeBigBinary}, reflect.TypeOf([]byte{})},
-		{"typeVariant", typeInfo{TypeId: typeVariant}, reflect.TypeOf(nil)},
+		{"typeVariant", typeInfo{TypeId: typeVariant}, reflect.TypeOf((*interface{})(nil)).Elem()},
 		{"typeUdt", typeInfo{TypeId: typeUdt}, reflect.TypeOf([]byte{})},
 	}
 


### PR DESCRIPTION
## Summary

`sql_variant` columns returned `nil` from `ColumnType.ScanType()`, which broke downstream libraries (e.g. Grafana - see grafana/grafana#81935) that rely on a non-nil `reflect.Type` for all column types.

## Changes

- `makeGoLangScanType()` now returns `reflect.TypeOf((*interface{})(nil)).Elem()` for `typeVariant` instead of `reflect.TypeOf(nil)`
- Updated unit test to match

Since `sql_variant` can hold any SQL Server type (int, varchar, datetime, etc.), `interface{}` is the correct Go scan type representing its polymorphic nature.

## Attribution

Thanks to @aangelisc for reporting this issue and identifying the root cause.

Fixes #186