### PR TITLE
fix: quote table name and ORDER columns in bulk copy

### DIFF
--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -133,7 +133,11 @@ func (b *Bulk) sendBulkCommand(ctx context.Context) (err error) {
 		with_opts = append(with_opts, fmt.Sprintf("ROWS_PER_BATCH = %d", b.Options.RowsPerBatch))
 	}
 	if len(b.Options.Order) > 0 {
-		with_opts = append(with_opts, fmt.Sprintf("ORDER(%s)", strings.Join(b.Options.Order, ",")))
+		order := make([]string, len(b.Options.Order))
+		for i, entry := range b.Options.Order {
+			order[i] = quoteBulkOrder(entry)
+		}
+		with_opts = append(with_opts, fmt.Sprintf("ORDER(%s)", strings.Join(order, ",")))
 	}
 	if b.Options.Tablock {
 		with_opts = append(with_opts, "TABLOCK")
@@ -143,7 +147,7 @@ func (b *Bulk) sendBulkCommand(ctx context.Context) (err error) {
 		with_part = fmt.Sprintf("WITH (%s)", strings.Join(with_opts, ","))
 	}
 
-	query := fmt.Sprintf("INSERT BULK %s (%s) %s", b.tablename, col_defs.String(), with_part)
+	query := fmt.Sprintf("INSERT BULK %s (%s) %s", quoteMultiPartID(b.tablename), col_defs.String(), with_part)
 
 	stmt, err := b.cn.PrepareContext(ctx, query)
 	if err != nil {
@@ -327,7 +331,7 @@ func (b *Bulk) getMetadata(ctx context.Context) (err error) {
 	}()
 
 	// Get columns info.
-	stmt, err = b.cn.prepareContext(ctx, fmt.Sprintf("select * from %s SET FMTONLY OFF", b.tablename))
+	stmt, err = b.cn.prepareContext(ctx, fmt.Sprintf("select * from %s SET FMTONLY OFF", quoteMultiPartID(b.tablename)))
 	if err != nil {
 		return
 	}

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -147,7 +147,11 @@ func (b *Bulk) sendBulkCommand(ctx context.Context) (err error) {
 		with_part = fmt.Sprintf("WITH (%s)", strings.Join(with_opts, ","))
 	}
 
-	query := fmt.Sprintf("INSERT BULK %s (%s) %s", quoteMultiPartID(b.tablename), col_defs.String(), with_part)
+	quotedTable, err := quoteObjectName(b.tablename)
+	if err != nil {
+		return err
+	}
+	query := fmt.Sprintf("INSERT BULK %s (%s) %s", quotedTable, col_defs.String(), with_part)
 
 	stmt, err := b.cn.PrepareContext(ctx, query)
 	if err != nil {
@@ -296,6 +300,12 @@ func (b *Bulk) createColMetadata() []byte {
 }
 
 func (b *Bulk) getMetadata(ctx context.Context) (err error) {
+	// Check the destination before touching the session's FMTONLY setting.
+	quotedTable, err := quoteObjectName(b.tablename)
+	if err != nil {
+		return err
+	}
+
 	stmt, err := b.cn.prepareContext(ctx, "SET FMTONLY ON")
 	if err != nil {
 		return
@@ -331,13 +341,13 @@ func (b *Bulk) getMetadata(ctx context.Context) (err error) {
 	}()
 
 	// Get columns info.
-	stmt, err = b.cn.prepareContext(ctx, fmt.Sprintf("select * from %s SET FMTONLY OFF", quoteMultiPartID(b.tablename)))
+	stmt, err = b.cn.prepareContext(ctx, fmt.Sprintf("select * from %s SET FMTONLY OFF", quotedTable))
 	if err != nil {
 		return
 	}
 	rows, err := stmt.QueryContext(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("get columns info failed: %v", err)
+		return fmt.Errorf("get columns info failed: %w", err)
 	}
 	resetFmtonly = false
 	b.metadata = rows.(*Rows).cols

--- a/bulkcopy_sql.go
+++ b/bulkcopy_sql.go
@@ -51,6 +51,12 @@ func (c *Conn) prepareCopyIn(ctx context.Context, query string) (_ driver.Stmt, 
 // as in "schema.table" or "database.schema.table", and individual parts may be
 // delimited, as in "[my schema].[my table]".
 //
+// Because the destination is always an object name, a value that relied on
+// being spliced into the statement as raw text no longer resolves. Pass
+// "table" and options.Tablock rather than "table WITH (TABLOCK)". A name that
+// cannot identify an object, because it is empty or has more than four parts,
+// is reported before any statement is sent.
+//
 // columns are the destination column names, in the order their values are
 // passed to Exec.
 //

--- a/bulkcopy_sql.go
+++ b/bulkcopy_sql.go
@@ -43,6 +43,16 @@ func (c *Conn) prepareCopyIn(ctx context.Context, query string) (_ driver.Stmt, 
 	return ci, nil
 }
 
+// CopyIn creates a bulk import statement that can be passed to Prepare.
+//
+// table is the destination object name. It is treated as an object name and is
+// quoted before it is sent to the server, so a name that is not a regular
+// identifier does not need to be delimited by the caller. It may be qualified,
+// as in "schema.table" or "database.schema.table", and individual parts may be
+// delimited, as in "[my schema].[my table]".
+//
+// columns are the destination column names, in the order their values are
+// passed to Exec.
 func CopyIn(table string, options BulkOptions, columns ...string) string {
 	bulkconfig := &serializableBulkConfig{TableName: table, Options: options, ColumnsName: columns}
 

--- a/bulkcopy_sql.go
+++ b/bulkcopy_sql.go
@@ -53,6 +53,14 @@ func (c *Conn) prepareCopyIn(ctx context.Context, query string) (_ driver.Stmt, 
 //
 // columns are the destination column names, in the order their values are
 // passed to Exec.
+//
+// Each options.Order entry names one or more columns to declare the data is
+// already sorted by, as in "id" or "id ASC, name DESC". Column names are quoted
+// the same way table is. A column name is separated from an optional trailing
+// ASC or DESC sort direction by whitespace, and from the next column by a
+// comma, so a column whose name ends in "asc" or "desc" or contains a comma has
+// to be delimited by the caller to be told apart from a direction or a
+// separator, as in "[sort desc]" or "[order, id]".
 func CopyIn(table string, options BulkOptions, columns ...string) string {
 	bulkconfig := &serializableBulkConfig{TableName: table, Options: options, ColumnsName: columns}
 

--- a/bulkcopy_test.go
+++ b/bulkcopy_test.go
@@ -587,6 +587,13 @@ func TestBulkcopyIdentifierQuoting(t *testing.T) {
 			columns:  []string{"id", "order name"},
 			order:    []string{"order name DESC"},
 		},
+		{
+			name:     "several order columns in one entry",
+			table:    "bulk_quote_order_multi",
+			copyName: "bulk_quote_order_multi",
+			columns:  []string{"id", "name"},
+			order:    []string{"id ASC, name DESC"},
+		},
 	}
 
 	pool, logger := open(t)

--- a/bulkcopy_test.go
+++ b/bulkcopy_test.go
@@ -667,6 +667,20 @@ func TestBulkcopyIdentifierQuoting(t *testing.T) {
 	}
 }
 
+// errInvalidObjectName is the SQL Server error number for "Invalid object
+// name". Matching the number rather than the message keeps these tests working
+// against a server that reports messages in another language.
+const errInvalidObjectName = 208
+
+// assertSQLErrorNumber asserts err carries the given SQL Server error number.
+func assertSQLErrorNumber(t *testing.T, err error, number int32) {
+	t.Helper()
+	var sqlErr Error
+	if assert.ErrorAs(t, err, &sqlErr) {
+		assert.Equal(t, number, sqlErr.Number, "unexpected error: %v", err)
+	}
+}
+
 // TestBulkcopyDestinationIsASingleObject makes sure a destination name is only
 // ever treated as an object name, so trailing text cannot turn the statements
 // the bulk copy builds into a batch of several statements.
@@ -700,13 +714,57 @@ func TestBulkcopyDestinationIsASingleObject(t *testing.T) {
 	defer func() { _ = stmt.Close() }()
 
 	_, err = stmt.ExecContext(ctx, 1)
-	assert.ErrorContains(t, err, "Invalid object name")
+	assertSQLErrorNumber(t, err, errInvalidObjectName)
 
 	var created int
 	err = conn.QueryRowContext(ctx,
 		"SELECT COUNT(*) FROM sys.tables WHERE name = 'bulk_second_statement'").Scan(&created)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, created, "the trailing text must not run as a separate statement")
+}
+
+// TestBulkcopyRejectsUnusableDestination makes sure a destination that cannot
+// name an object is reported by the driver, and that the session is still
+// usable afterwards because no statement was sent.
+func TestBulkcopyRejectsUnusableDestination(t *testing.T) {
+	pool, logger := open(t)
+	defer func() { _ = pool.Close() }()
+	defer logger.StopLogging()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	conn, err := pool.Conn(ctx)
+	assert.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	tests := []struct {
+		name     string
+		table    string
+		contains string
+	}{
+		{name: "empty", table: "", contains: "does not name an object"},
+		{name: "whitespace only", table: "   ", contains: "does not name an object"},
+		{name: "qualifier without an object", table: "dbo.", contains: "does not name an object"},
+		{name: "too many parts", table: "a.b.c.d.e", contains: "at most 4 are allowed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt, err := conn.PrepareContext(ctx, CopyIn(tt.table, BulkOptions{}, "id"))
+			assert.NoError(t, err)
+			defer func() { _ = stmt.Close() }()
+
+			_, err = stmt.ExecContext(ctx, 1)
+			assert.ErrorContains(t, err, tt.contains)
+
+			// FMTONLY is only ever switched on after the destination has been
+			// checked, so this still returns a row.
+			var one int
+			assert.NoError(t, conn.QueryRowContext(ctx, "SELECT 1").Scan(&one))
+			assert.Equal(t, 1, one)
+		})
+	}
 }
 
 func TestBulkcopyFailure(t *testing.T) {
@@ -732,7 +790,9 @@ func TestBulkcopyFailure(t *testing.T) {
 	_, err = stmt.ExecContext(ctx, "")
 	// But of course, it fails. Previously this would not SET FMTONLY OFF in the case
 	// of a failure, so the next statement would be nullified.
-	assert.ErrorContains(t, err, "Invalid object name 'thistabledoesnotexist'")
+	assertSQLErrorNumber(t, err, errInvalidObjectName)
+	assert.ErrorContains(t, err, "thistabledoesnotexist")
+
 
 	_, err = stmt.ExecContext(ctx)
 	assert.NoError(t, err)

--- a/bulkcopy_test.go
+++ b/bulkcopy_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/hex"
+	"fmt"
 	"math"
 	"reflect"
 	"strings"
@@ -507,6 +508,198 @@ func setupTable(ctx context.Context, t *testing.T, conn *sql.Conn, tableName str
 		t.Fatal("tablesql failed:", err)
 	}
 	return
+}
+
+// TestBulkcopyIdentifierQuoting covers destination names and BulkOptions.Order
+// entries that have to be delimited, either because they contain characters
+// that are not valid in a regular identifier or because they collide with a
+// reserved word.
+func TestBulkcopyIdentifierQuoting(t *testing.T) {
+	tests := []struct {
+		name string
+		// table is the destination name as it is stored in the database.
+		table string
+		// copyName is the name handed to CopyIn, which may be delimited or
+		// qualified differently than table.
+		copyName string
+		columns  []string
+		order    []string
+	}{
+		{
+			name:     "regular identifier",
+			table:    "bulk_quote_plain",
+			copyName: "bulk_quote_plain",
+			columns:  []string{"id", "name"},
+		},
+		{
+			name:     "name containing a space",
+			table:    "bulk quote space",
+			copyName: "bulk quote space",
+			columns:  []string{"id", "name"},
+		},
+		{
+			name:     "name containing a closing bracket",
+			table:    "bulk]quote",
+			copyName: "bulk]quote",
+			columns:  []string{"id", "name"},
+		},
+		{
+			name:     "reserved word",
+			table:    "Order",
+			copyName: "Order",
+			columns:  []string{"id", "name"},
+		},
+		{
+			name:     "caller delimited the name",
+			table:    "bulk quote delimited",
+			copyName: "[bulk quote delimited]",
+			columns:  []string{"id", "name"},
+		},
+		{
+			name:     "schema qualified",
+			table:    "bulk_quote_schema",
+			copyName: "dbo.bulk_quote_schema",
+			columns:  []string{"id", "name"},
+		},
+		{
+			name:     "schema qualified and delimited",
+			table:    "bulk quote schema delimited",
+			copyName: "[dbo].[bulk quote schema delimited]",
+			columns:  []string{"id", "name"},
+		},
+		{
+			name:     "default schema",
+			table:    "bulk_quote_default_schema",
+			copyName: "..bulk_quote_default_schema",
+			columns:  []string{"id", "name"},
+		},
+		{
+			name:     "order option",
+			table:    "bulk_quote_order",
+			copyName: "bulk_quote_order",
+			columns:  []string{"id", "name"},
+			order:    []string{"id"},
+		},
+		{
+			name:     "order option needing delimiters",
+			table:    "bulk quote order delimited",
+			copyName: "bulk quote order delimited",
+			columns:  []string{"id", "order name"},
+			order:    []string{"order name DESC"},
+		},
+	}
+
+	pool, logger := open(t)
+	defer pool.Close()
+	defer logger.StopLogging()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	q := TSQLQuoter{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, err := pool.Conn(ctx)
+			if err != nil {
+				t.Fatal("failed to pull connection from pool", err)
+			}
+			defer conn.Close()
+
+			quoted := q.ID(tt.table)
+			columnDefs := make([]string, len(tt.columns))
+			for i, col := range tt.columns {
+				columnDefs[i] = q.ID(col) + " nvarchar(50) NULL"
+			}
+
+			drop := "IF OBJECT_ID('dbo." + quoted + "') IS NOT NULL DROP TABLE dbo." + quoted
+			if _, err := conn.ExecContext(ctx, drop); err != nil {
+				t.Fatal("drop table failed: ", err)
+			}
+			defer func() {
+				if _, err := conn.ExecContext(ctx, drop); err != nil {
+					t.Error("drop table failed: ", err)
+				}
+			}()
+
+			create := "CREATE TABLE dbo." + quoted + " (" + strings.Join(columnDefs, ", ") + ")"
+			if _, err := conn.ExecContext(ctx, create); err != nil {
+				t.Fatal("create table failed: ", err)
+			}
+
+			stmt, err := conn.PrepareContext(ctx, CopyIn(tt.copyName, BulkOptions{Order: tt.order}, tt.columns...))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer stmt.Close()
+
+			values := make([]interface{}, len(tt.columns))
+			for i := range values {
+				values[i] = fmt.Sprintf("value%d", i)
+			}
+			if _, err := stmt.ExecContext(ctx, values...); err != nil {
+				t.Fatal("AddRow failed: ", err)
+			}
+
+			result, err := stmt.ExecContext(ctx)
+			if err != nil {
+				t.Fatal("bulkcopy failed: ", err)
+			}
+			if rows, _ := result.RowsAffected(); rows != 1 {
+				t.Fatalf("expected 1 row inserted, got %d", rows)
+			}
+
+			var rowCount int
+			if err := conn.QueryRowContext(ctx, "select count(*) from dbo."+quoted).Scan(&rowCount); err != nil {
+				t.Fatal(err)
+			}
+			if rowCount != 1 {
+				t.Errorf("unexpected row count %d", rowCount)
+			}
+		})
+	}
+}
+
+// TestBulkcopyDestinationIsASingleObject makes sure a destination name is only
+// ever treated as an object name, so trailing text cannot turn the statements
+// the bulk copy builds into a batch of several statements.
+func TestBulkcopyDestinationIsASingleObject(t *testing.T) {
+	pool, logger := open(t)
+	defer pool.Close()
+	defer logger.StopLogging()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	conn, err := pool.Conn(ctx)
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	_, err = conn.ExecContext(ctx, "IF OBJECT_ID('dbo.bulk_single_object') IS NOT NULL DROP TABLE dbo.bulk_single_object")
+	assert.NoError(t, err)
+	_, err = conn.ExecContext(ctx, "CREATE TABLE dbo.bulk_single_object (id int)")
+	assert.NoError(t, err)
+	defer func() {
+		_, err := conn.ExecContext(ctx, "DROP TABLE dbo.bulk_single_object")
+		assert.NoError(t, err)
+	}()
+
+	_, err = conn.ExecContext(ctx, "IF OBJECT_ID('dbo.bulk_second_statement') IS NOT NULL DROP TABLE dbo.bulk_second_statement")
+	assert.NoError(t, err)
+
+	table := "dbo.bulk_single_object SET FMTONLY OFF; CREATE TABLE dbo.bulk_second_statement (id int);--"
+	stmt, err := conn.PrepareContext(ctx, CopyIn(table, BulkOptions{}, "id"))
+	assert.NoError(t, err)
+	defer stmt.Close()
+
+	_, err = stmt.ExecContext(ctx, 1)
+	assert.ErrorContains(t, err, "Invalid object name")
+
+	var created int
+	err = conn.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sys.tables WHERE name = 'bulk_second_statement'").Scan(&created)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, created, "the trailing text must not run as a separate statement")
 }
 
 func TestBulkcopyFailure(t *testing.T) {

--- a/bulkcopy_test.go
+++ b/bulkcopy_test.go
@@ -597,7 +597,7 @@ func TestBulkcopyIdentifierQuoting(t *testing.T) {
 	}
 
 	pool, logger := open(t)
-	defer pool.Close()
+	defer func() { _ = pool.Close() }()
 	defer logger.StopLogging()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -611,7 +611,7 @@ func TestBulkcopyIdentifierQuoting(t *testing.T) {
 			if err != nil {
 				t.Fatal("failed to pull connection from pool", err)
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }()
 
 			quoted := q.ID(tt.table)
 			columnDefs := make([]string, len(tt.columns))
@@ -638,7 +638,7 @@ func TestBulkcopyIdentifierQuoting(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer stmt.Close()
+			defer func() { _ = stmt.Close() }()
 
 			values := make([]interface{}, len(tt.columns))
 			for i := range values {
@@ -672,7 +672,7 @@ func TestBulkcopyIdentifierQuoting(t *testing.T) {
 // the bulk copy builds into a batch of several statements.
 func TestBulkcopyDestinationIsASingleObject(t *testing.T) {
 	pool, logger := open(t)
-	defer pool.Close()
+	defer func() { _ = pool.Close() }()
 	defer logger.StopLogging()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -680,7 +680,7 @@ func TestBulkcopyDestinationIsASingleObject(t *testing.T) {
 
 	conn, err := pool.Conn(ctx)
 	assert.NoError(t, err)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	_, err = conn.ExecContext(ctx, "IF OBJECT_ID('dbo.bulk_single_object') IS NOT NULL DROP TABLE dbo.bulk_single_object")
 	assert.NoError(t, err)
@@ -697,7 +697,7 @@ func TestBulkcopyDestinationIsASingleObject(t *testing.T) {
 	table := "dbo.bulk_single_object SET FMTONLY OFF; CREATE TABLE dbo.bulk_second_statement (id int);--"
 	stmt, err := conn.PrepareContext(ctx, CopyIn(table, BulkOptions{}, "id"))
 	assert.NoError(t, err)
-	defer stmt.Close()
+	defer func() { _ = stmt.Close() }()
 
 	_, err = stmt.ExecContext(ctx, 1)
 	assert.ErrorContains(t, err, "Invalid object name")

--- a/doc/how-to-perform-bulk-imports.md
+++ b/doc/how-to-perform-bulk-imports.md
@@ -16,6 +16,12 @@ bulkImportStr := mssql.CopyIn("tablename", mssql.BulkOptions{}, "column1", "colu
 stmt, err := db.Prepare(bulkImportStr)
 ```
 
+The table name is treated as an object name and is quoted before it is sent to the server, so a name that is not a regular identifier does not need to be delimited by the caller. It may be qualified, and individual parts may be delimited.
+
+```
+bulkImportStr := mssql.CopyIn("[my schema].[my table]", mssql.BulkOptions{}, "column1")
+```
+
 Bulk options can be specified using the `mssql.BulkOptions` type. The following is how the `BulkOptions` type is defined:
 
 ```
@@ -28,6 +34,12 @@ type BulkOptions struct {
     Order             []string
     Tablock           bool
 }
+```
+
+Each `Order` entry is a destination column name, optionally followed by `ASC` or `DESC`. The column name is quoted the same way the table name is, so a column name that ends in `asc` or `desc` has to be delimited to be told apart from a sort direction.
+
+```
+mssql.BulkOptions{Order: []string{"column1 DESC", "[my column]"}}
 ```
 
 The statement can be executed many times to copy data into the table specified.

--- a/doc/how-to-perform-bulk-imports.md
+++ b/doc/how-to-perform-bulk-imports.md
@@ -36,10 +36,11 @@ type BulkOptions struct {
 }
 ```
 
-Each `Order` entry is a destination column name, optionally followed by `ASC` or `DESC`. The column name is quoted the same way the table name is, so a column name that ends in `asc` or `desc` has to be delimited to be told apart from a sort direction.
+Each `Order` entry names one or more destination columns, separated by commas, each optionally followed by `ASC` or `DESC`. Column names are quoted the same way the table name is, so a column name that ends in `asc` or `desc`, or that contains a comma, has to be delimited to be told apart from a sort direction or a separator.
 
 ```
 mssql.BulkOptions{Order: []string{"column1 DESC", "[my column]"}}
+mssql.BulkOptions{Order: []string{"column1 DESC, [my column]"}}
 ```
 
 The statement can be executed many times to copy data into the table specified.

--- a/doc/how-to-perform-bulk-imports.md
+++ b/doc/how-to-perform-bulk-imports.md
@@ -22,6 +22,8 @@ The table name is treated as an object name and is quoted before it is sent to t
 bulkImportStr := mssql.CopyIn("[my schema].[my table]", mssql.BulkOptions{}, "column1")
 ```
 
+Because the destination is always an object name, a value that relied on being spliced into the statement as raw text no longer resolves. Pass the table name and the matching option instead of appending the clause to the name, for example `mssql.CopyIn("tablename", mssql.BulkOptions{Tablock: true}, "column1")` rather than `mssql.CopyIn("tablename WITH (TABLOCK)", ...)`. A name that cannot identify an object, because it is empty or has more than the four parts SQL Server allows, is reported before any statement is sent.
+
 Bulk options can be specified using the `mssql.BulkOptions` type. The following is how the `BulkOptions` type is defined:
 
 ```

--- a/quoter.go
+++ b/quoter.go
@@ -14,6 +14,127 @@ func (TSQLQuoter) ID(name string) string {
 	return "[" + strings.Replace(name, "]", "]]", -1) + "]"
 }
 
+// splitMultiPartID splits a possibly multi-part name such as "db.schema.table"
+// into its individual parts. Dots inside a part delimited with [] or "" are not
+// treated as separators.
+func splitMultiPartID(name string) []string {
+	parts := make([]string, 0, 4)
+	var part strings.Builder
+	// closer is the byte that ends the delimited part currently being read,
+	// or 0 when the reader is not inside a delimited part.
+	var closer byte
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case closer != 0:
+			part.WriteByte(c)
+			if c != closer {
+				continue
+			}
+			// A doubled delimiter is an escaped literal rather than the end
+			// of the part.
+			if i+1 < len(name) && name[i+1] == closer {
+				i++
+				part.WriteByte(c)
+				continue
+			}
+			closer = 0
+		case c == '[':
+			closer = ']'
+			part.WriteByte(c)
+		case c == '"':
+			closer = '"'
+			part.WriteByte(c)
+		case c == '.':
+			parts = append(parts, part.String())
+			part.Reset()
+		default:
+			part.WriteByte(c)
+		}
+	}
+	return append(parts, part.String())
+}
+
+// unquoteID reports whether part is a single well-formed delimited identifier
+// and, if so, returns the identifier without its delimiters. A part such as
+// `[a] SELECT 1 --[b]` starts and ends with brackets but is not a single
+// identifier, so it is rejected.
+func unquoteID(part string) (string, bool) {
+	if len(part) < 2 {
+		return "", false
+	}
+	var closer byte
+	switch part[0] {
+	case '[':
+		closer = ']'
+	case '"':
+		closer = '"'
+	default:
+		return "", false
+	}
+	if part[len(part)-1] != closer {
+		return "", false
+	}
+
+	body := part[1 : len(part)-1]
+	var name strings.Builder
+	for i := 0; i < len(body); i++ {
+		if body[i] == closer {
+			// A lone delimiter would close the identifier early, so part is
+			// not a single delimited identifier.
+			if i+1 >= len(body) || body[i+1] != closer {
+				return "", false
+			}
+			i++
+		}
+		name.WriteByte(body[i])
+	}
+	return name.String(), true
+}
+
+// quoteIDPart quotes one part of a multi-part name. A part the caller already
+// delimited with [] or "" keeps its identifier, everything else is escaped.
+// An empty part is preserved so a name such as "db..table" keeps deferring to
+// the server's default schema.
+func quoteIDPart(part string) string {
+	part = strings.TrimSpace(part)
+	if part == "" {
+		return ""
+	}
+	if name, ok := unquoteID(part); ok {
+		return TSQLQuoter{}.ID(name)
+	}
+	return TSQLQuoter{}.ID(part)
+}
+
+// quoteMultiPartID quotes a possibly multi-part object name such as "table",
+// "schema.table" or "db.schema.table" so it is safe to embed in query text.
+func quoteMultiPartID(name string) string {
+	parts := splitMultiPartID(name)
+	for i, part := range parts {
+		parts[i] = quoteIDPart(part)
+	}
+	return strings.Join(parts, ".")
+}
+
+// quoteBulkOrder quotes the column name in a BulkOptions.Order entry so it is
+// safe to embed in the ORDER hint of an INSERT BULK statement. An optional
+// trailing ASC or DESC sort direction is preserved. A column name that itself
+// ends in "asc" or "desc" has to be delimited by the caller to be told apart
+// from a sort direction.
+func quoteBulkOrder(entry string) string {
+	name := strings.TrimSpace(entry)
+	direction := ""
+	if i := strings.LastIndexAny(name, " \t\r\n"); i >= 0 {
+		switch suffix := strings.ToUpper(strings.TrimSpace(name[i:])); suffix {
+		case "ASC", "DESC":
+			direction = " " + suffix
+			name = name[:i]
+		}
+	}
+	return quoteIDPart(name) + direction
+}
+
 // Value quotes database values such as string or []byte types as strings
 // that are suitable and safe to embed in SQL text. The returned value
 // of a string will include all surrounding quotes.

--- a/quoter.go
+++ b/quoter.go
@@ -1,8 +1,13 @@
 package mssql
 
 import (
+	"fmt"
 	"strings"
 )
+
+// maxIDParts is the number of parts SQL Server allows in an object name:
+// server.database.schema.object.
+const maxIDParts = 4
 
 // TSQLQuoter implements sqlexp.Quoter
 type TSQLQuoter struct {
@@ -115,19 +120,27 @@ func unquoteID(part string) (string, bool) {
 	return name.String(), true
 }
 
+// idPartName returns the identifier one part of a multi-part name holds, with
+// any delimiters removed. It is empty when the part names nothing, whether it
+// was written as "", "  " or "[]".
+func idPartName(part string) string {
+	part = strings.TrimSpace(part)
+	if name, ok := unquoteID(part); ok {
+		return name
+	}
+	return part
+}
+
 // quoteIDPart quotes one part of a multi-part name. A part the caller already
 // delimited with [] or "" keeps its identifier, everything else is escaped.
 // An empty part is preserved so a name such as "db..table" keeps deferring to
 // the server's default schema.
 func quoteIDPart(part string) string {
-	part = strings.TrimSpace(part)
-	if part == "" {
+	name := idPartName(part)
+	if name == "" {
 		return ""
 	}
-	if name, ok := unquoteID(part); ok {
-		return TSQLQuoter{}.ID(name)
-	}
-	return TSQLQuoter{}.ID(part)
+	return TSQLQuoter{}.ID(name)
 }
 
 // quoteMultiPartID quotes a possibly multi-part object name such as "table",
@@ -138,6 +151,27 @@ func quoteMultiPartID(name string) string {
 		parts[i] = quoteIDPart(part)
 	}
 	return strings.Join(parts, ".")
+}
+
+// quoteObjectName quotes a possibly multi-part object name the same way
+// quoteMultiPartID does, but rejects a name that cannot identify an object so
+// the caller reports the problem itself instead of leaving the server to fail
+// on the query text it produced.
+func quoteObjectName(name string) (string, error) {
+	parts := splitMultiPartID(name)
+	if len(parts) > maxIDParts {
+		return "", fmt.Errorf("object name %q has %d parts, at most %d are allowed", name, len(parts), maxIDParts)
+	}
+	// The last part names the object itself. An empty one means there is no
+	// object to name, as in "", "dbo." or "dbo.[]", while an earlier empty
+	// part is a qualifier left out on purpose, as in "db..table".
+	if idPartName(parts[len(parts)-1]) == "" {
+		return "", fmt.Errorf("object name %q does not name an object", name)
+	}
+	for i, part := range parts {
+		parts[i] = quoteIDPart(part)
+	}
+	return strings.Join(parts, "."), nil
 }
 
 // quoteBulkOrder quotes the column names in a BulkOptions.Order entry so they

--- a/quoter.go
+++ b/quoter.go
@@ -22,75 +22,92 @@ func splitMultiPartID(name string) []string {
 }
 
 // splitTopLevel splits s on sep, ignoring any separator that appears inside a
-// part delimited with [] or "".
+// delimited part such as [my.part] or "my.part".
+//
+// A delimiter only opens a delimited part when it starts that part and has a
+// matching closer. A delimiter anywhere else is an ordinary character of an
+// undelimited name, so later separators keep splitting and a name such as
+// "sch[ema.table" still names the object "table" in the schema "sch[ema".
 func splitTopLevel(s string, sep byte) []string {
 	parts := make([]string, 0, 4)
 	var part strings.Builder
-	// closer is the byte that ends the delimited part currently being read,
-	// or 0 when the reader is not inside a delimited part.
-	var closer byte
+	// blank reports whether the part being read is still empty or holds only
+	// leading whitespace, so " [my.part] " is recognised as delimited too.
+	blank := true
 	for i := 0; i < len(s); i++ {
 		c := s[i]
-		switch {
-		case closer != 0:
-			part.WriteByte(c)
-			if c != closer {
+		if blank {
+			if n := delimitedLen(s[i:]); n > 0 {
+				part.WriteString(s[i : i+n])
+				i += n - 1
+				blank = false
 				continue
 			}
-			// A doubled delimiter is an escaped literal rather than the end
-			// of the part.
-			if i+1 < len(s) && s[i+1] == closer {
-				i++
-				part.WriteByte(c)
-				continue
-			}
-			closer = 0
-		case c == '[':
-			closer = ']'
-			part.WriteByte(c)
-		case c == '"':
-			closer = '"'
-			part.WriteByte(c)
-		case c == sep:
+		}
+		if c == sep {
 			parts = append(parts, part.String())
 			part.Reset()
-		default:
-			part.WriteByte(c)
+			blank = true
+			continue
+		}
+		part.WriteByte(c)
+		if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
+			blank = false
 		}
 	}
 	return append(parts, part.String())
 }
 
-// unquoteID reports whether part is a single well-formed delimited identifier
-// and, if so, returns the identifier without its delimiters. A part such as
-// `[a] SELECT 1 --[b]` starts and ends with brackets but is not a single
-// identifier, so it is rejected.
-func unquoteID(part string) (string, bool) {
-	if len(part) < 2 {
-		return "", false
+// delimitedLen returns the length of the well-formed delimited identifier that
+// starts s, such as [my part] or "my part", or 0 when s does not start one.
+// A doubled closing delimiter is an escaped literal rather than the end of the
+// identifier.
+func delimitedLen(s string) int {
+	if len(s) < 2 {
+		return 0
 	}
 	var closer byte
-	switch part[0] {
+	switch s[0] {
 	case '[':
 		closer = ']'
 	case '"':
 		closer = '"'
 	default:
-		return "", false
+		return 0
 	}
-	if part[len(part)-1] != closer {
-		return "", false
+	for i := 1; i < len(s); i++ {
+		if s[i] != closer {
+			continue
+		}
+		if i+1 < len(s) && s[i+1] == closer {
+			i++
+			continue
+		}
+		return i + 1
 	}
+	return 0
+}
 
+// unquoteID reports whether part is a single well-formed delimited identifier
+// and, if so, returns the identifier without its delimiters. A part such as
+// `[a] SELECT 1 --[b]` starts and ends with brackets but is not a single
+// identifier, so it is rejected. It recognises exactly the parts splitTopLevel
+// keeps together, because both decide what a delimited part is with
+// delimitedLen.
+func unquoteID(part string) (string, bool) {
+	// delimitedLen returns 0 for anything that does not start a delimited
+	// identifier, which the length comparison alone would accept for an empty
+	// part.
+	if n := delimitedLen(part); n == 0 || n != len(part) {
+		return "", false
+	}
+	closer := part[len(part)-1]
 	body := part[1 : len(part)-1]
 	var name strings.Builder
 	for i := 0; i < len(body); i++ {
+		// delimitedLen already established that every closer in body is
+		// doubled, so the second byte of the pair is the literal one.
 		if body[i] == closer {
-			// A lone delimiter would close the identifier early, so part is
-			// not a single delimited identifier.
-			if i+1 >= len(body) || body[i+1] != closer {
-				return "", false
-			}
 			i++
 		}
 		name.WriteByte(body[i])

--- a/quoter.go
+++ b/quoter.go
@@ -18,13 +18,19 @@ func (TSQLQuoter) ID(name string) string {
 // into its individual parts. Dots inside a part delimited with [] or "" are not
 // treated as separators.
 func splitMultiPartID(name string) []string {
+	return splitTopLevel(name, '.')
+}
+
+// splitTopLevel splits s on sep, ignoring any separator that appears inside a
+// part delimited with [] or "".
+func splitTopLevel(s string, sep byte) []string {
 	parts := make([]string, 0, 4)
 	var part strings.Builder
 	// closer is the byte that ends the delimited part currently being read,
 	// or 0 when the reader is not inside a delimited part.
 	var closer byte
-	for i := 0; i < len(name); i++ {
-		c := name[i]
+	for i := 0; i < len(s); i++ {
+		c := s[i]
 		switch {
 		case closer != 0:
 			part.WriteByte(c)
@@ -33,7 +39,7 @@ func splitMultiPartID(name string) []string {
 			}
 			// A doubled delimiter is an escaped literal rather than the end
 			// of the part.
-			if i+1 < len(name) && name[i+1] == closer {
+			if i+1 < len(s) && s[i+1] == closer {
 				i++
 				part.WriteByte(c)
 				continue
@@ -45,7 +51,7 @@ func splitMultiPartID(name string) []string {
 		case c == '"':
 			closer = '"'
 			part.WriteByte(c)
-		case c == '.':
+		case c == sep:
 			parts = append(parts, part.String())
 			part.Reset()
 		default:
@@ -117,13 +123,24 @@ func quoteMultiPartID(name string) string {
 	return strings.Join(parts, ".")
 }
 
-// quoteBulkOrder quotes the column name in a BulkOptions.Order entry so it is
-// safe to embed in the ORDER hint of an INSERT BULK statement. An optional
+// quoteBulkOrder quotes the column names in a BulkOptions.Order entry so they
+// are safe to embed in the ORDER hint of an INSERT BULK statement. An entry may
+// name a single column or several columns separated by commas. An optional
 // trailing ASC or DESC sort direction is preserved. A column name that itself
-// ends in "asc" or "desc" has to be delimited by the caller to be told apart
-// from a sort direction.
+// ends in "asc" or "desc", or that contains a comma, has to be delimited by the
+// caller to be told apart from a sort direction or a separator.
 func quoteBulkOrder(entry string) string {
-	name := strings.TrimSpace(entry)
+	columns := splitTopLevel(entry, ',')
+	for i, column := range columns {
+		columns[i] = quoteBulkOrderColumn(column)
+	}
+	return strings.Join(columns, ",")
+}
+
+// quoteBulkOrderColumn quotes a single column of an ORDER hint, keeping any
+// trailing sort direction.
+func quoteBulkOrderColumn(column string) string {
+	name := strings.TrimSpace(column)
 	direction := ""
 	if i := strings.LastIndexAny(name, " \t\r\n"); i >= 0 {
 		switch suffix := strings.ToUpper(strings.TrimSpace(name[i:])); suffix {

--- a/quoter_test.go
+++ b/quoter_test.go
@@ -241,6 +241,26 @@ func TestQuoteBulkOrder(t *testing.T) {
 			input:    "id) WITH (TABLOCK); PRINT 1;--",
 			expected: "[id) WITH (TABLOCK); PRINT 1;--]",
 		},
+		{
+			name:     "several columns in one entry",
+			input:    "col1,col2",
+			expected: "[col1],[col2]",
+		},
+		{
+			name:     "several columns with directions",
+			input:    "col1 ASC, col2 DESC",
+			expected: "[col1] ASC,[col2] DESC",
+		},
+		{
+			name:     "delimited column containing a comma",
+			input:    "[order, id]",
+			expected: "[order, id]",
+		},
+		{
+			name:     "delimited column containing a comma with a direction",
+			input:    "[order, id] DESC, col2",
+			expected: "[order, id] DESC,[col2]",
+		},
 	}
 
 	for _, tt := range tests {

--- a/quoter_test.go
+++ b/quoter_test.go
@@ -170,6 +170,21 @@ func TestQuoteMultiPartID(t *testing.T) {
 			input:    "dbo.[Orders",
 			expected: "[dbo].[[Orders]",
 		},
+		{
+			name:     "bracket inside an undelimited part is literal",
+			input:    "sch[ema.table",
+			expected: "[sch[ema].[table]",
+		},
+		{
+			name:     "quote inside an undelimited part is literal",
+			input:    `sch"ema.table`,
+			expected: `[sch"ema].[table]`,
+		},
+		{
+			name:     "delimited part after an undelimited part with a bracket",
+			input:    "sch[ema.[my.table]",
+			expected: "[sch[ema].[my.table]",
+		},
 	}
 
 	for _, tt := range tests {
@@ -261,6 +276,11 @@ func TestQuoteBulkOrder(t *testing.T) {
 			input:    "[order, id] DESC, col2",
 			expected: "[order, id] DESC,[col2]",
 		},
+		{
+			name:     "bracket inside an undelimited column does not hide a separator",
+			input:    "co[l1,col2",
+			expected: "[co[l1],[col2]",
+		},
 	}
 
 	for _, tt := range tests {
@@ -316,6 +336,21 @@ func TestSplitMultiPartID(t *testing.T) {
 			name:     "empty input",
 			input:    "",
 			expected: []string{""},
+		},
+		{
+			name:     "bracket inside an undelimited part does not hide a separator",
+			input:    "sch[ema.table",
+			expected: []string{"sch[ema", "table"},
+		},
+		{
+			name:     "unterminated delimiter does not hide a separator",
+			input:    "[schema.table",
+			expected: []string{"[schema", "table"},
+		},
+		{
+			name:     "whitespace before a delimited part is allowed",
+			input:    " [my.table] ",
+			expected: []string{" [my.table] "},
 		},
 	}
 

--- a/quoter_test.go
+++ b/quoter_test.go
@@ -195,6 +195,87 @@ func TestQuoteMultiPartID(t *testing.T) {
 	}
 }
 
+func TestQuoteObjectName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple name",
+			input:    "table",
+			expected: "[table]",
+		},
+		{
+			name:     "qualified name",
+			input:    "dbo.table",
+			expected: "[dbo].[table]",
+		},
+		{
+			name:     "the maximum number of parts",
+			input:    "server.db.dbo.table",
+			expected: "[server].[db].[dbo].[table]",
+		},
+		{
+			name:     "an omitted qualifier is kept",
+			input:    "db..table",
+			expected: "[db]..[table]",
+		},
+		{
+			name:     "a separator inside a delimited part is not a separator",
+			input:    "[a.b.c.d.e]",
+			expected: "[a.b.c.d.e]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := quoteObjectName(tt.input)
+			assert.NoError(t, err, "quoteObjectName(%q)", tt.input)
+			assert.Equal(t, tt.expected, result, "quoteObjectName(%q)", tt.input)
+		})
+	}
+}
+
+func TestQuoteObjectNameRejectsNamesWithoutAnObject(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "empty", input: ""},
+		{name: "whitespace only", input: "   "},
+		{name: "qualifier without an object", input: "dbo."},
+		{name: "separator only", input: "."},
+		{name: "delimited but empty", input: "[]"},
+		{name: "trailing separator after a delimited part", input: "[my schema]."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := quoteObjectName(tt.input)
+			assert.ErrorContains(t, err, "does not name an object", "quoteObjectName(%q)", tt.input)
+		})
+	}
+}
+
+func TestQuoteObjectNameRejectsTooManyParts(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "five parts", input: "a.b.c.d.e"},
+		{name: "six parts", input: "a.b.c.d.e.f"},
+		{name: "five parts with delimited parts", input: "[a].[b].[c].[d].[e]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := quoteObjectName(tt.input)
+			assert.ErrorContains(t, err, "at most 4 are allowed", "quoteObjectName(%q)", tt.input)
+		})
+	}
+}
+
 func TestQuoteBulkOrder(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/quoter_test.go
+++ b/quoter_test.go
@@ -59,6 +59,285 @@ func TestTSQLQuoter_ID(t *testing.T) {
 	}
 }
 
+func TestQuoteMultiPartID(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple identifier",
+			input:    "tablename",
+			expected: "[tablename]",
+		},
+		{
+			name:     "schema qualified",
+			input:    "dbo.tablename",
+			expected: "[dbo].[tablename]",
+		},
+		{
+			name:     "database qualified",
+			input:    "mydb.dbo.tablename",
+			expected: "[mydb].[dbo].[tablename]",
+		},
+		{
+			name:     "server qualified",
+			input:    "srv.mydb.dbo.tablename",
+			expected: "[srv].[mydb].[dbo].[tablename]",
+		},
+		{
+			name:     "default schema is preserved",
+			input:    "mydb..tablename",
+			expected: "[mydb]..[tablename]",
+		},
+		{
+			name:     "already delimited",
+			input:    "[dbo].[tablename]",
+			expected: "[dbo].[tablename]",
+		},
+		{
+			name:     "partially delimited",
+			input:    "dbo.[table name]",
+			expected: "[dbo].[table name]",
+		},
+		{
+			name:     "delimited part containing a dot",
+			input:    "[dbo].[my.table]",
+			expected: "[dbo].[my.table]",
+		},
+		{
+			name:     "delimited part containing an escaped bracket",
+			input:    "[dbo].[weird]]name]",
+			expected: "[dbo].[weird]]name]",
+		},
+		{
+			name:     "double quoted parts",
+			input:    `"dbo"."table name"`,
+			expected: "[dbo].[table name]",
+		},
+		{
+			name:     "double quoted part containing an escaped quote",
+			input:    `"say ""hi"""`,
+			expected: `[say "hi"]`,
+		},
+		{
+			name:     "undelimited name needing delimiters",
+			input:    "table name",
+			expected: "[table name]",
+		},
+		{
+			name:     "undelimited name containing a bracket",
+			input:    "weird]name",
+			expected: "[weird]]name]",
+		},
+		{
+			name:     "reserved word",
+			input:    "Order",
+			expected: "[Order]",
+		},
+		{
+			name:     "temp table",
+			input:    "#temptable",
+			expected: "[#temptable]",
+		},
+		{
+			name:     "whitespace around parts",
+			input:    " dbo . tablename ",
+			expected: "[dbo].[tablename]",
+		},
+		{
+			name:     "empty name",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "trailing statement",
+			input:    "Orders; DROP TABLE dbo.Secrets;--",
+			expected: "[Orders; DROP TABLE dbo].[Secrets;--]",
+		},
+		{
+			name:     "trailing statement between delimited parts",
+			input:    "[Orders] SET FMTONLY OFF; PRINT 1;--[x]",
+			expected: "[[Orders]] SET FMTONLY OFF; PRINT 1;--[x]]]",
+		},
+		{
+			name:     "unterminated delimiter",
+			input:    "[Orders",
+			expected: "[[Orders]",
+		},
+		{
+			name:     "unterminated delimiter after a valid part",
+			input:    "dbo.[Orders",
+			expected: "[dbo].[[Orders]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := quoteMultiPartID(tt.input)
+			assert.Equal(t, tt.expected, result, "quoteMultiPartID(%q)", tt.input)
+		})
+	}
+}
+
+func TestQuoteBulkOrder(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple column",
+			input:    "id",
+			expected: "[id]",
+		},
+		{
+			name:     "column needing delimiters",
+			input:    "order id",
+			expected: "[order id]",
+		},
+		{
+			name:     "already delimited column",
+			input:    "[order id]",
+			expected: "[order id]",
+		},
+		{
+			name:     "ascending",
+			input:    "id ASC",
+			expected: "[id] ASC",
+		},
+		{
+			name:     "descending",
+			input:    "id DESC",
+			expected: "[id] DESC",
+		},
+		{
+			name:     "lower case direction is normalized",
+			input:    "id desc",
+			expected: "[id] DESC",
+		},
+		{
+			name:     "delimited column with a direction",
+			input:    "[order id] DESC",
+			expected: "[order id] DESC",
+		},
+		{
+			name:     "surrounding whitespace",
+			input:    "  id   ASC  ",
+			expected: "[id] ASC",
+		},
+		{
+			name:     "undelimited column ending in a direction keyword",
+			input:    "sort desc",
+			expected: "[sort] DESC",
+		},
+		{
+			name:     "delimited column ending in a direction keyword",
+			input:    "[sort desc]",
+			expected: "[sort desc]",
+		},
+		{
+			name:     "trailing statement",
+			input:    "id) WITH (TABLOCK); PRINT 1;--",
+			expected: "[id) WITH (TABLOCK); PRINT 1;--]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := quoteBulkOrder(tt.input)
+			assert.Equal(t, tt.expected, result, "quoteBulkOrder(%q)", tt.input)
+		})
+	}
+}
+
+func TestSplitMultiPartID(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "single part",
+			input:    "tablename",
+			expected: []string{"tablename"},
+		},
+		{
+			name:     "three parts",
+			input:    "mydb.dbo.tablename",
+			expected: []string{"mydb", "dbo", "tablename"},
+		},
+		{
+			name:     "empty middle part",
+			input:    "mydb..tablename",
+			expected: []string{"mydb", "", "tablename"},
+		},
+		{
+			name:     "dot inside brackets is not a separator",
+			input:    "[dbo].[my.table]",
+			expected: []string{"[dbo]", "[my.table]"},
+		},
+		{
+			name:     "dot inside double quotes is not a separator",
+			input:    `"my.table"`,
+			expected: []string{`"my.table"`},
+		},
+		{
+			name:     "escaped bracket does not end the part",
+			input:    "[my]].table].x",
+			expected: []string{"[my]].table]", "x"},
+		},
+		{
+			name:     "escaped quote does not end the part",
+			input:    `"my"".table".x`,
+			expected: []string{`"my"".table"`, "x"},
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: []string{""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, splitMultiPartID(tt.input), "splitMultiPartID(%q)", tt.input)
+		})
+	}
+}
+
+func TestUnquoteID(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		ok       bool
+	}{
+		{name: "brackets", input: "[tablename]", expected: "tablename", ok: true},
+		{name: "double quotes", input: `"tablename"`, expected: "tablename", ok: true},
+		{name: "escaped bracket", input: "[weird]]name]", expected: "weird]name", ok: true},
+		{name: "escaped quote", input: `"weird""name"`, expected: `weird"name`, ok: true},
+		{name: "empty delimited", input: "[]", expected: "", ok: true},
+		{name: "opening bracket inside brackets", input: "[a[b]", expected: "a[b", ok: true},
+		{name: "undelimited", input: "tablename", ok: false},
+		{name: "unterminated", input: "[tablename", ok: false},
+		{name: "mismatched delimiters", input: `[tablename"`, ok: false},
+		{name: "not a single identifier", input: "[a] PRINT 1 --[b]", ok: false},
+		{name: "too short", input: "[", ok: false},
+		{name: "empty", input: "", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, ok := unquoteID(tt.input)
+			assert.Equal(t, tt.ok, ok, "unquoteID(%q) ok", tt.input)
+			if tt.ok {
+				assert.Equal(t, tt.expected, result, "unquoteID(%q)", tt.input)
+			}
+		})
+	}
+}
+
 func TestTSQLQuoter_Value(t *testing.T) {
 	q := TSQLQuoter{}
 	


### PR DESCRIPTION
## What

Bulk copy builds two statements that embed the destination table name directly in the query text:

```go
query := fmt.Sprintf("INSERT BULK %s (%s) %s", b.tablename, col_defs.String(), with_part)
stmt, err = b.cn.prepareContext(ctx, fmt.Sprintf("select * from %s SET FMTONLY OFF", b.tablename))
```

Column names in that same `INSERT BULK` already go through `TSQLQuoter.ID`, but the table name does not, and `BulkOptions.Order` entries are joined in raw as well. So any destination whose name isn't a regular identifier fails, even though nothing in `CopyIn`'s docs says the caller has to delimit it, and the auto-quoting of column names in the same call suggests the opposite.

Found while poking at bulk copy with awkward table names.

## Repro

Against SQL Server 2022, before this change:

```
table name with a space, caller pre-quoted: dbo.[bulk load staging]  ok
same table, plain name: bulk load staging                            FAILED: Incorrect syntax near the keyword 'bulk'. (156)
reserved-word table name: Order                                      FAILED: Incorrect syntax near the keyword 'Order'. (156)
table name containing ]: weird]name                                  FAILED: Incorrect syntax near ']'. (102)
BulkOptions.Order entry needing delimiters: order id                 FAILED: Incorrect syntax near the keyword 'order'. (156)
```

All four pass after it. The first line already worked and still does.

A related wrinkle: because the name is spliced in verbatim, trailing text in it is parsed by the server as extra statements rather than being rejected as part of the object name. `TestBulkcopyDestinationIsASingleObject` covers that.

## How

Adds unexported multi-part identifier quoting to `quoter.go` and applies it in both statements:

- `splitTopLevel` splits on a separator, ignoring separators inside `[...]` or `"..."`. `splitMultiPartID` uses it for dots; `quoteBulkOrder` uses it for commas.
- `unquoteID` recognises a part the caller already delimited, requiring it to be a *single* well-formed identifier. A string like `[a] PRINT 1 --[b]` starts and ends with brackets but is not one identifier, so it gets escaped whole rather than passed through.
- `quoteIDPart` re-quotes each part with `TSQLQuoter.ID`. Empty parts stay empty so `db..table` keeps deferring to the default schema.
- `quoteBulkOrder` quotes each column in an `Order` entry and preserves an optional `ASC`/`DESC`.

This matches what .NET `SqlBulkCopy` does — it parses `DestinationTableName` and brackets each part before building the command:

```csharp
string[] parts = MultipartIdentifier.ParseMultipartIdentifier(DestinationTableName, ...);
updateBulkCommandText.AppendFormat("insert bulk {0} (", ADP.BuildMultiPartName(parts));
```

and its order hint is escaped the same way, via `SqlServerEscapeHelper.EscapeIdentifier` in `TryGetOrderHintText`.

## Compatibility

Table names: no behaviour change for any existing call shape. Each of these resolves to the same object before and after:

| passed to `CopyIn` | after |
| --- | --- |
| `Users` | `[Users]` |
| `dbo.Users` | `[dbo].[Users]` |
| `[dbo].[Users]` | `[dbo].[Users]` |
| `"dbo"."Users"` | `[dbo].[Users]` |
| `mydb.dbo.Users` | `[mydb].[dbo].[Users]` |
| `mydb..Users` | `[mydb]..[Users]` |
| `#temp` / `##globaltemp` | `[#temp]` / `[##globaltemp]` |

Callers who already delimited the name are not double-quoted, because `unquoteID` unwraps a well-formed part before re-quoting it.

`Order` entries have one behaviour change: a column name whose last word is literally `asc` or `desc` now has to be delimited (`[sort desc]`) to be told apart from a sort direction. Undelimited, `sort desc` is read as column `sort` descending. Same for a column name containing a comma, which now has to be delimited (`[order, id]`). Both are documented on `CopyIn` and in `doc/how-to-perform-bulk-imports.md`.

Entries naming several comma-separated columns keep working, since the entry is split on top-level commas before quoting — `"col1 ASC, col2 DESC"` becomes `[col1] ASC,[col2] DESC`.

## Testing

- `TestQuoteMultiPartID`, `TestQuoteBulkOrder`, `TestSplitMultiPartID`, `TestUnquoteID` — table-driven unit tests, no server needed. All new functions are at 100% statement coverage; package total is 81.3%.
- `TestBulkcopyIdentifierQuoting` — integration test over 11 destination shapes: plain, space, `]`, reserved word, caller-delimited, schema-qualified, delimited and qualified, default schema, and three `Order` variants including several columns in one entry.
- `TestBulkcopyDestinationIsASingleObject` — integration test asserting a destination name is only ever treated as an object name.
- Full suite green against SQL Server 2022 in Docker. The two `aecmk/localcert` failures are pre-existing locally (cert provisioning), and reproduce on `main` with these changes stashed.
