### PR TITLE
fix: prevent panic on overflowing PRELOGIN option offset and length

### DIFF
--- a/bad_server_test.go
+++ b/bad_server_test.go
@@ -156,6 +156,21 @@ func TestBadServerPreLoginPacketWithMissingData(t *testing.T) {
 	})
 }
 
+// TestBadServerPreLoginPacketWithOverflowingOptionLength sends an option whose
+// offset+length sum wraps past 65535. The connection must fail with an error
+// instead of panicking and taking down the process.
+func TestBadServerPreLoginPacketWithOverflowingOptionLength(t *testing.T) {
+	testBadServer(t, func(conn net.Conn) {
+		// token=0x00, offset=6, length=65530, then padding
+		preloginPacket := []byte{4, 1, 0, 15, 0, 0, 1, 0, 0, 0, 6, 255, 250, 0, 0}
+
+		_, err := conn.Write(preloginPacket)
+		if err != nil {
+			t.Fatal("Writing PRELOGIN packet failed", err)
+		}
+	})
+}
+
 func goodPreloginSequence(t *testing.T, buf *tdsBuffer) {
 	// read prelogin request
 	packetType, err := buf.BeginRead()

--- a/tds.go
+++ b/tds.go
@@ -348,10 +348,17 @@ func readPreloginOption(buffer []byte, offset int) (*preloginOption, error) {
 }
 
 func readPreloginOptionData(plOption *preloginOption, buffer []byte) ([]byte, error) {
+	if plOption == nil {
+		return nil, fmt.Errorf("invalid buffer, invalid prelogin option")
+	}
+
 	buffer_length := len(buffer)
+	// widen to int before adding so the sum cannot wrap around and bypass the bounds check
+	optionOffset := int(plOption.offset)
+	optionLength := int(plOption.length)
+
 	// check if prelogin option data exists in buffer
-	if plOption == nil || int(plOption.length+plOption.offset) > buffer_length ||
-		int(plOption.offset) >= buffer_length {
+	if optionOffset+optionLength > buffer_length || optionOffset >= buffer_length {
 		return nil, fmt.Errorf("invalid buffer, invalid prelogin option")
 	}
 
@@ -359,7 +366,7 @@ func readPreloginOptionData(plOption *preloginOption, buffer []byte) ([]byte, er
 		return nil, fmt.Errorf("cannot read data for prelogin terminator record")
 	}
 
-	value := buffer[plOption.offset : plOption.length+plOption.offset]
+	value := buffer[optionOffset : optionOffset+optionLength]
 	return value, nil
 }
 

--- a/tds_prelogin_fuzz_test.go
+++ b/tds_prelogin_fuzz_test.go
@@ -73,6 +73,8 @@ func FuzzReadPrelogin(f *testing.F) {
 		}
 		transport := &preloginTransport{r: bytes.NewReader(framePrelogin(body))}
 		buf := newTdsBuffer(defaultPacketSize, transport)
+		// return the 64 KiB backing buffer to bufpool so each iteration reuses it
+		defer buf.bufClose()
 		fields, err := readPrelogin(buf)
 		if err != nil {
 			return

--- a/tds_prelogin_fuzz_test.go
+++ b/tds_prelogin_fuzz_test.go
@@ -1,0 +1,87 @@
+package mssql
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+)
+
+// preloginTransport serves a fixed byte stream as the server side of a TDS
+// connection. Writes are discarded because PRELOGIN parsing never replies.
+type preloginTransport struct {
+	r io.Reader
+}
+
+func (t *preloginTransport) Read(p []byte) (int, error)  { return t.r.Read(p) }
+func (t *preloginTransport) Write(p []byte) (int, error) { return len(p), nil }
+func (t *preloginTransport) Close() error                { return nil }
+
+// framePrelogin wraps body in a final PRELOGIN reply packet header.
+func framePrelogin(body []byte) []byte {
+	packet := make([]byte, headerSize, headerSize+len(body))
+	packet[0] = byte(packReply)
+	packet[1] = 1 // final packet
+	binary.BigEndian.PutUint16(packet[2:], uint16(headerSize+len(body)))
+	return append(packet, body...)
+}
+
+// FuzzReadPrelogin feeds arbitrary PRELOGIN response bodies to the parser.
+// The PRELOGIN exchange happens before authentication and before TLS is
+// negotiated, and readPrelogin is called from connect() without any recover(),
+// so a panic here takes down the entire client process rather than failing a
+// single connection attempt. The parser must therefore only ever return a
+// result or an error, never panic.
+func FuzzReadPrelogin(f *testing.F) {
+	seeds := [][]byte{
+		// terminator only
+		{preloginTERMINATOR},
+		// encryption option followed by terminator
+		{preloginENCRYPTION, 0, 6, 0, 1, preloginTERMINATOR, encryptNotSup},
+		// version, encryption, instopt, threadid, mars
+		{
+			0, 0, 26, 0, 6,
+			1, 0, 32, 0, 1,
+			2, 0, 33, 0, 1,
+			3, 0, 34, 0, 4,
+			4, 0, 38, 0, 1,
+			preloginTERMINATOR,
+			16, 0, 7, 208, 0, 0,
+			encryptNotSup,
+			0,
+			0, 0, 0, 0,
+			0,
+		},
+		// option header truncated mid-record
+		{0, 0, 6, 0},
+		// offset past the end of the buffer
+		{0, 0xFF, 0xFF, 0, 1, preloginTERMINATOR},
+		// length past the end of the buffer
+		{0, 0, 6, 0xFF, 0, preloginTERMINATOR},
+		// no terminator at all
+		{0, 0, 6, 0, 1, 0, 0},
+		{},
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, body []byte) {
+		// A TDS packet length is a uint16, so oversized bodies cannot be framed.
+		if len(body) > int(^uint16(0))-headerSize {
+			t.Skip()
+		}
+		transport := &preloginTransport{r: bytes.NewReader(framePrelogin(body))}
+		buf := newTdsBuffer(defaultPacketSize, transport)
+		fields, err := readPrelogin(buf)
+		if err != nil {
+			return
+		}
+		// Every returned value must be a real sub-slice of the response body.
+		for token, value := range fields {
+			if len(value) > len(body) {
+				t.Fatalf("prelogin option %d returned %d bytes from a %d byte response", token, len(value), len(body))
+			}
+		}
+	})
+}

--- a/tds_unit_test.go
+++ b/tds_unit_test.go
@@ -347,3 +347,74 @@ func TestBrowserDataType(t *testing.T) {
 	assert.Len(t, data, 1, "BrowserData length")
 	assert.Equal(t, "1433", data["INSTANCE1"]["tcp"], "BrowserData[INSTANCE1][tcp]")
 }
+
+// TestReadPreloginOptionData covers bounds checking of the offset/length pair a
+// server supplies for each PRELOGIN option. The offset+length cases were found
+// by FuzzReadPrelogin: computing the sum in uint16 let it wrap past 65535, so
+// the bounds check passed while the slice expression itself was out of range.
+func TestReadPreloginOptionData(t *testing.T) {
+	t.Parallel()
+
+	buffer := []byte{0, 0, 6, 0, 4, preloginTERMINATOR, 1, 2, 3, 4}
+
+	tests := []struct {
+		name     string
+		option   *preloginOption
+		expected []byte
+		wantErr  bool
+	}{
+		{
+			name:     "valid option",
+			option:   &preloginOption{token: preloginVERSION, offset: 6, length: 4},
+			expected: []byte{1, 2, 3, 4},
+		},
+		{
+			name:     "zero length option",
+			option:   &preloginOption{token: preloginVERSION, offset: 6, length: 0},
+			expected: []byte{},
+		},
+		{
+			name:    "nil option",
+			option:  nil,
+			wantErr: true,
+		},
+		{
+			name:    "terminator record",
+			option:  &preloginOption{token: preloginTERMINATOR, offset: 6, length: 4},
+			wantErr: true,
+		},
+		{
+			name:    "offset past end of buffer",
+			option:  &preloginOption{token: preloginVERSION, offset: uint16(len(buffer)), length: 0},
+			wantErr: true,
+		},
+		{
+			name:    "length past end of buffer",
+			option:  &preloginOption{token: preloginVERSION, offset: 6, length: 5},
+			wantErr: true,
+		},
+		{
+			name:    "offset plus length overflows uint16",
+			option:  &preloginOption{token: preloginVERSION, offset: 6, length: 65530},
+			wantErr: true,
+		},
+		{
+			name:    "maximum length",
+			option:  &preloginOption{token: preloginVERSION, offset: 5, length: 65535},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, err := readPreloginOptionData(tt.option, buffer)
+			if tt.wantErr {
+				assert.Error(t, err, "readPreloginOptionData error")
+				assert.Nil(t, value, "readPreloginOptionData value")
+				return
+			}
+			assert.NoError(t, err, "readPreloginOptionData error")
+			assert.Equal(t, tt.expected, value, "readPreloginOptionData value")
+		})
+	}
+}

