### PR TITLE
ci: run appveyor on SQL Server 2025 and drop the duplicate job

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,10 @@ version: 1.0.{build}
 # SQL Server 2022 and 2025 are only available on the Visual Studio 2026 image.
 image: Visual Studio 2026
 
+# Every push to a branch with an open PR otherwise queues two builds, and the
+# project runs one build at a time. Only the PR build is a required check.
+skip_branch_with_pr: true
+
 clone_folder: c:\gopath\src\github.com\microsoft\go-mssqldb
 
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.0.{build}
 
-image:
-  - Visual Studio 2015
+# SQL Server 2022 and 2025 are only available on the Visual Studio 2026 image.
+image: Visual Studio 2026
 
 clone_folder: c:\gopath\src\github.com\microsoft\go-mssqldb
 
@@ -12,30 +12,32 @@ environment:
   SQLPASSWORD: Password12!
   DATABASE: test
   GOVERSION: 125
+  SQLINSTANCE: SQL2025
   COLUMNENCRYPTION:
-  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
   TAGS:
   matrix:
-    - SQLINSTANCE: SQL2017
+      # Default protocol negotiation, 64bit, SQL auth
     - GOVERSION: 125
-      SQLINSTANCE: SQL2017
+      # Always Encrypted
     - GOVERSION: 125
-      SQLINSTANCE: SQL2019
       COLUMNENCRYPTION: 1
       # Cover 32bit and named pipes protocol
     - GOVERSION: 125-x86
-      SQLINSTANCE: SQL2017
       GOARCH: 386
       PROTOCOL: np
       TAGS: -tags np
       # Cover SSPI and lpc protocol
     - GOVERSION: 125
-      SQLINSTANCE: SQL2019
       PROTOCOL: lpc
       TAGS: -tags sm
       SQLUSER:
       SQLPASSWORD:
+
+init:
+  # AppVeyor does not document instance names past SQL2019; print what is installed.
+  - ps: Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -ErrorAction SilentlyContinue | Out-String
+
 install:
   - set GOROOT=c:\go%GOVERSION%
   - set PATH=%GOPATH%\bin;%GOROOT%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,17 +17,17 @@ environment:
 
   TAGS:
   matrix:
-      # Default protocol negotiation, 64bit, SQL auth
+    # Default protocol negotiation, 64bit, SQL auth
     - GOVERSION: 125
-      # Always Encrypted
+    # Always Encrypted
     - GOVERSION: 125
       COLUMNENCRYPTION: 1
-      # Cover 32bit and named pipes protocol
+    # 32bit and named pipes protocol
     - GOVERSION: 125-x86
       GOARCH: 386
       PROTOCOL: np
       TAGS: -tags np
-      # Cover SSPI and lpc protocol
+    # SSPI and lpc protocol
     - GOVERSION: 125
       PROTOCOL: lpc
       TAGS: -tags sm
@@ -35,8 +35,12 @@ environment:
       SQLPASSWORD:
 
 init:
-  # AppVeyor does not document instance names past SQL2019; print what is installed.
-  - ps: Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL' -ErrorAction SilentlyContinue | Out-String
+  # AppVeyor does not document instance names past SQL2019; list what is installed.
+  - ps: |
+      $key = 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL'
+      (Get-ItemProperty $key -ErrorAction SilentlyContinue).PSObject.Properties |
+        Where-Object Name -notlike 'PS*' |
+        ForEach-Object { "instance: $($_.Name) -> $($_.Value)" }
 
 install:
   - set GOROOT=c:\go%GOVERSION%


### PR DESCRIPTION
Fixes #435

## Problem

`appveyor.yml` had three issues.

**A duplicate job.** The matrix's first entry inherited `GOVERSION: 125` from the top-level `environment`, making it identical to the second entry. Confirmed on [build 1886](https://ci.appveyor.com/project/kburtram/go-mssqldb/builds/54558697) — both jobs reported `go1.25.7 windows/amd64` against SQL `14.0.1000.169`, same protocol, same tags. AppVeyor runs jobs serially on our plan, so that's roughly 15 minutes on every build for a job we already ran.

