### PR TITLE
fix: clarify NTLM URL encoding for URL DSNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ For further information on usage:
 * `sqlserver://username@host/instance?krb5-configfile=path/to/file&krb5-credcachefile=/path/to/cache`
     * `sqlserver://username@host/instance?krb5-configfile=path/to/file&krb5-realm=domain.com&krb5-keytabfile=/path/to/keytabfile`
 
+  For URL connection strings, percent-encode special characters in the username or password. Windows authentication usernames use `%5C` for the domain separator, for example `sqlserver://DOMAIN%5Cusername:password@host`. In ADO and ODBC connection strings, use the literal `DOMAIN\username` form.
+
 2. ADO: `key=value` pairs separated by `;`. Values can contain `;` and other special characters by enclosing them in double quotes. Leading and trailing whitespace is ignored.
      Examples:
 

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -260,6 +260,9 @@ func TestValidConnectionString(t *testing.T) {
 		{"sqlserver://someuser:@somehost?connection+timeout=30", func(p Config) bool {
 			return p.Host == "somehost" && p.Port == 0 && p.Instance == "" && p.User == "someuser" && p.Password == "" && p.ConnTimeout == 30*time.Second
 		}},
+		{"sqlserver://DOMAIN%5Cuser:pass@somehost?connection+timeout=30", func(p Config) bool {
+			return p.Host == "somehost" && p.Port == 0 && p.Instance == "" && p.User == "DOMAIN\\user" && p.Password == "pass" && p.ConnTimeout == 30*time.Second
+		}},
 		{"sqlserver://someuser:foo%3A%2F%5C%21~%40;bar@somehost?connection+timeout=30", func(p Config) bool {
 			return p.Host == "somehost" && p.Port == 0 && p.Instance == "" && p.User == "someuser" && p.Password == "foo:/\\!~@;bar" && p.ConnTimeout == 30*time.Second
 		}},


### PR DESCRIPTION
## Problem
The Learn content and README discussion around NTLM usernames in URL-form connection strings is easy to misread as if `DOMAIN\user` should work unchanged everywhere.

## Root Cause
`sqlserver://...` connection strings are parsed through Go's URL parser, which rejects a raw backslash in URL userinfo. The username must therefore be percent-encoded in URL form, even though ADO and ODBC forms use the literal `DOMAIN\user` representation.

## Solution
Clarify the README so it explicitly distinguishes URL DSNs from ADO/ODBC DSNs, and add a parser regression test for `sqlserver://DOMAIN%5Cuser:pass@host`.

## Changes
| Area | Change |
| --- | --- |
| Tests | Added URL parser coverage for a percent-encoded Windows domain username in `msdsn/conn_str_test.go`. |
| Docs | Clarified that URL DSNs use `%5C` for the domain separator while ADO/ODBC DSNs use literal `DOMAIN\username`. |

## Testing
- `go test ./msdsn -run TestValidConnectionString -count=1 -v`

## Related Issues
- None
