### PR TITLE
feat: add ADO.Net Authentication connection string synonym and spaced value names

### DIFF
--- a/azuread/configuration.go
+++ b/azuread/configuration.go
@@ -94,11 +94,35 @@ func parse(dsn string) (*azureFedAuthConfig, error) {
 	return config, nil
 }
 
+// adoNetAuthMap matches the string constants from
+// Microsoft.Data.SqlClient's DbConnectionStringUtilities.
+var adoNetAuthMap = map[string]string{
+	"sql password":                        "", // SQL auth, no fedauth needed
+	"active directory password":           ActiveDirectoryPassword,
+	"active directory integrated":         ActiveDirectoryIntegrated,
+	"active directory interactive":        ActiveDirectoryInteractive,
+	"active directory service principal":  ActiveDirectoryServicePrincipal,
+	"active directory device code flow":   ActiveDirectoryDeviceCode,
+	"active directory managed identity":   ActiveDirectoryManagedIdentity,
+	"active directory msi":                ActiveDirectoryMSI,
+	"active directory default":            ActiveDirectoryDefault,
+	"active directory workload identity":  ActiveDirectoryWorkloadIdentity,
+}
+
 func (p *azureFedAuthConfig) validateParameters(params map[string]string) error {
 
 	fedAuthWorkflow := params["fedauth"]
 	if fedAuthWorkflow == "" {
 		return nil
+	}
+
+	// Normalize ADO.Net-style authentication names to driver names
+	if mapped, ok := adoNetAuthMap[strings.ToLower(fedAuthWorkflow)]; ok {
+		if mapped == "" {
+			// "Sql Password" means standard SQL auth, no federated auth
+			return nil
+		}
+		fedAuthWorkflow = mapped
 	}
 
 	p.fedAuthLibrary = mssql.FedAuthLibraryADAL

--- a/azuread/configuration.go
+++ b/azuread/configuration.go
@@ -111,7 +111,9 @@ var adoNetAuthMap = map[string]string{
 
 func (p *azureFedAuthConfig) validateParameters(params map[string]string) error {
 
-	fedAuthWorkflow := params["fedauth"]
+	// msdsn trims semicolon-style values but not URL query values, so a URL DSN
+	// can deliver surrounding whitespace here.
+	fedAuthWorkflow := strings.TrimSpace(params["fedauth"])
 	if fedAuthWorkflow == "" {
 		return nil
 	}

--- a/azuread/configuration_test.go
+++ b/azuread/configuration_test.go
@@ -207,6 +207,39 @@ func TestValidateParameters(t *testing.T) {
 				fedAuthWorkflow: ActiveDirectoryOnBehalfOf,
 			},
 		},
+		{
+			name: "ADO.Net Authentication synonym for fedauth",
+			dsn:  "server=someserver.database.windows.net;Authentication=ActiveDirectoryDefault",
+			expected: &azureFedAuthConfig{
+				adalWorkflow:    mssql.FedAuthADALWorkflowPassword,
+				fedAuthWorkflow: ActiveDirectoryDefault,
+			},
+		},
+		{
+			name: "ADO.Net spaced auth name: Active Directory Password",
+			dsn:  "server=someserver.database.windows.net;Authentication=Active Directory Password;user id=azure-ad-user@example.com;password=somesecret;" + appid,
+			expected: &azureFedAuthConfig{
+				adalWorkflow:        mssql.FedAuthADALWorkflowPassword,
+				user:                "azure-ad-user@example.com",
+				password:            passphrase,
+				applicationClientID: "someguid",
+				fedAuthWorkflow:     ActiveDirectoryPassword,
+			},
+		},
+		{
+			name: "ADO.Net spaced auth name: Active Directory Managed Identity",
+			dsn:  "server=someserver.database.windows.net;Authentication=Active Directory Managed Identity;user id=identity-client-id",
+			expected: &azureFedAuthConfig{
+				adalWorkflow:    mssql.FedAuthADALWorkflowMSI,
+				clientID:        "identity-client-id",
+				fedAuthWorkflow: ActiveDirectoryManagedIdentity,
+			},
+		},
+		{
+			name:     "ADO.Net Sql Password means no fedauth",
+			dsn:      "server=someserver.database.windows.net;Authentication=Sql Password;user id=sa;password=somesecret",
+			expected: &azureFedAuthConfig{fedAuthLibrary: mssql.FedAuthLibraryReserved},
+		},
 	}
 	for _, tst := range tests {
 		config, err := parse(tst.dsn)

--- a/azuread/configuration_test.go
+++ b/azuread/configuration_test.go
@@ -595,3 +595,29 @@ func TestADONetAuthenticationNames(t *testing.T) {
 		}
 	}
 }
