### PR TITLE
fix: validate LOGINACK token size before indexing (fixes #427)

### DIFF
--- a/testdata/fuzz/FuzzFeatureExtAckAndLoginAck/loginack_size_zero_crash
+++ b/testdata/fuzz/FuzzFeatureExtAckAndLoginAck/loginack_size_zero_crash
@@ -1,0 +1,4 @@
+go test fuzz v1
+byte('Y')
+[]byte("\x00\x00")
+byte('\x03')

--- a/token.go
+++ b/token.go
@@ -589,10 +589,19 @@ func parseLoginAck(r *tdsBuffer) loginAckStruct {
 	size := r.uint16()
 	buf := make([]byte, size)
 	r.ReadFull(buf)
+	sz := int(size)
+	// Minimum fixed layout: Interface(1) + TDSVersion(4) + prognamelen(1) + ProgVer(4) = 10 bytes.
+	if sz < 1+4+1+4 {
+		badStreamPanicf("LOGINACK token too short: %d", sz)
+	}
 	var res loginAckStruct
 	res.Interface = buf[0]
 	res.TDSVersion = binary.BigEndian.Uint32(buf[1:])
-	prognamelen := buf[1+4]
+	prognamelen := int(buf[1+4])
+	// Ensure the variable-length program name plus the trailing ProgVer fit within the token.
+	if 1+4+1+prognamelen*2+4 > sz {
+		badStreamPanicf("LOGINACK program name length %d exceeds token size %d", prognamelen, sz)
+	}
 	var err error
 	if res.ProgName, err = ucs22str(buf[1+4+1 : 1+4+1+prognamelen*2]); err != nil {
 		badStreamPanic(err)

--- a/token.go
+++ b/token.go
@@ -591,10 +591,19 @@ func parseLoginAck(r *tdsBuffer) loginAckStruct {
 	size := r.uint16()
 	buf := make([]byte, size)
 	r.ReadFull(buf)
+	sz := int(size)
+	// Minimum fixed layout: Interface(1) + TDSVersion(4) + prognamelen(1) + ProgVer(4) = 10 bytes.
+	if sz < 1+4+1+4 {
+		badStreamPanicf("LOGINACK token too short: %d", sz)
+	}
 	var res loginAckStruct
 	res.Interface = buf[0]
 	res.TDSVersion = binary.BigEndian.Uint32(buf[1:])
-	prognamelen := buf[1+4]
+	prognamelen := int(buf[1+4])
+	// Ensure the variable-length program name plus the trailing ProgVer fit within the token.
+	if 1+4+1+prognamelen*2+4 > sz {
+		badStreamPanicf("LOGINACK program name length %d exceeds token size %d", prognamelen, sz)
+	}
 	var err error
 	if res.ProgName, err = ucs22str(buf[1+4+1 : 1+4+1+prognamelen*2]); err != nil {
 		badStreamPanic(err)

--- a/token_loginack_regression_test.go
+++ b/token_loginack_regression_test.go
@@ -1,0 +1,66 @@
+package mssql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseLoginAck_MalformedSizePanics is a regression test for issue #427:
+// parseLoginAck read a uint16 size, allocated a buffer, and then unconditionally
+// indexed into it (buf[0], buf[1:5], buf[5], buf[size-4:], and a slice sized by
+// an embedded prog-name length). A short or inconsistent token drove an index /
+// slice out-of-range runtime panic, which processSingleResponse's recover() does
+// not catch, crashing the driver. The parser must now reject such tokens with a
+// recoverable StreamError (badStreamPanic) instead.
+func TestParseLoginAck_MalformedSizePanics(t *testing.T) {
+	// buildShort frames a LOGINACK body of the given size with `size` zero bytes
+	// behind the uint16 length prefix, so ReadFull succeeds but the fixed layout
+	// (>=10 bytes) is not satisfied.
+	buildShort := func(size int) []byte {
+		stream := []byte{byte(size), byte(size >> 8)}
+		stream = append(stream, make([]byte, size)...)
+		return stream
+	}
+
+	cases := map[string]struct {
+		stream  []byte
+		wantSub string
+	}{
+		// size=0: buf[0] previously panicked with index out of range.
+		"size zero": {stream: buildShort(0), wantSub: "too short"},
+		// size=3: buf[1:5] (TDS version) previously sliced out of range.
+		"size three": {stream: buildShort(3), wantSub: "too short"},
+		// size=5: buf[5] (prognamelen) previously indexed out of range.
+		"size five": {stream: buildShort(5), wantSub: "too short"},
+		// size=9: one byte short of the 10-byte minimum fixed layout.
+		"size nine": {stream: buildShort(9), wantSub: "too short"},
+		// size=10 but prognamelen=0xFF: the prog name slice (1+4+1 .. +255*2)
+		// previously ran past the end of buf; byte arithmetic on prognamelen*2
+		// could also overflow. int arithmetic now rejects it.
+		"progname overrun": {
+			// interface(1)+TDSVersion(4)+prognamelen(0xFF)+4 trailing bytes = 10.
+			stream:  []byte{0x0A, 0x00, 0x01, 0, 0, 0, 0, 0xFF, 0, 0, 0, 0},
+			wantSub: "exceeds token size",
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			err := recoverErr(func() { parseLoginAck(bufFromBytes(tc.stream)) })
+			if err == nil {
+				t.Fatalf("expected a stream error, got none")
+			}
+			assert.Contains(t, err.Error(), tc.wantSub)
+		})
+	}
+}
+
+// TestParseLoginAck_WellFormed confirms the guard does not reject a valid
+// LOGINACK token.
+func TestParseLoginAck_WellFormed(t *testing.T) {
+	body := loginAckBody("go-mssqldb", -1)
+	ack := parseLoginAck(bufFromBytes(body))
+	assert.Equal(t, "go-mssqldb", ack.ProgName)
+}


### PR DESCRIPTION
## Summary

Fixes #427 (found by fuzzing, umbrella #418). Stacks on PR #426; base branch is `saurabh500-fuzz-layer3-complex-tokens`.

`parseLoginAck` (token.go) read a server-controlled `uint16` size, allocated a buffer of that size, `ReadFull`'d it, then **unconditionally** indexed into it:

- `buf[0]` — panics when `size == 0`
- `binary.BigEndian.Uint32(buf[1:])` — needs `size >= 5`
- `buf[1+4]` (prognamelen) — needs `size >= 6`
- `ucs22str(buf[1+4+1 : 1+4+1+prognamelen*2])` — needs `size >= 6 + prognamelen*2`; `prognamelen*2` was byte arithmetic that could overflow
- `buf[size-4:]` — underflows when `size < 4`

These produce a `runtime.Error` (index/slice out of range), **not** a recoverable `StreamError`, so `processSingleResponse`'s `recover()` does not catch them and the driver crashes.

## Fix

Validate before indexing, using `int` arithmetic to avoid byte/uint16 overflow, and raise `badStreamPanicf` (a recoverable `StreamError`) on violation:

- Reject tokens shorter than the 10-byte fixed layout (Interface(1) + TDSVersion(4) + prognamelen(1) + ProgVer(4)) right after `ReadFull`.
- After reading `prognamelen` as an `int`, reject tokens where `1+4+1+prognamelen*2+4 > size`.

The `>= 10` guard also keeps `buf[size-4:]` safe.

## Tests

- `TestParseLoginAck_MalformedSizePanics` / `TestParseLoginAck_WellFormed`: unit regression covering `size = 0, 3, 5, 9`, a prognamelen-overrun case, and a well-formed token, asserting a recoverable `StreamError` (not a runtime panic).
- Re-added the minimized crasher as a fuzz regression seed under `testdata/fuzz/FuzzFeatureExtAckAndLoginAck/` (selector `'Y'` → parseLoginAck path, LOGINACK body `uint16` size `0x0000`, frag `0x03`).

## Validation

- `go build ./...`, `go vet .`, gofmt-clean for touched files ✅
- `go test -run 'Fuzz|Test' .` → PASS ✅
- `go test . -run=^$ -fuzz=^FuzzFeatureExtAckAndLoginAck$ -fuzztime=180s -parallel=4` → PASS, no crash / no worker OOM ✅