### PR TITLE
fix: validate PRELOGIN encryption response length

### DIFF
--- a/tds.go
+++ b/tds.go
@@ -1027,6 +1027,9 @@ func interpretPreloginResponse(p msdsn.Config, fe *featureExtFedAuth, fields map
 	if !ok {
 		return 0, fmt.Errorf("encrypt negotiation failed")
 	}
+	if len(encryptBytes) != 1 {
+		return 0, fmt.Errorf("encrypt negotiation response length should be 1: is %d", len(encryptBytes))
+	}
 	encrypt = encryptBytes[0]
 	if p.Encryption == msdsn.EncryptionRequired && (encrypt == encryptNotSup || encrypt == encryptOff) {
 		return 0, fmt.Errorf("server does not support encryption")

--- a/tds_prelogin_fuzz_test.go
+++ b/tds_prelogin_fuzz_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 	"io"
 	"testing"
+
+	"github.com/microsoft/go-mssqldb/msdsn"
 )
 
 // preloginTransport serves a fixed byte stream as the server side of a TDS
@@ -38,6 +40,8 @@ func FuzzReadPrelogin(f *testing.F) {
 		{preloginTERMINATOR},
 		// encryption option followed by terminator
 		{preloginENCRYPTION, 0, 6, 0, 1, preloginTERMINATOR, encryptNotSup},
+		// zero-length encryption option followed by terminator and padding
+		{preloginENCRYPTION, 0, 6, 0, 0, preloginTERMINATOR, 0},
 		// version, encryption, instopt, threadid, mars
 		{
 			0, 0, 26, 0, 6,
@@ -85,5 +89,6 @@ func FuzzReadPrelogin(f *testing.F) {
 				t.Fatalf("prelogin option %d returned %d bytes from a %d byte response", token, len(value), len(body))
 			}
 		}
+		_, _ = interpretPreloginResponse(msdsn.Config{}, &featureExtFedAuth{FedAuthLibrary: FedAuthLibraryReserved}, fields)
 	})
 }

--- a/tds_unit_test.go
+++ b/tds_unit_test.go
@@ -348,6 +348,50 @@ func TestBrowserDataType(t *testing.T) {
 	assert.Equal(t, "1433", data["INSTANCE1"]["tcp"], "BrowserData[INSTANCE1][tcp]")
 }
 
+func TestInterpretPreloginResponseEncryptionLength(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		fields    map[uint8][]byte
+		expected  byte
+		expectErr string
+	}{
+		{
+			name:     "valid encryption option",
+			fields:   map[uint8][]byte{preloginENCRYPTION: {encryptNotSup}},
+			expected: encryptNotSup,
+		},
+		{
+			name:      "missing encryption option",
+			fields:    map[uint8][]byte{},
+			expectErr: "encrypt negotiation failed",
+		},
+		{
+			name:      "empty encryption option",
+			fields:    map[uint8][]byte{preloginENCRYPTION: {}},
+			expectErr: "encrypt negotiation response length should be 1: is 0",
+		},
+		{
+			name:      "oversized encryption option",
+			fields:    map[uint8][]byte{preloginENCRYPTION: {encryptOn, encryptOff}},
+			expectErr: "encrypt negotiation response length should be 1: is 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encrypt, err := interpretPreloginResponse(msdsn.Config{}, &featureExtFedAuth{FedAuthLibrary: FedAuthLibraryReserved}, tt.fields)
+			if tt.expectErr != "" {
+				assert.EqualError(t, err, tt.expectErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, encrypt)
+		})
+	}
+}
+
 // TestReadPreloginOptionData covers bounds checking of the offset/length pair a
 // server supplies for each PRELOGIN option. The offset+length cases were found
 // by FuzzReadPrelogin: computing the sum in uint16 let it wrap past 65535, so


### PR DESCRIPTION
## Summary

- reject PRELOGIN encryption responses whose payload length is not exactly one byte
- add regression coverage for missing, empty, oversized, and valid encryption options
- extend `FuzzReadPrelogin` through `interpretPreloginResponse` so parsed server responses exercise their consumer

## Security impact

A malicious server could send a zero-length PRELOGIN encryption option. `readPrelogin` returned the option as an empty slice, and `interpretPreloginResponse` indexed its first byte without validating the length, causing an unrecovered panic before authentication and, for non-strict connections, before TLS negotiation.

Malformed encryption options now return an error instead of terminating the client process.

## Testing

- `go test . -run '^(TestInterpretPreloginResponseEncryptionLength|FuzzReadPrelogin)$'`
- `go test . -run '^$' -fuzz '^FuzzReadPrelogin$' -fuzztime 10s` (19,005 executions)
- `go test ./msdsn ./internal/... ./integratedauth/... ./azuread`
- `go build .`