### PR TITLE
docs: fix install command, go install fails on non-main packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A pure Go database/sql driver for Microsoft SQL Server and Azure SQL Database. T
 
 ## Install
 
-Requires Go 1.17 or above.
+Requires Go 1.25 or above.
 
 Install with `go get github.com/microsoft/go-mssqldb@latest`.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A pure Go database/sql driver for Microsoft SQL Server and Azure SQL Database. T
 
 Requires Go 1.17 or above.
 
-Install with `go install github.com/microsoft/go-mssqldb@latest`.
+Install with `go get github.com/microsoft/go-mssqldb@latest`.
 
 ## Connection Parameters and DSN
 


### PR DESCRIPTION
go install only works on main packages but this module is a library.