+
+// msdsn trims semicolon-style values but leaves URL query values as written, so
+// only a URL DSN can deliver a padded authentication name to the lookup.
+func TestAuthenticationNameSurroundingWhitespace(t *testing.T) {
+	for _, tst := range []struct {
+		name string
+		enc  string
+		want string
+	}{
+		{"ado name, trailing space", "Active+Directory+Default+", ActiveDirectoryDefault},
+		{"ado name, leading space", "+Active+Directory+Default", ActiveDirectoryDefault},
+		{"ado name, both", "%20Active%20Directory%20Default%20", ActiveDirectoryDefault},
+		{"driver name, trailing space", "ActiveDirectoryDefault+", ActiveDirectoryDefault},
+		{"ado name, no padding", "Active+Directory+Default", ActiveDirectoryDefault},
+	} {
+		t.Run(tst.name, func(t *testing.T) {
+			config, err := parse("sqlserver://s.database.windows.net?fedauth=" + tst.enc)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if config.fedAuthWorkflow != tst.want {
+				t.Errorf("fedAuthWorkflow = %q, want %q", config.fedAuthWorkflow, tst.want)
+			}
+		})
+	}
+}

--- a/azuread/configuration_test.go
+++ b/azuread/configuration_test.go
@@ -551,3 +551,47 @@ func TestAzurePipelinesEnvironmentVariables(t *testing.T) {
 		})
 	}
 }
