### PR TITLE
fix: return float64 for REAL columns in readFixedType

### DIFF
--- a/queries_test.go
+++ b/queries_test.go
@@ -561,6 +561,7 @@ func TestParams(t *testing.T) {
 		"",
 		[]byte{1, 2, 3},
 		[]byte{},
+		float32(1.12313),
 		float64(1.12313554),
 		true,
 		false,
@@ -604,6 +605,15 @@ func TestParams(t *testing.T) {
 					same = decodedval == int64(intVal)
 				case int:
 					same = decodedval == int64(intVal)
+				default:
+					same = retval == val
+				}
+			case float64:
+				// REAL (float32) params are widened to float64 on the read path
+				// per the database/sql/driver.Value contract.
+				switch fVal := val.(type) {
+				case float32:
+					same = decodedval == float64(fVal)
 				default:
 					same = retval == val
 				}

--- a/types.go
+++ b/types.go
@@ -361,7 +361,7 @@ func readFixedType(ti *typeInfo, r *tdsBuffer, c *cryptoMetadata, encoding msdsn
 	case typeDateTim4:
 		return decodeDateTim4(buf, loc)
 	case typeFlt4:
-		return math.Float32frombits(binary.LittleEndian.Uint32(buf))
+		return float64(math.Float32frombits(binary.LittleEndian.Uint32(buf)))
 	case typeMoney4:
 		return decodeMoney4(buf)
 	case typeMoney:

--- a/types_test.go
+++ b/types_test.go
@@ -1,10 +1,13 @@
 package mssql
 
 import (
+	"encoding/binary"
+	"math"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/microsoft/go-mssqldb/msdsn"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -283,4 +286,28 @@ func handlePanic(t *testing.T) {
 	if r := recover(); r != nil {
 		assert.Fail(t, "recovered panic", "%v", r)
 	}
+}
+
+// TestReadFixedType_Flt4_ReturnsFloat64 verifies that REAL (typeFlt4) values
+// returned by readFixedType are widened to float64, matching the scan type
+// advertised by ColumnTypeScanType and the database/sql contract. Returning
+// float32 here previously caused downstream scan failures for *float64 destinations.
+func TestReadFixedType_Flt4_ReturnsFloat64(t *testing.T) {
+	const want = float32(3.14)
+
+	ti := typeInfo{TypeId: typeFlt4, Size: 4, Buffer: make([]byte, 4)}
+	binary.LittleEndian.PutUint32(ti.Buffer, math.Float32bits(want))
+
+	buf := newTdsBuffer(512, nil)
+	copy(buf.rbuf[:4], ti.Buffer)
+	buf.rpos = 0
+	buf.rsize = 4
+
+	got := readFixedType(&ti, buf, nil, msdsn.EncodeParameters{Timezone: time.UTC})
+
+	gotF64, ok := got.(float64)
+	if !ok {
+		t.Fatalf("readFixedType returned %T, want float64", got)
+	}
+	assert.Equal(t, float64(want), gotF64)
 }


### PR DESCRIPTION
## Problem

When a `REAL` column (TDS `typeFlt4`) is decoded via the fixed-type fast path in `readFixedType`, the driver returns a bare `float32` value:

```go
// types.go
case typeFlt4:
    return math.Float32frombits(binary.LittleEndian.Uint32(buf))
```

This conflicts with:

- The advertised scan type. `makeGoLangScanType` reports `reflect.TypeOf(float64(0))` for `typeFlt4` (see [types_test.go](https://github.com/microsoft/go-mssqldb/blob/main/types_test.go#L24)), and `Rowsq.ColumnTypeScanType` agrees ([rowsq_unit_test.go](https://github.com/microsoft/go-mssqldb/blob/main/rowsq_unit_test.go#L31)).
- The `database/sql.Scanner` contract, which mandates `float64` for floating-point sources.
- The sibling `readVariableType` / bulk-copy paths in the same file, which already widen to `float64` (see `types.go` L431 and L677).

Scanning a `REAL` column directly into a `*float64` therefore fails depending on which decode path is taken. Reported downstream in [uptrace/bun#993](https://github.com/uptrace/bun/issues/993#issuecomment-2253340639).

## Root Cause

A single missing `float64(...)` cast on the fixed-type code path. The other read paths for `typeFlt4` were already correct, so this is best explained as an oversight at the time the fast path was added.

## Solution

Wrap the result in `float64(...)`, matching the sibling paths and the documented scan type. Widening `float32 -> float64` is exact, so there is no precision change.

```go
case typeFlt4:
    return float64(math.Float32frombits(binary.LittleEndian.Uint32(buf)))
```

## Changes

| File | Change |
| --- | --- |
| `types.go` | Widen `typeFlt4` result to `float64` in `readFixedType` to match scan type contract. |
| `types_test.go` | Add `TestReadFixedType_Flt4_ReturnsFloat64` regression test. |
| `queries_test.go` | Add `float32` round-trip case to `TestParams` (carried forward from #209). |

## Testing

- `go test -run TestReadFixedType_Flt4_ReturnsFloat64 -v .` passes.
- Verified the new test fails against the pre-fix version of `types.go` (reverting the one-line change produces `readFixedType returned float32, want float64`).
- Existing `TestMakeGoLangScanType` and `TestRowsq_ColumnTypeScanType` continue to pass; they already asserted the `float64` contract that this fix makes the fast path honor.
- `TestParams` (integration) gains a `float32` value, exercising the round-trip path end-to-end against SQL Server.

## Compatibility

This is technically a user-visible behavior change for one narrow case: code that scans a `REAL` column into an `interface{}` destination and then type-asserts the result as `float32`. For example:

```go
var v interface{}
row.Scan(&v)
x := v.(float32) // previously worked when the fast path was hit; will now panic
```

Such code was already non-portable:

- `ColumnTypeScanType` has always advertised `float64` for `typeFlt4`.
- The variable-length read path (`readVariableType`) and the bulk path already returned `float64`, so the same query against a `REAL NULL` column or under TVPs would yield `float64` today.

After this change, all three decode paths return `float64`, matching the advertised scan type and the `database/sql` contract.

## Related

- Supersedes #208 (originally by @CL-Jeremy). The author is credited via `Co-authored-by` on the commit. This branch is rebased on current `main` and adds the regression test that #208 lacked, which is why a new PR is cleaner than pushing onto the original branch (which had `maintainer-can-modify` against the contributor's fork `main`).
- Incorporates the useful `float32` integration coverage from #209 (also by @CL-Jeremy), credited via `Co-authored-by`. The `types_test.go` portion of #209 is obsolete on current `main` (table-driven rewrite).
- Closes #208.
- Closes #209.