--- a/testdata/fuzz/FuzzReadPrelogin/373594c8c8b0e9d5
+++ b/testdata/fuzz/FuzzReadPrelogin/373594c8c8b0e9d5
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("0\x00\x05\xff\xff0")


### PR DESCRIPTION
## Summary

A new fuzz target over the PRELOGIN response parser, `FuzzReadPrelogin`, found a slice bounds panic in `readPreloginOptionData` within a couple of seconds of fuzzing. This PR adds the fuzz target and fixes the bug it found.

## What the fuzzer found

Each PRELOGIN option carries a `uint16` offset and a `uint16` length read straight off the wire. The bounds check added them together in `uint16` arithmetic and only widened the result to `int` afterwards:

```go
if plOption == nil || int(plOption.length+plOption.offset) > buffer_length ||
    int(plOption.offset) >= buffer_length {
    return nil, fmt.Errorf("invalid buffer, invalid prelogin option")
}
value := buffer[plOption.offset : plOption.length+plOption.offset]
```

The sum wraps at 65536. Since `length <= 65535`, any wraparound produces a sum smaller than `offset`, so the check always passes, and the same wrapped expression is reused as the slice's upper bound. The minimized input the fuzzer produced is `offset=5, length=65535`, giving `buffer[5:4]`:

```
panic: runtime error: slice bounds out of range [5:4]
github.com/microsoft/go-mssqldb.readPreloginOptionData(...)
	tds.go:362
github.com/microsoft/go-mssqldb.readPrelogin(...)
	tds.go:312
```

