### PR TITLE
fix: strip port from AKV URLs for AllowedLocations and endpoint

### DIFF
--- a/aecmk/akv/keyprovider.go
+++ b/aecmk/akv/keyprovider.go
@@ -240,11 +240,13 @@ func (p *Provider) allowedPathAndEndpoint(masterKeyPath string) (endpoint string
 		allowed = false
 		return
 	}
+	// Use Hostname() to strip port for case-insensitive suffix comparison
+	hostname := url.Hostname()
 	if !allowed {
 
 	loop:
 		for _, l := range p.AllowedLocations {
-			if strings.HasSuffix(strings.ToLower(url.Host), strings.ToLower(l)) {
+			if strings.HasSuffix(strings.ToLower(hostname), strings.ToLower(l)) {
 				allowed = true
 				break loop
 			}
@@ -257,6 +259,12 @@ func (p *Provider) allowedPathAndEndpoint(masterKeyPath string) (endpoint string
 			return
 		}
 		keypath = pathParts[1:]
+		// Strip default HTTPS port (:443) to avoid Azure SDK challenge
+		// verification issues, but preserve non-standard ports.
+		port := url.Port()
+		if port == "" || port == "443" {
+			url.Host = hostname
+		}
 		url.Path = ""
 		url.RawQuery = ""
 		url.Fragment = ""

--- a/aecmk/akv/keyprovider_test.go
+++ b/aecmk/akv/keyprovider_test.go
@@ -10,10 +10,64 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/microsoft/go-mssqldb/aecmk"
 	"github.com/microsoft/go-mssqldb/internal/akvkeys"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestAllowedPathAndEndpointWithPort(t *testing.T) {
+	p := &Provider{
+		credentials:      make(map[string]azcore.TokenCredential),
+		AllowedLocations: []string{"myvault.vault.azure.net"},
+	}
+
+	tests := []struct {
+		name             string
+		masterKeyPath    string
+		expectAllowed    bool
+		expectEndpoint   string
+		expectKeypath    []string
+	}{
+		{
+			name:           "URL without port",
+			masterKeyPath:  "https://myvault.vault.azure.net/keys/mykey/abc123",
+			expectAllowed:  true,
+			expectEndpoint: "https://myvault.vault.azure.net",
+			expectKeypath:  []string{"mykey", "abc123"},
+		},
+		{
+			name:           "URL with port 443",
+			masterKeyPath:  "https://myvault.vault.azure.net:443/keys/mykey/abc123",
+			expectAllowed:  true,
+			expectEndpoint: "https://myvault.vault.azure.net",
+			expectKeypath:  []string{"mykey", "abc123"},
+		},
+		{
+			name:           "URL with non-standard port",
+			masterKeyPath:  "https://myvault.vault.azure.net:8443/keys/mykey/abc123",
+			expectAllowed:  true,
+			expectEndpoint: "https://myvault.vault.azure.net:8443",
+			expectKeypath:  []string{"mykey", "abc123"},
+		},
+		{
+			name:          "URL with port not in allowed list",
+			masterKeyPath: "https://other.vault.azure.net:443/keys/mykey/abc123",
+			expectAllowed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, keypath, allowed := p.allowedPathAndEndpoint(tt.masterKeyPath)
+			assert.Equal(t, tt.expectAllowed, allowed, "allowed")
+			if tt.expectAllowed {
+				assert.Equal(t, tt.expectEndpoint, endpoint, "endpoint")
+				assert.Equal(t, tt.expectKeypath, keypath, "keypath")
+			}
+		})
+	}
+}
 
 func TestEncryptDecryptRoundTrip(t *testing.T) {
 	client, vaultURL, err := akvkeys.GetTestAKV()

--- a/aecmk/akv/keyprovider_test.go
+++ b/aecmk/akv/keyprovider_test.go
@@ -10,55 +10,61 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/microsoft/go-mssqldb/aecmk"
 	"github.com/microsoft/go-mssqldb/internal/akvkeys"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAllowedPathAndEndpointWithPort(t *testing.T) {
-	p := &Provider{
-		credentials:      make(map[string]azcore.TokenCredential),
-		AllowedLocations: []string{"myvault.vault.azure.net"},
-	}
-
 	tests := []struct {
 		name             string
+		allowedLocations []string
 		masterKeyPath    string
 		expectAllowed    bool
 		expectEndpoint   string
 		expectKeypath    []string
 	}{
 		{
-			name:           "URL without port",
-			masterKeyPath:  "https://myvault.vault.azure.net/keys/mykey/abc123",
-			expectAllowed:  true,
-			expectEndpoint: "https://myvault.vault.azure.net",
-			expectKeypath:  []string{"mykey", "abc123"},
+			name:             "URL without port",
+			allowedLocations: []string{"myvault.vault.azure.net"},
+			masterKeyPath:    "https://myvault.vault.azure.net/keys/mykey/abc123",
+			expectAllowed:    true,
+			expectEndpoint:   "https://myvault.vault.azure.net",
+			expectKeypath:    []string{"mykey", "abc123"},
 		},
 		{
-			name:           "URL with port 443",
-			masterKeyPath:  "https://myvault.vault.azure.net:443/keys/mykey/abc123",
-			expectAllowed:  true,
-			expectEndpoint: "https://myvault.vault.azure.net",
-			expectKeypath:  []string{"mykey", "abc123"},
+			name:             "URL with port 443",
+			allowedLocations: []string{"myvault.vault.azure.net"},
+			masterKeyPath:    "https://myvault.vault.azure.net:443/keys/mykey/abc123",
+			expectAllowed:    true,
+			expectEndpoint:   "https://myvault.vault.azure.net",
+			expectKeypath:    []string{"mykey", "abc123"},
 		},
 		{
-			name:           "URL with non-standard port",
-			masterKeyPath:  "https://myvault.vault.azure.net:8443/keys/mykey/abc123",
-			expectAllowed:  true,
-			expectEndpoint: "https://myvault.vault.azure.net:8443",
-			expectKeypath:  []string{"mykey", "abc123"},
+			name:             "URL with non-standard port",
+			allowedLocations: []string{"myvault.vault.azure.net"},
+			masterKeyPath:    "https://myvault.vault.azure.net:8443/keys/mykey/abc123",
+			expectAllowed:    true,
+			expectEndpoint:   "https://myvault.vault.azure.net:8443",
+			expectKeypath:    []string{"mykey", "abc123"},
 		},
 		{
-			name:          "URL with port not in allowed list",
-			masterKeyPath: "https://other.vault.azure.net:443/keys/mykey/abc123",
-			expectAllowed: false,
+			name:             "URL with port not in allowed list",
+			allowedLocations: []string{"myvault.vault.azure.net"},
+			masterKeyPath:    "https://other.vault.azure.net:443/keys/mykey/abc123",
+			expectAllowed:    false,
+		},
+		{
+			name:             "AllowedLocations entry with port does not match hostname",
+			allowedLocations: []string{"myvault.vault.azure.net:443"},
+			masterKeyPath:    "https://myvault.vault.azure.net/keys/mykey/abc123",
+			expectAllowed:    false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			p := &Provider{AllowedLocations: tt.allowedLocations}
 			endpoint, keypath, allowed := p.allowedPathAndEndpoint(tt.masterKeyPath)
 			assert.Equal(t, tt.expectAllowed, allowed, "allowed")
 			if tt.expectAllowed {


### PR DESCRIPTION
## Problem

When SQL Server returns AKV (Azure Key Vault) key identifier URLs that include a port number (e.g. `https://xxx.vault.azure.net:443/keys/keyname/version`), two things break:

### Bug 1: AllowedLocations check fails
`url.Host` returns `xxx.vault.azure.net:443` (with port), but `AllowedLocations` entries are typically hostnames like `xxx.vault.azure.net`. The `HasSuffix` check fails because `:443` is appended.

### Bug 2: Azure SDK challenge verification fails
The endpoint URL passed to `azkeys.NewClient` includes the port, causing the Azure SDK's built-in challenge verification to reject the request because `host:443` doesn't match `host`.

## Fix

Use `url.Hostname()` instead of `url.Host` for:
1. The `AllowedLocations` suffix comparison
2. The reconstructed endpoint URL passed to `azkeys.NewClient`

`url.Hostname()` strips the port component, returning just the hostname.

## Tests

Added `TestAllowedPathAndEndpointWithPort` with 5 test cases:
- URL without port (baseline, works before and after)
- URL with `:443` (was broken, now works)
- URL with non-standard port (also works)
- URL with port not in allowed list (correctly rejected)

Fixes #176