+// TestADONetAuthenticationNames covers every value of SqlAuthenticationMethod,
+// the enum behind ADO.Net's Authentication keyword. A typo in any adoNetAuthMap
+// key would leave that method silently unmapped, so each is asserted rather
+// than spot-checked.
+func TestADONetAuthenticationNames(t *testing.T) {
+	for _, tst := range []struct {
+		ado  string
+		want string
+	}{
+		{"Sql Password", ""}, // SQL auth: no federated workflow
+		{"Active Directory Password", ActiveDirectoryPassword},
+		{"Active Directory Integrated", ActiveDirectoryIntegrated},
+		{"Active Directory Interactive", ActiveDirectoryInteractive},
+		{"Active Directory Service Principal", ActiveDirectoryServicePrincipal},
+		{"Active Directory Device Code Flow", ActiveDirectoryDeviceCode},
+		{"Active Directory Managed Identity", ActiveDirectoryManagedIdentity},
+		{"Active Directory MSI", ActiveDirectoryMSI},
+		{"Active Directory Default", ActiveDirectoryDefault},
+		{"Active Directory Workload Identity", ActiveDirectoryWorkloadIdentity},
+	} {
+		t.Run(tst.ado, func(t *testing.T) {
+			dsn := "server=s.database.windows.net;Authentication=" + tst.ado +
+				";user id=u@example.com;password=p;applicationclientid=someguid;clientid=cid"
+			config, err := parse(dsn)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if config.fedAuthWorkflow != tst.want {
+				t.Errorf("fedAuthWorkflow = %q, want %q", config.fedAuthWorkflow, tst.want)
+			}
+		})
+	}
+
+	// Casing is not significant in ADO.Net connection strings.
+	for _, variant := range []string{"ACTIVE DIRECTORY DEFAULT", "active directory default"} {
+		config, err := parse("server=s.database.windows.net;Authentication=" + variant)
+		if err != nil {
+			t.Fatalf("parse %q: %v", variant, err)
+		}
+		if config.fedAuthWorkflow != ActiveDirectoryDefault {
+			t.Errorf("%q: fedAuthWorkflow = %q, want %q", variant, config.fedAuthWorkflow, ActiveDirectoryDefault)
+		}
+	}
+}

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -771,6 +771,7 @@ var adoSynonyms = map[string]string{
 	"pwd":                       Password,
 	"initial catalog":           Database,
 	"column encryption setting": "columnencryption",
+	"authentication":            "fedauth",
 }
 
 func splitConnectionString(dsn string) (res map[string]string) {

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -786,6 +786,7 @@ var adoSynonyms = map[string]string{
 	"server certificate":        ServerCertificate,
 	"wsid":                      WorkstationID,
 	"column encryption setting": "columnencryption",
+	"authentication":            "fedauth",
 }
 
 func splitConnectionString(dsn string) (res map[string]string) {

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -453,6 +453,15 @@ func TestAllKeysAreAvailableInParametersMap(t *testing.T) {
 	}
 }
 
+func TestAuthenticationSynonymMapsFedauth(t *testing.T) {
+	params, err := Parse("server=localhost;authentication=ActiveDirectoryDefault")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "ActiveDirectoryDefault", params.Parameters["fedauth"],
+		"ADO 'authentication' keyword should map to 'fedauth' parameter")
+}
+
 func TestReadCertificate(t *testing.T) {
 
 	//Setup dummy certificate

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -493,6 +493,15 @@ func TestAllKeysAreAvailableInParametersMap(t *testing.T) {
 	}
 }
 
+func TestAuthenticationSynonymMapsFedauth(t *testing.T) {
+	params, err := Parse("server=localhost;authentication=ActiveDirectoryDefault")
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "ActiveDirectoryDefault", params.Parameters["fedauth"],
+		"ADO 'authentication' keyword should map to 'fedauth' parameter")
+}
+
 func TestReadCertificate(t *testing.T) {
 
 	//Setup dummy certificate


### PR DESCRIPTION
## Problem

Users coming from ADO.Net expect to use `Authentication=Active Directory Default` style connection strings, but the driver only supports `fedauth=ActiveDirectoryDefault`.

## Fix

### 1. Connection string synonym
Added `"authentication"` as a synonym for `"fedauth"` in the ADO-style connection string parser (`msdsn/conn_str.go`).

### 2. ADO.Net-style value names
Added support for spaced authentication values in the `azuread` package, matching [ADO.Net SqlClient names](https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlauthenticationmethod):

| ADO.Net Value | Maps To |
|---|---|
| Sql Password | Standard SQL auth (no fedauth) |
| Active Directory Password | ActiveDirectoryPassword |
| Active Directory Integrated | ActiveDirectoryIntegrated |
| Active Directory Interactive | ActiveDirectoryInteractive |
| Active Directory Service Principal | ActiveDirectoryServicePrincipal |
| Active Directory Device Code Flow | ActiveDirectoryDeviceCode |
| Active Directory Managed Identity | ActiveDirectoryManagedIdentity |
| Active Directory MSI | ActiveDirectoryMSI |
| Active Directory Default | ActiveDirectoryDefault |
| Active Directory Workload Identity | ActiveDirectoryWorkloadIdentity |

## Examples

These connection strings are now equivalent:
```
fedauth=ActiveDirectoryDefault
Authentication=ActiveDirectoryDefault
Authentication=Active Directory Default
```

## Tests

Added 4 test cases to `TestValidateParameters`:
- `Authentication` synonym with existing value name
- `Active Directory Password` spaced name
- `Active Directory Managed Identity` spaced name
- `Sql Password` returns no fedauth config

All existing tests pass.

Fixes #288