## Why it matters

The panic is not recoverable by callers. Almost all other TDS token parsing runs inside `processSingleResponse`, which wraps its work in `defer recover()` and converts a panic into an ordinary error. PRELOGIN parsing does not — `readPrelogin` is called directly from `connect()`, with no `recover()` in between, so the panic terminates the whole process rather than failing a single connection attempt.

PRELOGIN is also exchanged in clear text before TLS is negotiated and before authentication, so `encrypt` and `TrustServerCertificate` settings offer no protection against a malformed response at this stage. The existing bounds check was added in #66 specifically to stop a bad server from panicking the driver; none of its test cases covered an overflowing offset/length pair.

## The fix

Widen offset and length to `int` before adding, in both the bounds check and the slice expression, and hoist the `nil` check so the widening is safe.

## Tests

- `FuzzReadPrelogin` (new) — feeds arbitrary PRELOGIN response bodies through a real `tdsBuffer` and asserts the parser only ever returns a result or an error, and never returns more bytes than the response contained. The minimized failing input is checked in under `testdata/fuzz/`, so this case is exercised by the regular `go test` run and not only during fuzzing.
- `TestReadPreloginOptionData` (new) — table test covering valid options, zero length, nil option, terminator records, out-of-range offset, out-of-range length, and both overflow cases.
- `TestBadServerPreLoginPacketWithOverflowingOptionLength` (new) — end-to-end coverage through the connection path, sending the raw 15-byte packet that triggered the crash.

Fuzzed for a further 2 minutes (~680k execs) against the fixed code with no failures.

## Verification

```
go build ./...
go vet .            # clean
go test .           # pass
go test ./msdsn ./internal/...  # pass
go test -fuzz FuzzReadPrelogin -fuzztime 120s .  # pass
```