### PR TITLE
perf: fast path for pure ASCII decoding in CharsetToUTF8

### DIFF
--- a/internal/cp/ascii_scan.go
+++ b/internal/cp/ascii_scan.go
@@ -1,0 +1,35 @@
+//go:build !386 && !arm && !mips && !mipsle
+
+package cp
+
+import "unsafe"
+
+// asciiMask64 has the high bit set in each byte. When AND-ed with an 8 byte
+// chunk it reports whether any byte in that chunk has its high bit set, i.e.
+// is >= 0x80.
+const asciiMask64 uint64 = 0x8080808080808080
+
+// isASCII reports whether s contains only bytes in the ASCII range (0x00-0x7F).
+// It scans the input in 8 byte chunks, the same pattern used by ucs22str in the
+// parent package.
+func isASCII(s []byte) bool {
+	// how many 8 byte chunks are in the input buffer
+	nlen8 := len(s) & 0xFFFFFFF8
+	for i := 0; i < nlen8; i += 8 {
+		// dereference directly into the array as a uint64
+		ui64 := *(*uint64)(unsafe.Pointer(&s[i]))
+
+		// mask the entire 64 bit region and check for any byte with the high bit set
+		if ui64&asciiMask64 > 0 {
+			return false
+		}
+	}
+
+	// deal with the at most 7 remaining bytes
+	for i := nlen8; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cp/ascii_scan.go
+++ b/internal/cp/ascii_scan.go
@@ -2,7 +2,7 @@
 
 package cp
 
-import "unsafe"
+import "encoding/binary"
 
 // asciiMask64 has the high bit set in each byte. When AND-ed with an 8 byte
 // chunk it reports whether any byte in that chunk has its high bit set, i.e.
@@ -16,8 +16,8 @@ func isASCII(s []byte) bool {
 	// how many 8 byte chunks are in the input buffer
 	nlen8 := len(s) &^ 7
 	for i := 0; i < nlen8; i += 8 {
-		// dereference directly into the array as a uint64
-		ui64 := *(*uint64)(unsafe.Pointer(&s[i]))
+		// read the 8 byte chunk with an alignment-safe load
+		ui64 := binary.NativeEndian.Uint64(s[i : i+8])
 
 		// mask the entire 64 bit region and check for any byte with the high bit set
 		if ui64&asciiMask64 > 0 {

--- a/internal/cp/ascii_scan.go
+++ b/internal/cp/ascii_scan.go
@@ -14,7 +14,7 @@ const asciiMask64 uint64 = 0x8080808080808080
 // parent package.
 func isASCII(s []byte) bool {
 	// how many 8 byte chunks are in the input buffer
-	nlen8 := len(s) & 0xFFFFFFF8
+	nlen8 := len(s) &^ 7
 	for i := 0; i < nlen8; i += 8 {
 		// dereference directly into the array as a uint64
 		ui64 := *(*uint64)(unsafe.Pointer(&s[i]))

--- a/internal/cp/ascii_scan_32bit.go
+++ b/internal/cp/ascii_scan_32bit.go
@@ -1,0 +1,13 @@
+//go:build arm || 386 || mips || mipsle
+
+package cp
+
+// isASCII reports whether s contains only bytes in the ASCII range (0x00-0x7F).
+func isASCII(s []byte) bool {
+	for _, b := range s {
+		if b >= 0x80 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cp/charset.go
+++ b/internal/cp/charset.go
@@ -96,6 +96,13 @@ func CharsetToUTF8(col Collation, s []byte) string {
 		return string(s)
 	}
 
+	// Fast path: every code page maps the ASCII range (0x00-0x7F) to the
+	// identical Unicode code points, so a pure ASCII input can be returned
+	// without per-character decoding.
+	if isASCII(s) {
+		return string(s)
+	}
+
 	buf := strings.Builder{}
 	buf.Grow(len(s))
 	for i := 0; i < len(s); i++ {

--- a/internal/cp/charset_benchmark_test.go
+++ b/internal/cp/charset_benchmark_test.go
@@ -1,0 +1,37 @@
+package cp
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Benchmarks for CharsetToUTF8, the per-row varchar/char decode hot path.
+
+var charSetToUTF8Out string
+
+func BenchmarkCharsetToUTF8ASCIIShort(b *testing.B) {
+	c := Collation{SortId: 50} // cp1252
+	s := []byte("Hello, World!")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		charSetToUTF8Out = CharsetToUTF8(c, s)
+	}
+}
+
+func BenchmarkCharsetToUTF8ASCIILong(b *testing.B) {
+	c := Collation{SortId: 50}                      // cp1252
+	s := bytes.Repeat([]byte("Hello, World! "), 10) // 140 bytes
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		charSetToUTF8Out = CharsetToUTF8(c, s)
+	}
+}
+
+func BenchmarkCharsetToUTF8Extended(b *testing.B) {
+	c := Collation{SortId: 50}       // cp1252
+	s := []byte{'c', 'a', 'f', 0xe9} // café encoded in cp1252
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		charSetToUTF8Out = CharsetToUTF8(c, s)
+	}
+}

--- a/internal/cp/cp_test.go
+++ b/internal/cp/cp_test.go
@@ -248,6 +248,45 @@ func TestCharsetToUTF8_IncompleteDoubleByte(t *testing.T) {
 	assert.GreaterOrEqual(t, len(result), 2, "Expected at least 2 characters, got %q", result)
 }
 
+func TestCharsetToUTF8_ASCIIFastPath(t *testing.T) {
+	t.Parallel()
+	// Pure ASCII inputs must pass through unchanged, including lengths that
+	// straddle the 8 byte chunked scan boundaries of the ASCII fast path.
+	lengths := []int{0, 1, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128}
+	for _, n := range lengths {
+		s := make([]byte, n)
+		for i := range s {
+			s[i] = byte('a' + i%26)
+		}
+		expected := string(s)
+		for _, sortID := range []uint8{50, 192} { // cp1252 and cp932
+			c := Collation{SortId: sortID}
+			if got := CharsetToUTF8(c, s); got != expected {
+				t.Errorf("CharsetToUTF8(sortId %d, %d ascii bytes) = %q, want %q", sortID, n, got, expected)
+			}
+		}
+	}
+}
+
+func TestCharsetToUTF8_NonASCIIAtChunkBoundary(t *testing.T) {
+	t.Parallel()
+	// A non-ASCII byte placed at an 8 byte chunk boundary must still be
+	// detected by the ASCII fast path scan and decoded by the slow path.
+	c := Collation{SortId: 50} // cp1252
+	positions := []int{0, 7, 8, 15, 16, 31}
+	for _, pos := range positions {
+		s := make([]byte, 32)
+		for i := range s {
+			s[i] = 'a'
+		}
+		s[pos] = 0x80 // cp1252 -> €
+		want := string(s[:pos]) + "€" + string(s[pos+1:])
+		if got := CharsetToUTF8(c, s); got != want {
+			t.Errorf("pos %d: got %q, want %q", pos, got, want)
+		}
+	}
+}
+
 // Test each code page getter returns a valid charset map
 func TestGetCodePages(t *testing.T) {
 	t.Parallel()
@@ -280,11 +319,12 @@ func TestGetCodePages(t *testing.T) {
 			if cm == nil {
 				t.Fatal("getter returned nil")
 			}
-			// Verify ASCII portion (0x00-0x7F) maps correctly
+			// The ASCII range (0x00-0x7F) must map to the identical code points
+			// in every code page; this invariant is required by the CharsetToUTF8
+			// ASCII fast path.
 			for i := 0; i < 128; i++ {
-				if cm.sb[i] != rune(i) && cm.sb[i] != -1 {
-					// Some code pages may have variations even in ASCII range
-					// but most should match
+				if cm.sb[i] != rune(i) {
+					t.Errorf("%s: byte 0x%02x maps to U+%04X, want U+%02X", cp.name, i, cm.sb[i], i)
 				}
 			}
 			// Verify at least some extended chars are defined (0x80-0xFF)


### PR DESCRIPTION
**Summary**
Adds an ASCII fast path to `CharsetToUTF8` in `internal/cp`. Every code page maps bytes 0x00-0x7F to identical Unicode code points, so pure-ASCII input can be returned as `string(s)` without per-character decoding. Detection uses an 8-byte chunked masked scan on 64-bit platforms (the same pattern as the existing `ucs22str` fast path) with a portable byte-scan fallback for 32-bit architectures. Behavior is unchanged for non-ASCII, DBCS (CP932 etc.), nil-charset, and invalid input.

**Benchmark results** (median of 8 runs, identical methodology before/after)
| Benchmark | Before | After | Δ |
|---|---|---|---|
| CharsetToUTF8ASCIIShort (13 B) | 61.01 ns/op | 20.90 ns/op | **-65.7%** |
| CharsetToUTF8ASCIILong (140 B) | 395.60 ns/op | 54.02 ns/op | **-86.3%** |
| CharsetToUTF8Extended (4 B, one non-ASCII) | 24.59 ns/op | 26.87 ns/op | +9.3% (+2.3 ns) |
| BenchmarkReadByteLenType_VarChar (CI-tracked) | 96.08 ns/op | 49.55 ns/op | **-48.4%** |

Allocations are unchanged in every case.

**Testing**
- New `TestCharsetToUTF8_ASCIIFastPath` (ASCII identity across chunk-boundary lengths, cp1252 + cp932)
- New `TestCharsetToUTF8_NonASCIIAtChunkBoundary` (non-ASCII at 8-byte chunk edges routed to the slow path)
- `TestGetCodePages` strengthened to assert ASCII-identity for all 16 code pages (was a no-op)
- `go test ./internal/cp`, DB-free root unit tests on the varchar read path, `go vet ./internal/cp .`, `git diff --check` - all pass
- 32-bit fallback compiled for `386`/`arm`/`mips`/`mipsle`

**Known trade-offs/limitations**
- ~2 ns cost on very short (<8 B) non-ASCII values from the pre-scan before fallback; amortizes for longer values and is identical in nature to the existing `ucs22str` fast path.
- The 32-bit fallback is a simple byte scan and is not exercised by CI (amd64 only), matching the existing `ucs22str_32bit.go` precedent.