### PR TITLE
ci: add scheduled fuzz workflow (layer 4/4)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,66 @@
+name: fuzz
+
+on:
+  schedule:
+    - cron: '0 7 * * *'   # nightly 07:00 UTC
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: 'Duration per fuzz target (Go duration, e.g. 180s, 10m)'
+        required: false
+        default: '180s'
+
+permissions: {}
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - '.'
+          - './batch'
+          - './integratedauth/ntlm'
+          - './internal/querytext'
+          - './msdsn'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25.7'
+      - name: Run fuzz targets
+        shell: bash
+        env:
+          FUZZTIME: ${{ github.event.inputs.fuzztime || '180s' }}
+          PKG: ${{ matrix.package }}
+        run: |
+          go version
+          set -euo pipefail
+          mapfile -t TARGETS < <(go test "$PKG" -list '^Fuzz' 2>/dev/null | grep '^Fuzz' || true)
+          if [ ${#TARGETS[@]} -eq 0 ]; then
+            echo "No fuzz targets in $PKG; skipping."
+            exit 0
+          fi
+          echo "Targets in $PKG: ${TARGETS[*]}"
+          rc=0
+          for t in "${TARGETS[@]}"; do
+            echo "::group::fuzz $PKG $t ($FUZZTIME)"
+            if ! go test "$PKG" -run '^$' -fuzz "^${t}$" -fuzztime "$FUZZTIME" -parallel 4; then
+              echo "::error::fuzz target $t in $PKG failed"
+              rc=1
+            fi
+            echo "::endgroup::"
+          done
+          exit $rc
+      - name: Upload crashers
+        if: failure()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: fuzz-crashers-${{ strategy.job-index }}
+          path: '**/testdata/fuzz/**'
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Final layer (4/4) of the proactive TDS parser fuzz-hardening stack tracked by #418.

This PR adds `.github/workflows/fuzz.yml`, a scheduled (nightly 07:00 UTC) + manually-dispatchable workflow that runs **every** native Go fuzz target in the repo and uploads any crashers as artifacts. These are pure TDS/parser fuzz targets — no SQL Server instance is required.

## What it does

- Runs on a nightly cron and via `workflow_dispatch` (with a configurable `fuzztime` input, default `180s`).
- Uses a per-package matrix (`.`, `./batch`, `./integratedauth/ntlm`, `./internal/querytext`, `./msdsn`) that covers all 18 fuzz targets in the repo.
- Discovers targets dynamically via `go test <pkg> -list '^Fuzz'`, then fuzzes each one.
- Uses `-parallel 4`: the TDS value decoders eagerly allocate up to a large per-length cap (bounded by #421 but still large), so the default 32 workers would OOM a 7GB CI runner. The per-package matrix keeps memory and wall-time bounded.
- Uploads any `testdata/fuzz/**` crashers as artifacts on failure.
- Follows the repo's pinned-SHA action + minimal `permissions` conventions from `pr-validation.yml`.

## The fuzz-hardening stack

This is the final layer of a dependent stack that proactively fuzzed the TDS parser and fixed the bugs it uncovered:

- **#420** — OOM from unbounded allocations on attacker-controlled lengths
- **#422** — row-value slice out-of-bounds read
- **#423** — temporal-decoder integer underflow
- **#427** — LOGINACK token index out-of-bounds

Stacks on PR #428 (`saurabh500-fix-427-loginack`).

Refs #418