**Dead config.** `image: Visual Studio 2015` never took effect, because `APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019` in `environment` overrode it. Two sources of truth for one setting, and the one you read first was wrong.

**Unpatched RTM instances.** The SQL instances baked into the `Visual Studio 2019` worker image are `14.0.1000.169` (SQL 2017 RTM, 2017-09-29) and `15.0.2000.5` (SQL 2019 RTM, 2019-11-04). No CU, no GDR on either. The `COLUMNENCRYPTION=1` job was exercising Always Encrypted against 2019 RTM, and a lot of AE behavior changed in CUs.

## Solution

Move to SQL Server 2025 on the `Visual Studio 2026` image, and collapse the matrix.

Version choice was constrained. From AppVeyor's [image software table](https://github.com/appveyor/website/blob/master/src/docs/windows-images-software.md):

| SQL version | VS2015 | VS2017 | VS2019 | VS2022 | VS2026 |
|---|---|---|---|---|---|
| 2017 Developer | yes | yes | yes | yes | no |
| 2019 Developer | no | no | yes | yes | no |
| 2022 Developer | no | no | no | no | yes |
| 2025 Enterprise Developer | no | no | no | no | yes |

SQL 2022 and 2025 exist only on `Visual Studio 2026`, and that image carries neither 2017 nor 2019 — so this is a swap, not an addition.

Dropping Windows-side 2017/2019 coverage is deliberate. `pr-validation.yml` already runs `mcr.microsoft.com/mssql/server:{2017,2019,2022,2025}-latest`, fully patched. What AppVeyor uniquely covers is named pipes, shared memory/LPC, SSPI integrated auth, and 32-bit, and none of those are SQL-version-sensitive.

`C:\go125` and `C:\go125-x86` are both present on the VS2026 image, so the `GOROOT=c:\go%GOVERSION%` scheme is unaffected.

## Changes

| Change | Reason |
|---|---|
| `image: Visual Studio 2026`, removed `APPVEYOR_BUILD_WORKER_IMAGE` | One source of truth; required for SQL 2025 |
| `SQLINSTANCE: SQL2025` hoisted to top-level `environment` | Same for every job now, so it doesn't belong in the matrix |
| Matrix 5 entries to 4 | Removed the duplicate; every remaining entry is a distinct dimension |
| Added `init:` step dumping installed SQL instance names | AppVeyor's services docs stop at SQL 2019 and don't publish the 2022/2025 instance name |

Matrix after the change, all four distinct:

| Job | Coverage |
|---|---|
| `GOVERSION=125` | Default protocol negotiation, 64-bit, SQL auth |
| `GOVERSION=125, COLUMNENCRYPTION=1` | Always Encrypted |
| `GOVERSION=125-x86, GOARCH=386, PROTOCOL=np` | 32-bit + named pipes |
| `GOVERSION=125, PROTOCOL=lpc, TAGS=-tags sm` | Shared memory + SSPI (empty `SQLUSER`/`SQLPASSWORD`) |

## Testing

Parsed the file with PyYAML and expanded the matrix against the top-level defaults to confirm four jobs with the intended variables and no accidental duplicates.

The rest can only be verified by a real build, which is what the AppVeyor check on this PR is for. Two things to watch in its log:

1. The `init` step's instance dump. `SQL2025` follows AppVeyor's naming convention but is not documented — if the name differs, the dump tells us what to use.
2. `before_test` already runs `sqlcmd ... Select @@version`, so the log will show the actual SQL 2025 build number and confirm whether it is patched.

If the instance name is wrong the build fails loudly at `Start-Service` and we correct it from the dump.

## Related Issues

Fixes #435
