### PR TITLE
ci: unblock and harden the benchmark job

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -101,6 +101,24 @@ jobs:
           if ! NAMES=$(docker ps -a --format '{{.Names}}'); then
             echo "::warning::docker ps failed; cannot determine whether the sqlserver container exists"
           elif echo "$NAMES" | grep -Fxq sqlserver; then
+            # A memory kill reaches the tests as connection resets and unexpected
+            # EOF, which reads as a driver bug. Say so before dumping the logs.
+            if STATE=$(docker inspect sqlserver --format '{{.State.OOMKilled}} {{.State.ExitCode}} {{.State.Status}} {{.HostConfig.Memory}}'); then
+              read -r OOM CODE STATUS LIMIT <<< "$STATE"
+              if [ "${LIMIT:-0}" -gt 0 ] 2>/dev/null; then
+                LIMIT="$((LIMIT / 1024 / 1024)) MiB"
+              else
+                LIMIT="unset"
+              fi
+              echo "sqlserver: oom-killed=$OOM exit=$CODE status=$STATUS memory-limit=$LIMIT"
+              if [ "$OOM" = "true" ]; then
+                echo "::error::SQL Server was OOM-killed. Connection errors above are a symptom of the container memory limit, not of the driver. Raise -m and MSSQL_MEMORY_LIMIT_MB together, keeping 10-20% headroom between them."
+              elif [ "$CODE" = "137" ]; then
+                echo "::warning::SQL Server exited 137 (SIGKILL) without an OOM flag; memory pressure is still the usual cause."
+              fi
+            else
+              echo "::warning::docker inspect failed; container state unknown"
+            fi
             docker logs sqlserver || echo "Unable to read logs from sqlserver."
           else
             echo "SQL Server container 'sqlserver' was not found."
@@ -320,6 +338,24 @@ jobs:
           if ! NAMES=$(docker ps -a --format '{{.Names}}'); then
             echo "::warning::docker ps failed; cannot determine whether the sqlserver container exists"
           elif echo "$NAMES" | grep -Fxq sqlserver; then
+            # A memory kill reaches the benchmarks as connection resets and
+            # unexpected EOF, which reads as a driver bug. Say so before the logs.
+            if STATE=$(docker inspect sqlserver --format '{{.State.OOMKilled}} {{.State.ExitCode}} {{.State.Status}} {{.HostConfig.Memory}}'); then
+              read -r OOM CODE STATUS LIMIT <<< "$STATE"
+              if [ "${LIMIT:-0}" -gt 0 ] 2>/dev/null; then
+                LIMIT="$((LIMIT / 1024 / 1024)) MiB"
+              else
+                LIMIT="unset"
+              fi
+              echo "sqlserver: oom-killed=$OOM exit=$CODE status=$STATUS memory-limit=$LIMIT"
+              if [ "$OOM" = "true" ]; then
+                echo "::error::SQL Server was OOM-killed. Connection errors above are a symptom of the container memory limit, not of the driver. Raise -m and MSSQL_MEMORY_LIMIT_MB together, keeping 10-20% headroom between them."
+              elif [ "$CODE" = "137" ]; then
+                echo "::warning::SQL Server exited 137 (SIGKILL) without an OOM flag; memory pressure is still the usual cause."
+              fi
+            else
+              echo "::warning::docker inspect failed; container state unknown"
+            fi
             docker logs sqlserver || echo "Unable to read logs from sqlserver."
           else
             echo "SQL Server container 'sqlserver' was not found."

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -216,20 +216,26 @@ jobs:
           export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}&trustServerCertificate=true"
           BENCH_PATTERN='Benchmark(BulkMakeParam|ConvertAssign|Decode|Encode|ManglePassword|Parse|Read|RoundTrip|Send|Str2ucs2|TdsBuffer|Ucs22str|Write)'
           git worktree add ../main-bench origin/main
-            # Run the PR's version of a benchmark on both sides so an edit to the
-            # benchmark itself does not read as a change in what it measures.
-            # Files new in this PR are skipped: a benchmark for a type the PR
-            # introduces cannot compile against main, and has no baseline anyway.
+            # Run the PR's version of the test code on both sides so an edit to a
+            # benchmark, or to a fixture it reads, does not show up as a change in
+            # what it measures. Not all gated benchmarks live in
+            # *_benchmark_test.go, and the ones that do read fixtures defined
+            # elsewhere, so the whole test corpus is copied rather than a subset.
+            #
+            # Files new in this PR are skipped: they cannot compile against main
+            # and have no baseline anyway.
             shopt -s nullglob
-            for f in *_benchmark_test.go msdsn/*_benchmark_test.go; do
-              if [ -e "../main-bench/$f" ]; then cp -v "$f" "../main-bench/$f"; fi
+            for f in *_test.go msdsn/*_test.go; do
+              if [ -e "../main-bench/$f" ]; then cp "$f" "../main-bench/$f"; fi
             done
             shopt -u nullglob
             cd ../main-bench
+            # An existing test file that now references something this PR adds will
+            # not build here. Fall back to main's own test code: less exact for an
+            # edited benchmark, but it always builds, so the gate still runs.
             if ! go vet . ./msdsn > vet_baseline.log 2>&1; then
-              echo "::error::Baseline does not build with this PR's benchmark files. Put benchmarks for types this PR introduces in their own *_benchmark_test.go file so they can be skipped for the baseline."
-              cat vet_baseline.log
-              exit 1
+              echo "::notice::This PR's test files do not build against main, so the baseline uses main's own copies. A comparison for an edited benchmark may not be exact."
+              git checkout -- .
             fi
           go test -run='^$' -bench="$BENCH_PATTERN" \
             -benchtime=1s -count=10 -benchmem -timeout=25m . ./msdsn 2>&1 | \
@@ -293,12 +299,16 @@ jobs:
           export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}&trustServerCertificate=true"
 
           git worktree add ../main-recheck origin/main
-          # Same rule as the baseline: only files the recheck worktree already has.
+          # Same rule as the baseline: the whole test corpus, but only files the
+          # recheck worktree already has, falling back to its own on a build failure.
           shopt -s nullglob
-          for f in *_benchmark_test.go msdsn/*_benchmark_test.go; do
-            if [ -e "../main-recheck/$f" ]; then cp -v "$f" "../main-recheck/$f"; fi
+          for f in *_test.go msdsn/*_test.go; do
+            if [ -e "../main-recheck/$f" ]; then cp "$f" "../main-recheck/$f"; fi
           done
           shopt -u nullglob
+          if ! ( cd ../main-recheck && go vet . ./msdsn > /dev/null 2>&1 ); then
+            git -C ../main-recheck checkout -- .
+          fi
 
           ( cd ../main-recheck && go test -run='^$' -bench="$PATTERN" \
             -benchtime=1s -count=10 -benchmem -timeout=25m . ./msdsn ) 2>&1 \

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -249,6 +249,15 @@ jobs:
           # expected here, so mask it alone and let errors surface.
           grep_ok() { grep "$@" || [ $? -eq 1 ]; }
 
+          # Rows benchstat called significant that are also more than 15% worse.
+          # Every stage can legitimately match nothing, so each needs grep_ok; a
+          # failure here means we could not evaluate, which must not read as a pass.
+          regressions() {
+            grep_ok -v '~' "$1" \
+              | grep_ok -E '^[^[:space:]]+[[:space:]]+.+[[:space:]]+\+[0-9]+(\.[0-9]+)?%' \
+              | awk '{ if (match($0, /\+[0-9]+(\.[0-9]+)?%/) && substr($0, RSTART+1, RLENGTH-2)+0 >= 15) print }'
+          }
+
           # A "no regression" verdict is only meaningful if we actually recognised
           # benchstat's table. Treat unparseable output as a failure, not a pass.
           if [ ! -s bench_diff.txt ]; then
@@ -270,26 +279,75 @@ jobs:
             echo ""
             echo "::notice::Performance improvements detected (see above)"
           fi
-          # Fail on statistically significant regressions exceeding 15%
-          # Sequential CI runs produce systematic drift up to ~12%, so we require
-          # both statistical significance (no ~ marker) AND >15% magnitude.
-          # Exclude TdsBuffer_Write_Large: ~120ns operation with multi-flush path
-          # shows 30-46% swings between sequential CI runs due to cache sensitivity.
-          # Every stage can legitimately match nothing, so each needs grep_ok; a
-          # failure here means we could not evaluate, which must not read as a pass.
-          if ! REGRESSED=$(grep_ok -v '~' bench_diff.txt \
-                | grep_ok -vE '^TdsBuffer_Write_Large[-[:space:]]' \
-                | grep_ok -E '^[^[:space:]]+[[:space:]]+.+[[:space:]]+\+[0-9]+(\.[0-9]+)?%' \
-                | awk '{ if (match($0, /\+[0-9]+(\.[0-9]+)?%/) && substr($0, RSTART+1, RLENGTH-2)+0 >= 15) print }'); then
+
+          if ! REGRESSED=$(regressions bench_diff.txt); then
             echo "::error::failed to evaluate benchmark comparison"
             exit 1
           fi
-          if [ -n "$REGRESSED" ]; then
-            echo "$REGRESSED"
-            echo "::error::Statistically significant regression detected (>15%, p<0.01)"
+          if [ -z "$REGRESSED" ]; then
+            echo "No significant regressions detected."
+            exit 0
+          fi
+
+          # The baseline and PR samples are collected ~20 minutes apart, so a
+          # significant result can still be an artefact of the runner rather than
+          # the diff. Measure the flagged benchmarks again and only fail if the
+          # regression reproduces.
+          echo "$REGRESSED"
+          echo "::notice::Candidate regressions found; re-measuring to see whether they reproduce."
+
+          # benchstat drops the Benchmark prefix and appends -GOMAXPROCS, so put
+          # the prefix back and strip the suffix to name the benchmarks again.
+          NAMES=$(awk '{print $1}' <<< "$REGRESSED" | sed -E 's/-[0-9]+$//' | sort -u)
+          PATTERN="^Benchmark($(paste -sd'|' - <<< "$NAMES"))$"
+          echo "Re-running: $PATTERN"
+
+          export SQLUSER=sa
+          export SQLPASSWORD=$SQLCMDPASSWORD
+          export DATABASE=master
+          export HOST=localhost
+          export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}&trustServerCertificate=true"
+
+          git worktree add ../main-recheck origin/main
+          cp -v *_benchmark_test.go ../main-recheck/ 2>/dev/null || true
+          cp -v msdsn/*_benchmark_test.go ../main-recheck/msdsn/ 2>/dev/null || true
+          ( cd ../main-recheck && go test -run='^$' -bench="$PATTERN" \
+            -benchtime=1s -count=10 -benchmem -timeout=15m . ./msdsn ) 2>&1 \
+            | tee recheck_old_full.log
+          go test -run='^$' -bench="$PATTERN" \
+            -benchtime=1s -count=10 -benchmem -timeout=15m . ./msdsn 2>&1 \
+            | tee recheck_new_full.log
+          git worktree remove ../main-recheck --force
+
+          grep_ok -E '^(Benchmark|goos:|goarch:|pkg:|cpu:)' recheck_old_full.log > recheck_old.txt
+          grep_ok -E '^(Benchmark|goos:|goarch:|pkg:|cpu:)' recheck_new_full.log > recheck_new.txt
+          if [ ! -s recheck_old.txt ] || [ ! -s recheck_new.txt ]; then
+            echo "::error::confirmation run produced no benchmark output; cannot evaluate"
             exit 1
           fi
-          echo "No significant regressions detected."
+
+          benchstat -alpha=0.01 recheck_old.txt recheck_new.txt | tee recheck_diff.txt
+          # Same standard as the first pass: a verdict only counts if we actually
+          # recognised benchstat's table, so whitespace cannot read as "clean".
+          if ! RECHECK_ROWS=$(grep_ok -cE '^[^[:space:]]+[[:space:]]+.+(±|~|[0-9]%)' recheck_diff.txt); then
+            echo "::error::failed to scan confirmation output; cannot evaluate"
+            exit 1
+          fi
+          if [ "$RECHECK_ROWS" -eq 0 ]; then
+            echo "::error::confirmation run produced no recognisable benchstat rows; cannot evaluate"
+            cat recheck_diff.txt
+            exit 1
+          fi
+          if ! CONFIRMED=$(regressions recheck_diff.txt); then
+            echo "::error::failed to evaluate confirmation run"
+            exit 1
+          fi
+          if [ -n "$CONFIRMED" ]; then
+            echo "$CONFIRMED"
+            echo "::error::Regression reproduced on a second measurement (>15%, p<0.01)"
+            exit 1
+          fi
+          echo "::warning::Flagged regression did not reproduce; treating the first measurement as runner noise."
       - name: Post benchmark results to PR
         # Fork PRs get read-only tokens; comment will be skipped gracefully.
         continue-on-error: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -302,7 +302,11 @@ jobs:
 
           # benchstat drops the Benchmark prefix and appends -GOMAXPROCS, so put
           # the prefix back and strip the suffix to name the benchmarks again.
-          NAMES=$(awk '{print $1}' <<< "$REGRESSED" | sed -E 's/-[0-9]+$//' | sort -u)
+          # Sub-benchmarks collapse to their parent: go test splits -bench at '/'
+          # and matches each element separately, so "Parent/Sub" cannot be one
+          # element. Re-running the parent covers the flagged child.
+          awk '{print $1}' <<< "$REGRESSED" | sort -u > flagged_rows.txt
+          NAMES=$(sed -E 's/-[0-9]+$//; s#/.*##' flagged_rows.txt | sort -u)
           PATTERN="^Benchmark($(paste -sd'|' - <<< "$NAMES"))$"
           echo "Re-running: $PATTERN"
 
@@ -344,7 +348,8 @@ jobs:
             cat recheck_diff.txt
             exit 1
           fi
-          if ! CONFIRMED=$(regressions recheck_diff.txt); then
+          if ! CONFIRMED=$(regressions recheck_diff.txt \
+                | awk 'NR==FNR { want[$1]=1; next } want[$1]' flagged_rows.txt -); then
             echo "::error::failed to evaluate confirmation run"
             exit 1
           fi

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -113,6 +113,13 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.27.x'
+      - name: Install benchstat
+        shell: bash
+        # Before the benchmark runs, not after: they take ~46 minutes and this
+        # reaches outside the repo, so a fetch failure should surface at once.
+        run: |
+          go install golang.org/x/perf/cmd/benchstat@latest
+          command -v benchstat
       - name: Install sqlcmd
         run: |
           curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
@@ -186,9 +193,6 @@ jobs:
       - name: Compare benchmarks
         shell: bash
         run: |
-          # Pinned because the next step parses benchstat's output; an unpinned
-          # tool is free to change its format and silently disable the gate.
-          go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260813145340-fd4a688df892
           echo "## Benchmark Comparison (main vs PR)" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           benchstat -alpha=0.01 bench_old.txt bench_new.txt | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -93,7 +93,10 @@ jobs:
         if: failure()
         shell: bash
         run: |
-          if docker ps -a --format '{{.Names}}' | grep -Fxq sqlserver; then
+          # Distinguish "docker could not tell us" from "the container is absent".
+          if ! NAMES=$(docker ps -a --format '{{.Names}}'); then
+            echo "::warning::docker ps failed; cannot determine whether the sqlserver container exists"
+          elif echo "$NAMES" | grep -Fxq sqlserver; then
             docker logs sqlserver || echo "Unable to read logs from sqlserver."
           else
             echo "SQL Server container 'sqlserver' was not found."
@@ -301,7 +304,10 @@ jobs:
         if: failure()
         shell: bash
         run: |
-          if docker ps -a --format '{{.Names}}' | grep -Fxq sqlserver; then
+          # Distinguish "docker could not tell us" from "the container is absent".
+          if ! NAMES=$(docker ps -a --format '{{.Names}}'); then
+            echo "::warning::docker ps failed; cannot determine whether the sqlserver container exists"
+          elif echo "$NAMES" | grep -Fxq sqlserver; then
             docker logs sqlserver || echo "Unable to read logs from sqlserver."
           else
             echo "SQL Server container 'sqlserver' was not found."

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -44,7 +44,11 @@ jobs:
         shell: bash
         run: |
           go version
-          export SQLCMDPASSWORD=$(date +%s|sha256sum|base64|head -c 32)
+          # base64 of hex text yields no symbols, so the generated part supplies only
+          # upper, lower and digits, and a run that happens to contain no digit has
+          # two classes and fails SQL Server's three-of-four policy. The suffix
+          # supplies all four so the container always starts.
+          export SQLCMDPASSWORD=$(date +%s|sha256sum|base64|head -c 28)aA1!
           export SQLCMDUSER=sa
           export SQLUSER=sa
           export SQLPASSWORD=$SQLCMDPASSWORD
@@ -163,7 +167,8 @@ jobs:
       - name: Start SQL Server container
         shell: bash
         run: |
-          export SQLCMDPASSWORD=$(date +%s|sha256sum|base64|head -c 32)
+          # See the build job: the suffix guarantees SQL Server's password policy.
+          export SQLCMDPASSWORD=$(date +%s|sha256sum|base64|head -c 28)aA1!
           echo "SQLCMDPASSWORD=$SQLCMDPASSWORD" >> $GITHUB_ENV
           # 2 GB is the documented minimum with no headroom, and SQL 2025 was seen
           # failing to start at it. MSSQL_MEMORY_LIMIT_MB stays under the container

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -293,13 +293,18 @@ jobs:
             ' "$1"
           }
 
-          # Count of comparable rows, used to tell "nothing regressed" apart from
-          # "we did not understand the output".
+          # Count only rows this parser actually understands: inside a table whose
+          # header it recognised, with a delta it can read. If benchstat's CSV
+          # layout changes, the count reaches zero and the gate fails closed
+          # instead of reporting "nothing regressed" from rows it never parsed.
           count_rows() {
             awk -F, '
-              /^,/ && $3 == "CI" { next }
+              /^,/ && $3 == "CI" { unit = $2; next }
+              /^,/ { unit = ""; next }
               $1 == "" || $1 == "geomean" { next }
-              NF >= 6 { n++ }
+              unit == "" { next }
+              $6 !~ /^(~|[+-][0-9]+(\.[0-9]+)?%)$/ { next }
+              { n++ }
               END { print n + 0 }
             ' "$1"
           }
@@ -343,8 +348,10 @@ jobs:
           # Sub-benchmarks collapse to their parent: go test splits -bench at '/'
           # and matches each element separately, so "Parent/Sub" cannot be one
           # element. Re-running the parent covers the flagged child.
-          awk '{print $1}' <<< "$REGRESSED" | sort -u > flagged_rows.txt
-          NAMES=$(sed -E 's/-[0-9]+$//; s#/.*##' flagged_rows.txt | sort -u)
+          # Key on benchmark and unit together: the same benchmark regressing in a
+          # different metric is not the candidate reproducing.
+          awk -F'\t' '{ print $1 "\t" $3 }' <<< "$REGRESSED" | sort -u > flagged_rows.txt
+          NAMES=$(cut -f1 flagged_rows.txt | sed -E 's/-[0-9]+$//; s#/.*##' | sort -u)
           PATTERN="^Benchmark($(paste -sd'|' - <<< "$NAMES"))$"
           echo "Re-running: $PATTERN"
 
@@ -385,7 +392,7 @@ jobs:
             exit 1
           fi
           if ! CONFIRMED=$(regressions recheck_diff.csv \
-                | awk 'NR==FNR { want[$1]=1; next } want[$1]' flagged_rows.txt -); then
+                | awk -F'\t' 'NR==FNR { want[$1 SUBSEP $2]=1; next } want[$1 SUBSEP $3]' flagged_rows.txt -); then
             echo "::error::failed to evaluate confirmation run"
             exit 1
           fi

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -44,11 +44,7 @@ jobs:
         shell: bash
         run: |
           go version
-          # base64 of hex text yields no symbols, so the generated part supplies only
-          # upper, lower and digits, and a run that happens to contain no digit has
-          # two classes and fails SQL Server's three-of-four policy. The suffix
-          # supplies all four so the container always starts.
-          export SQLCMDPASSWORD=$(date +%s|sha256sum|base64|head -c 28)aA1!
+          export SQLCMDPASSWORD=$(date +%s|sha256sum|base64|head -c 32)
           export SQLCMDUSER=sa
           export SQLUSER=sa
           export SQLPASSWORD=$SQLCMDPASSWORD
@@ -167,8 +163,7 @@ jobs:
       - name: Start SQL Server container
         shell: bash
         run: |
-          # See the build job: the suffix guarantees SQL Server's password policy.
-          export SQLCMDPASSWORD=$(date +%s|sha256sum|base64|head -c 28)aA1!
+          export SQLCMDPASSWORD=$(date +%s|sha256sum|base64|head -c 32)
           echo "SQLCMDPASSWORD=$SQLCMDPASSWORD" >> $GITHUB_ENV
           # 2 GB is the documented minimum with no headroom, and SQL 2025 was seen
           # failing to start at it. MSSQL_MEMORY_LIMIT_MB stays under the container

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -197,13 +197,20 @@ jobs:
       - name: Check for regressions
         shell: bash
         run: |
+          # grep exits 1 for "no match" and 2 for a real error. Only the first is
+          # expected here, so mask it alone and let errors surface.
+          grep_ok() { grep "$@" || [ $? -eq 1 ]; }
+
           # A "no regression" verdict is only meaningful if we actually recognised
           # benchstat's table. Treat unparseable output as a failure, not a pass.
           if [ ! -s bench_diff.txt ]; then
             echo "::error::benchstat produced no output; cannot evaluate regressions"
             exit 1
           fi
-          ROWS=$(grep -cE '^\S+\s+.+(±|~|[+-][0-9])' bench_diff.txt || true)
+          if ! ROWS=$(grep_ok -cE '^\S+\s+.+(±|~|[+-][0-9])' bench_diff.txt); then
+            echo "::error::failed to scan benchstat output; cannot evaluate regressions"
+            exit 1
+          fi
           if [ "$ROWS" -eq 0 ]; then
             echo "::error::benchstat output not recognised; cannot evaluate regressions"
             cat bench_diff.txt
@@ -211,7 +218,7 @@ jobs:
           fi
           echo "Parsed $ROWS benchmark rows."
           # Report statistically significant improvements (real %, not ~)
-          if grep -v '~' bench_diff.txt | grep -E '^\S+\s+.+\s+-[0-9]+(\.[0-9]+)?%'; then
+          if grep_ok -v '~' bench_diff.txt | grep -E '^\S+\s+.+\s+-[0-9]+(\.[0-9]+)?%'; then
             echo ""
             echo "::notice::Performance improvements detected (see above)"
           fi
@@ -220,9 +227,15 @@ jobs:
           # both statistical significance (no ~ marker) AND >15% magnitude.
           # Exclude TdsBuffer_Write_Large: ~120ns operation with multi-flush path
           # shows 30-46% swings between sequential CI runs due to cache sensitivity.
-          # The trailing || true matters: grep exits 1 when nothing regressed, and
-          # under `set -eo pipefail` that would abort the step instead of passing.
-          REGRESSED=$(grep -v '~' bench_diff.txt | grep -v 'TdsBuffer_Write_Large' | grep -E '^\S+\s+.+\s+\+[0-9]+(\.[0-9]+)?%' | awk -F'+' '{split($2,a,"%"); if (a[1]+0 >= 15) print}' || true)
+          # Every stage can legitimately match nothing, so each needs grep_ok; a
+          # failure here means we could not evaluate, which must not read as a pass.
+          if ! REGRESSED=$(grep_ok -v '~' bench_diff.txt \
+                | grep_ok -v 'TdsBuffer_Write_Large' \
+                | grep_ok -E '^\S+\s+.+\s+\+[0-9]+(\.[0-9]+)?%' \
+                | awk -F'+' '{split($2,a,"%"); if (a[1]+0 >= 15) print}'); then
+            echo "::error::failed to evaluate benchmark comparison"
+            exit 1
+          fi
           if [ -n "$REGRESSED" ]; then
             echo "$REGRESSED"
             echo "::error::Statistically significant regression detected (>15%, p<0.01)"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -62,7 +62,10 @@ jobs:
           else
             export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}"
           fi
-          docker run -m 2GB -e ACCEPT_EULA=1 -d --name sqlserver -p 1433:1433 -e SA_PASSWORD=$SQLCMDPASSWORD mcr.microsoft.com/mssql/server:${{ matrix.sqlImage }}
+          # 2 GB is the documented minimum with no headroom, and SQL 2025 was seen
+          # failing to start at it. MSSQL_MEMORY_LIMIT_MB stays under the container
+          # cap so the engine leaves room for the rest of the container.
+          docker run -m 4GB -e ACCEPT_EULA=1 -e MSSQL_MEMORY_LIMIT_MB=3072 -d --name sqlserver -p 1433:1433 -e SA_PASSWORD=$SQLCMDPASSWORD mcr.microsoft.com/mssql/server:${{ matrix.sqlImage }}
           # Wait for SQL Server to be ready - retry up to 60 seconds (30 attempts x 2s)
           READY=0
           for i in {1..30}; do
@@ -139,7 +142,11 @@ jobs:
         run: |
           export SQLCMDPASSWORD=$(date +%s|sha256sum|base64|head -c 32)
           echo "SQLCMDPASSWORD=$SQLCMDPASSWORD" >> $GITHUB_ENV
-          docker run -m 2GB -e ACCEPT_EULA=1 -d --name sqlserver \
+          # 2 GB is the documented minimum with no headroom, and SQL 2025 was seen
+          # failing to start at it. MSSQL_MEMORY_LIMIT_MB stays under the container
+          # cap so the engine leaves room for the rest of the container.
+          docker run -m 4GB -e ACCEPT_EULA=1 -e MSSQL_MEMORY_LIMIT_MB=3072 \
+            -d --name sqlserver \
             -p 1433:1433 -e SA_PASSWORD=$SQLCMDPASSWORD \
             mcr.microsoft.com/mssql/server:2025-latest
           # Wait for SQL Server to be ready
@@ -252,7 +259,7 @@ jobs:
           # Every stage can legitimately match nothing, so each needs grep_ok; a
           # failure here means we could not evaluate, which must not read as a pass.
           if ! REGRESSED=$(grep_ok -v '~' bench_diff.txt \
-                | grep_ok -v 'TdsBuffer_Write_Large' \
+                | grep_ok -vE '^TdsBuffer_Write_Large[-[:space:]]' \
                 | grep_ok -E '^[^[:space:]]+[[:space:]]+.+[[:space:]]+\+[0-9]+(\.[0-9]+)?%' \
                 | awk '{ if (match($0, /\+[0-9]+(\.[0-9]+)?%/) && substr($0, RSTART+1, RLENGTH-2)+0 >= 15) print }'); then
             echo "::error::failed to evaluate benchmark comparison"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -250,6 +250,9 @@ jobs:
           benchstat -alpha=0.01 bench_old.txt bench_new.txt | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           benchstat -alpha=0.01 bench_old.txt bench_new.txt > bench_diff.txt
+          # The table is for humans; the gate reads CSV, where the unit and the
+          # row name are fields rather than something to recover from layout.
+          benchstat -format=csv -alpha=0.01 bench_old.txt bench_new.txt > bench_diff.csv
       - name: Check for regressions
         shell: bash
         run: |
@@ -258,37 +261,68 @@ jobs:
           grep_ok() { grep "$@" || [ $? -eq 1 ]; }
 
           # Rows benchstat called significant that are also more than 15% worse.
-          # Every stage can legitimately match nothing, so each needs grep_ok; a
-          # failure here means we could not evaluate, which must not read as a pass.
+          # Reads CSV: header rows carry the unit, so throughput tables (B/s),
+          # where a positive delta is an improvement, are skipped rather than
+          # counted as regressions. geomean is a summary, not a benchmark, and
+          # naming it in a -bench selector would match nothing.
           regressions() {
-            grep_ok -v '~' "$1" \
-              | grep_ok -E '^[^[:space:]]+[[:space:]]+.+[[:space:]]+\+[0-9]+(\.[0-9]+)?%' \
-              | awk '{ if (match($0, /\+[0-9]+(\.[0-9]+)?%/) && substr($0, RSTART+1, RLENGTH-2)+0 >= 15) print }'
+            awk -F, '
+              /^,/ && $3 == "CI" { unit = $2; next }
+              $1 == "geomean" || $1 == "" { next }
+              unit != "sec/op" && unit != "B/op" && unit != "allocs/op" { next }
+              $6 == "~" { next }
+              {
+                if (match($6, /\+[0-9]+(\.[0-9]+)?%/) &&
+                    substr($6, RSTART + 1, RLENGTH - 2) + 0 >= 15) print $1 "\t" $6 "\t" unit
+              }
+            ' "$1"
+          }
+
+          # Mirror of regressions(): beneficial changes, which for a throughput
+          # table means a positive delta.
+          improvements() {
+            awk -F, '
+              /^,/ && $3 == "CI" { unit = $2; next }
+              $1 == "geomean" || $1 == "" { next }
+              $6 == "~" { next }
+              {
+                lower = (unit == "sec/op" || unit == "B/op" || unit == "allocs/op")
+                if (lower && $6 ~ /^-/) print $1 "\t" $6 "\t" unit
+                if (!lower && $6 ~ /^\+/) print $1 "\t" $6 "\t" unit
+              }
+            ' "$1"
+          }
+
+          # Count of comparable rows, used to tell "nothing regressed" apart from
+          # "we did not understand the output".
+          count_rows() {
+            awk -F, '
+              /^,/ && $3 == "CI" { next }
+              $1 == "" || $1 == "geomean" { next }
+              NF >= 6 { n++ }
+              END { print n + 0 }
+            ' "$1"
           }
 
           # A "no regression" verdict is only meaningful if we actually recognised
-          # benchstat's table. Treat unparseable output as a failure, not a pass.
-          if [ ! -s bench_diff.txt ]; then
+          # benchstat's output. Treat unparseable output as a failure, not a pass.
+          if [ ! -s bench_diff.csv ]; then
             echo "::error::benchstat produced no output; cannot evaluate regressions"
             exit 1
           fi
-          if ! ROWS=$(grep_ok -cE '^[^[:space:]]+[[:space:]]+.+(±|~|[0-9]%)' bench_diff.txt); then
-            echo "::error::failed to scan benchstat output; cannot evaluate regressions"
-            exit 1
-          fi
+          ROWS=$(count_rows bench_diff.csv)
           if [ "$ROWS" -eq 0 ]; then
             echo "::error::benchstat output not recognised; cannot evaluate regressions"
-            cat bench_diff.txt
+            cat bench_diff.csv
             exit 1
           fi
           echo "Parsed $ROWS benchmark rows."
-          # Report statistically significant improvements (real %, not ~)
-          if grep_ok -v '~' bench_diff.txt | grep -E '^[^[:space:]]+[[:space:]]+.+[[:space:]]+-[0-9]+(\.[0-9]+)?%'; then
-            echo ""
+          if IMPROVED=$(improvements bench_diff.csv) && [ -n "$IMPROVED" ]; then
+            echo "$IMPROVED"
             echo "::notice::Performance improvements detected (see above)"
           fi
 
-          if ! REGRESSED=$(regressions bench_diff.txt); then
+          if ! REGRESSED=$(regressions bench_diff.csv); then
             echo "::error::failed to evaluate benchmark comparison"
             exit 1
           fi
@@ -341,18 +375,16 @@ jobs:
           fi
 
           benchstat -alpha=0.01 recheck_old.txt recheck_new.txt | tee recheck_diff.txt
+          benchstat -format=csv -alpha=0.01 recheck_old.txt recheck_new.txt > recheck_diff.csv
           # Same standard as the first pass: a verdict only counts if we actually
-          # recognised benchstat's table, so whitespace cannot read as "clean".
-          if ! RECHECK_ROWS=$(grep_ok -cE '^[^[:space:]]+[[:space:]]+.+(±|~|[0-9]%)' recheck_diff.txt); then
-            echo "::error::failed to scan confirmation output; cannot evaluate"
-            exit 1
-          fi
+          # recognised the output, so an empty file cannot read as "clean".
+          RECHECK_ROWS=$(count_rows recheck_diff.csv)
           if [ "$RECHECK_ROWS" -eq 0 ]; then
             echo "::error::confirmation run produced no recognisable benchstat rows; cannot evaluate"
-            cat recheck_diff.txt
+            cat recheck_diff.csv
             exit 1
           fi
-          if ! CONFIRMED=$(regressions recheck_diff.txt \
+          if ! CONFIRMED=$(regressions recheck_diff.csv \
                 | awk 'NR==FNR { want[$1]=1; next } want[$1]' flagged_rows.txt -); then
             echo "::error::failed to evaluate confirmation run"
             exit 1

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -186,7 +186,8 @@ jobs:
       - name: Compare benchmarks
         shell: bash
         run: |
-          # Last x/perf commit before its go directive moved to 1.26; setup-go sets GOTOOLCHAIN=local.
+          # Pinned because the next step parses benchstat's output; an unpinned
+          # tool is free to change its format and silently disable the gate.
           go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260813145340-fd4a688df892
           echo "## Benchmark Comparison (main vs PR)" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
@@ -196,12 +197,21 @@ jobs:
       - name: Check for regressions
         shell: bash
         run: |
-          if [ ! -f bench_diff.txt ]; then
-            echo "No comparison available, skipping regression check."
-            exit 0
+          # A "no regression" verdict is only meaningful if we actually recognised
+          # benchstat's table. Treat unparseable output as a failure, not a pass.
+          if [ ! -s bench_diff.txt ]; then
+            echo "::error::benchstat produced no output; cannot evaluate regressions"
+            exit 1
           fi
+          ROWS=$(grep -cE '^\S+\s+.+(±|~|[+-][0-9])' bench_diff.txt || true)
+          if [ "$ROWS" -eq 0 ]; then
+            echo "::error::benchstat output not recognised; cannot evaluate regressions"
+            cat bench_diff.txt
+            exit 1
+          fi
+          echo "Parsed $ROWS benchmark rows."
           # Report statistically significant improvements (real %, not ~)
-          if grep -v '~' bench_diff.txt | grep -E '^\S+\s+.+\s+-[0-9]+\.[0-9]+%'; then
+          if grep -v '~' bench_diff.txt | grep -E '^\S+\s+.+\s+-[0-9]+(\.[0-9]+)?%'; then
             echo ""
             echo "::notice::Performance improvements detected (see above)"
           fi
@@ -210,7 +220,9 @@ jobs:
           # both statistical significance (no ~ marker) AND >15% magnitude.
           # Exclude TdsBuffer_Write_Large: ~120ns operation with multi-flush path
           # shows 30-46% swings between sequential CI runs due to cache sensitivity.
-          REGRESSED=$(grep -v '~' bench_diff.txt | grep -v 'TdsBuffer_Write_Large' | grep -E '^\S+\s+.+\s+\+[0-9]+\.[0-9]+%' | awk -F'+' '{split($2,a,"%"); if (a[1]+0 >= 15) print}')
+          # The trailing || true matters: grep exits 1 when nothing regressed, and
+          # under `set -eo pipefail` that would abort the step instead of passing.
+          REGRESSED=$(grep -v '~' bench_diff.txt | grep -v 'TdsBuffer_Write_Large' | grep -E '^\S+\s+.+\s+\+[0-9]+(\.[0-9]+)?%' | awk -F'+' '{split($2,a,"%"); if (a[1]+0 >= 15) print}' || true)
           if [ -n "$REGRESSED" ]; then
             echo "$REGRESSED"
             echo "::error::Statistically significant regression detected (>15%, p<0.01)"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -136,14 +136,20 @@ jobs:
             -p 1433:1433 -e SA_PASSWORD=$SQLCMDPASSWORD \
             mcr.microsoft.com/mssql/server:2025-latest
           # Wait for SQL Server to be ready
+          READY=0
           for i in {1..30}; do
             if sqlcmd -S localhost -U sa -P "$SQLCMDPASSWORD" -C -Q "SELECT 1" > /dev/null 2>&1; then
               echo "SQL Server is ready (attempt $i)"
+              READY=1
               break
             fi
             echo "Waiting for SQL Server... (attempt $i/30)"
             sleep 2
           done
+          if [ "$READY" -eq 0 ]; then
+            echo "::error::SQL Server did not become ready; aborting benchmarks."
+            exit 1
+          fi
       - name: Warmup run (stabilize CPU/caches)
         shell: bash
         run: |
@@ -155,9 +161,14 @@ jobs:
           BENCH_PATTERN='Benchmark(BulkMakeParam|ConvertAssign|Decode|Encode|ManglePassword|Parse|Read|RoundTrip|Send|Str2ucs2|TdsBuffer|Ucs22str|Write)'
           # Throwaway run to warm CPU caches, prime the Go runtime, and settle
           # the OS scheduler. Results are discarded — ensures both measurement
-          # runs start from the same steady-state conditions.
-          go test -run='^$' -bench="$BENCH_PATTERN" \
-            -benchtime=100ms -count=1 -timeout=10m . ./msdsn > /dev/null 2>&1
+          # runs start from the same steady-state conditions. Output is kept so a
+          # failure here is diagnosable rather than a bare exit code.
+          if ! go test -run='^$' -bench="$BENCH_PATTERN" \
+              -benchtime=100ms -count=1 -timeout=10m . ./msdsn > warmup.log 2>&1; then
+            echo "::error::warmup run failed"
+            tail -50 warmup.log
+            exit 1
+          fi
       - name: Run baseline benchmarks (main)
         shell: bash
         run: |
@@ -285,4 +296,13 @@ jobs:
           else
             gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY"
             echo "Posted new benchmark comment."
+          fi
+      - name: Show SQL Server logs on failure
+        if: failure()
+        shell: bash
+        run: |
+          if docker ps -a --format '{{.Names}}' | grep -Fxq sqlserver; then
+            docker logs sqlserver || echo "Unable to read logs from sqlserver."
+          else
+            echo "SQL Server container 'sqlserver' was not found."
           fi

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -256,104 +256,27 @@ jobs:
       - name: Check for regressions
         shell: bash
         run: |
-          # grep exits 1 for "no match" and 2 for a real error. Only the first is
-          # expected here, so mask it alone and let errors surface.
-          grep_ok() { grep "$@" || [ $? -eq 1 ]; }
+          # go run does not propagate the program's exit status, so build first.
+          go build -o "$RUNNER_TEMP/benchgate" ./internal/benchgate
 
-          # Rows benchstat called significant that are also more than 15% worse.
-          # Reads CSV: header rows carry the unit, so throughput tables (B/s),
-          # where a positive delta is an improvement, are skipped rather than
-          # counted as regressions. geomean is a summary, not a benchmark, and
-          # naming it in a -bench selector would match nothing.
-          regressions() {
-            awk -F, '
-              /^,/ && $3 == "CI" { unit = $2; next }
-              $1 == "geomean" || $1 == "" { next }
-              unit != "sec/op" && unit != "B/op" && unit != "allocs/op" { next }
-              $6 == "~" { next }
-              {
-                if (match($6, /\+[0-9]+(\.[0-9]+)?%/) &&
-                    substr($6, RSTART + 1, RLENGTH - 2) + 0 >= 15) print $1 "\t" $6 "\t" unit
-              }
-            ' "$1"
-          }
+          set +e
+          "$RUNNER_TEMP/benchgate" detect \
+            -csv bench_diff.csv \
+            -flagged "$RUNNER_TEMP/flagged.tsv" \
+            -selector "$RUNNER_TEMP/selector.txt"
+          rc=$?
+          set -e
+          case "$rc" in
+            0) exit 0 ;;
+            2) ;;
+            *) echo "::error::could not evaluate the benchmark comparison"; exit 1 ;;
+          esac
 
-          # Mirror of regressions(): beneficial changes, which for a throughput
-          # table means a positive delta.
-          improvements() {
-            awk -F, '
-              /^,/ && $3 == "CI" { unit = $2; next }
-              $1 == "geomean" || $1 == "" { next }
-              $6 == "~" { next }
-              {
-                lower = (unit == "sec/op" || unit == "B/op" || unit == "allocs/op")
-                if (lower && $6 ~ /^-/) print $1 "\t" $6 "\t" unit
-                if (!lower && $6 ~ /^\+/) print $1 "\t" $6 "\t" unit
-              }
-            ' "$1"
-          }
-
-          # Count only rows this parser actually understands: inside a table whose
-          # header it recognised, with a delta it can read. If benchstat's CSV
-          # layout changes, the count reaches zero and the gate fails closed
-          # instead of reporting "nothing regressed" from rows it never parsed.
-          count_rows() {
-            awk -F, '
-              /^,/ && $3 == "CI" { unit = $2; next }
-              /^,/ { unit = ""; next }
-              $1 == "" || $1 == "geomean" { next }
-              unit == "" { next }
-              $6 !~ /^(~|[+-][0-9]+(\.[0-9]+)?%)$/ { next }
-              { n++ }
-              END { print n + 0 }
-            ' "$1"
-          }
-
-          # A "no regression" verdict is only meaningful if we actually recognised
-          # benchstat's output. Treat unparseable output as a failure, not a pass.
-          if [ ! -s bench_diff.csv ]; then
-            echo "::error::benchstat produced no output; cannot evaluate regressions"
-            exit 1
-          fi
-          ROWS=$(count_rows bench_diff.csv)
-          if [ "$ROWS" -eq 0 ]; then
-            echo "::error::benchstat output not recognised; cannot evaluate regressions"
-            cat bench_diff.csv
-            exit 1
-          fi
-          echo "Parsed $ROWS benchmark rows."
-          if IMPROVED=$(improvements bench_diff.csv) && [ -n "$IMPROVED" ]; then
-            echo "$IMPROVED"
-            echo "::notice::Performance improvements detected (see above)"
-          fi
-
-          if ! REGRESSED=$(regressions bench_diff.csv); then
-            echo "::error::failed to evaluate benchmark comparison"
-            exit 1
-          fi
-          if [ -z "$REGRESSED" ]; then
-            echo "No significant regressions detected."
-            exit 0
-          fi
-
-          # The baseline and PR samples are collected ~20 minutes apart, so a
-          # significant result can still be an artefact of the runner rather than
-          # the diff. Measure the flagged benchmarks again and only fail if the
-          # regression reproduces.
-          echo "$REGRESSED"
-          echo "::notice::Candidate regressions found; re-measuring to see whether they reproduce."
-
-          # benchstat drops the Benchmark prefix and appends -GOMAXPROCS, so put
-          # the prefix back and strip the suffix to name the benchmarks again.
-          # Sub-benchmarks collapse to their parent: go test splits -bench at '/'
-          # and matches each element separately, so "Parent/Sub" cannot be one
-          # element. Re-running the parent covers the flagged child.
-          # Key on benchmark and unit together: the same benchmark regressing in a
-          # different metric is not the candidate reproducing.
-          awk -F'\t' '{ print $1 "\t" $3 }' <<< "$REGRESSED" | sort -u > flagged_rows.txt
-          NAMES=$(cut -f1 flagged_rows.txt | sed -E 's/-[0-9]+$//; s#/.*##' | sort -u)
-          PATTERN="^Benchmark($(paste -sd'|' - <<< "$NAMES"))$"
-          echo "Re-running: $PATTERN"
+          # The two measurement passes are ~20 minutes apart, so a significant
+          # result can be runner drift rather than the diff. Re-measure just the
+          # flagged benchmarks, back to back, and only fail if it reproduces.
+          PATTERN=$(cat "$RUNNER_TEMP/selector.txt")
+          echo "::notice::Candidate regressions found; re-measuring $PATTERN"
 
           export SQLUSER=sa
           export SQLPASSWORD=$SQLCMDPASSWORD
@@ -366,6 +289,7 @@ jobs:
           for f in *_benchmark_test.go; do cp -v "$f" ../main-recheck/; done
           for f in msdsn/*_benchmark_test.go; do cp -v "$f" ../main-recheck/msdsn/; done
           shopt -u nullglob
+
           ( cd ../main-recheck && go test -run='^$' -bench="$PATTERN" \
             -benchtime=1s -count=10 -benchmem -timeout=25m . ./msdsn ) 2>&1 \
             | tee recheck_old_full.log
@@ -374,34 +298,22 @@ jobs:
             | tee recheck_new_full.log
           git worktree remove ../main-recheck --force
 
-          grep_ok -E '^(Benchmark|goos:|goarch:|pkg:|cpu:)' recheck_old_full.log > recheck_old.txt
-          grep_ok -E '^(Benchmark|goos:|goarch:|pkg:|cpu:)' recheck_new_full.log > recheck_new.txt
-          if [ ! -s recheck_old.txt ] || [ ! -s recheck_new.txt ]; then
-            echo "::error::confirmation run produced no benchmark output; cannot evaluate"
-            exit 1
-          fi
-
+          grep -E '^(Benchmark|goos:|goarch:|pkg:|cpu:)' recheck_old_full.log > recheck_old.txt || true
+          grep -E '^(Benchmark|goos:|goarch:|pkg:|cpu:)' recheck_new_full.log > recheck_new.txt || true
           benchstat -alpha=0.01 recheck_old.txt recheck_new.txt | tee recheck_diff.txt
           benchstat -format=csv -alpha=0.01 recheck_old.txt recheck_new.txt > recheck_diff.csv
-          # Same standard as the first pass: a verdict only counts if we actually
-          # recognised the output, so an empty file cannot read as "clean".
-          RECHECK_ROWS=$(count_rows recheck_diff.csv)
-          if [ "$RECHECK_ROWS" -eq 0 ]; then
-            echo "::error::confirmation run produced no recognisable benchstat rows; cannot evaluate"
-            cat recheck_diff.csv
-            exit 1
-          fi
-          if ! CONFIRMED=$(regressions recheck_diff.csv \
-                | awk -F'\t' 'NR==FNR { want[$1 SUBSEP $2]=1; next } want[$1 SUBSEP $3]' flagged_rows.txt -); then
-            echo "::error::failed to evaluate confirmation run"
-            exit 1
-          fi
-          if [ -n "$CONFIRMED" ]; then
-            echo "$CONFIRMED"
-            echo "::error::Regression reproduced on a second measurement (>15%, p<0.01)"
-            exit 1
-          fi
-          echo "::warning::Flagged regression did not reproduce; treating the first measurement as runner noise."
+
+          set +e
+          "$RUNNER_TEMP/benchgate" confirm \
+            -csv recheck_diff.csv \
+            -flagged "$RUNNER_TEMP/flagged.tsv"
+          rc=$?
+          set -e
+          case "$rc" in
+            0) exit 0 ;;
+            2) echo "::error::Regression reproduced on a second measurement (>15%, p<0.01)"; exit 1 ;;
+            *) echo "::error::could not evaluate the confirmation run"; exit 1 ;;
+          esac
       - name: Post benchmark results to PR
         # Fork PRs get read-only tokens; comment will be skipped gracefully.
         continue-on-error: true

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -212,8 +212,12 @@ jobs:
           export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}&trustServerCertificate=true"
           BENCH_PATTERN='Benchmark(BulkMakeParam|ConvertAssign|Decode|Encode|ManglePassword|Parse|Read|RoundTrip|Send|Str2ucs2|TdsBuffer|Ucs22str|Write)'
           git worktree add ../main-bench origin/main
-          cp -v *_benchmark_test.go ../main-bench/ 2>/dev/null || true
-          cp -v msdsn/*_benchmark_test.go ../main-bench/msdsn/ 2>/dev/null || true
+          # nullglob so a missing match copies nothing instead of erroring, while a
+          # real cp failure still aborts rather than resurfacing as "no output".
+          shopt -s nullglob
+          for f in *_benchmark_test.go; do cp -v "$f" ../main-bench/; done
+          for f in msdsn/*_benchmark_test.go; do cp -v "$f" ../main-bench/msdsn/; done
+          shopt -u nullglob
           cd ../main-bench
           go test -run='^$' -bench="$BENCH_PATTERN" \
             -benchtime=1s -count=10 -benchmem -timeout=25m . ./msdsn 2>&1 | \
@@ -309,8 +313,10 @@ jobs:
           export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}&trustServerCertificate=true"
 
           git worktree add ../main-recheck origin/main
-          cp -v *_benchmark_test.go ../main-recheck/ 2>/dev/null || true
-          cp -v msdsn/*_benchmark_test.go ../main-recheck/msdsn/ 2>/dev/null || true
+          shopt -s nullglob
+          for f in *_benchmark_test.go; do cp -v "$f" ../main-recheck/; done
+          for f in msdsn/*_benchmark_test.go; do cp -v "$f" ../main-recheck/msdsn/; done
+          shopt -u nullglob
           ( cd ../main-recheck && go test -run='^$' -bench="$PATTERN" \
             -benchtime=1s -count=10 -benchmem -timeout=15m . ./msdsn ) 2>&1 \
             | tee recheck_old_full.log

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -216,13 +216,21 @@ jobs:
           export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}&trustServerCertificate=true"
           BENCH_PATTERN='Benchmark(BulkMakeParam|ConvertAssign|Decode|Encode|ManglePassword|Parse|Read|RoundTrip|Send|Str2ucs2|TdsBuffer|Ucs22str|Write)'
           git worktree add ../main-bench origin/main
-          # nullglob so a missing match copies nothing instead of erroring, while a
-          # real cp failure still aborts rather than resurfacing as "no output".
-          shopt -s nullglob
-          for f in *_benchmark_test.go; do cp -v "$f" ../main-bench/; done
-          for f in msdsn/*_benchmark_test.go; do cp -v "$f" ../main-bench/msdsn/; done
-          shopt -u nullglob
-          cd ../main-bench
+            # Run the PR's version of a benchmark on both sides so an edit to the
+            # benchmark itself does not read as a change in what it measures.
+            # Files new in this PR are skipped: a benchmark for a type the PR
+            # introduces cannot compile against main, and has no baseline anyway.
+            shopt -s nullglob
+            for f in *_benchmark_test.go msdsn/*_benchmark_test.go; do
+              if [ -e "../main-bench/$f" ]; then cp -v "$f" "../main-bench/$f"; fi
+            done
+            shopt -u nullglob
+            cd ../main-bench
+            if ! go vet . ./msdsn > vet_baseline.log 2>&1; then
+              echo "::error::Baseline does not build with this PR's benchmark files. Put benchmarks for types this PR introduces in their own *_benchmark_test.go file so they can be skipped for the baseline."
+              cat vet_baseline.log
+              exit 1
+            fi
           go test -run='^$' -bench="$BENCH_PATTERN" \
             -benchtime=1s -count=10 -benchmem -timeout=25m . ./msdsn 2>&1 | \
             tee "$GITHUB_WORKSPACE/bench_old_full.log"
@@ -285,9 +293,11 @@ jobs:
           export SQLSERVER_DSN="sqlserver://${SQLUSER}:${SQLPASSWORD}@localhost:1433?database=${DATABASE}&trustServerCertificate=true"
 
           git worktree add ../main-recheck origin/main
+          # Same rule as the baseline: only files the recheck worktree already has.
           shopt -s nullglob
-          for f in *_benchmark_test.go; do cp -v "$f" ../main-recheck/; done
-          for f in msdsn/*_benchmark_test.go; do cp -v "$f" ../main-recheck/msdsn/; done
+          for f in *_benchmark_test.go msdsn/*_benchmark_test.go; do
+            if [ -e "../main-recheck/$f" ]; then cp -v "$f" "../main-recheck/$f"; fi
+          done
           shopt -u nullglob
 
           ( cd ../main-recheck && go test -run='^$' -bench="$PATTERN" \

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -108,6 +108,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      # Inherited from setup-go today, but stated so the fail-fast behaviour of
+      # the benchstat install cannot change under us if that default does.
+      GOTOOLCHAIN: local
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -225,7 +229,7 @@ jobs:
             echo "::error::benchstat produced no output; cannot evaluate regressions"
             exit 1
           fi
-          if ! ROWS=$(grep_ok -cE '^\S+\s+.+(±|~|[+-][0-9])' bench_diff.txt); then
+          if ! ROWS=$(grep_ok -cE '^[^[:space:]]+[[:space:]]+.+(±|~|[+-][0-9])' bench_diff.txt); then
             echo "::error::failed to scan benchstat output; cannot evaluate regressions"
             exit 1
           fi
@@ -236,7 +240,7 @@ jobs:
           fi
           echo "Parsed $ROWS benchmark rows."
           # Report statistically significant improvements (real %, not ~)
-          if grep_ok -v '~' bench_diff.txt | grep -E '^\S+\s+.+\s+-[0-9]+(\.[0-9]+)?%'; then
+          if grep_ok -v '~' bench_diff.txt | grep -E '^[^[:space:]]+[[:space:]]+.+[[:space:]]+-[0-9]+(\.[0-9]+)?%'; then
             echo ""
             echo "::notice::Performance improvements detected (see above)"
           fi
@@ -249,7 +253,7 @@ jobs:
           # failure here means we could not evaluate, which must not read as a pass.
           if ! REGRESSED=$(grep_ok -v '~' bench_diff.txt \
                 | grep_ok -v 'TdsBuffer_Write_Large' \
-                | grep_ok -E '^\S+\s+.+\s+\+[0-9]+(\.[0-9]+)?%' \
+                | grep_ok -E '^[^[:space:]]+[[:space:]]+.+[[:space:]]+\+[0-9]+(\.[0-9]+)?%' \
                 | awk -F'+' '{split($2,a,"%"); if (a[1]+0 >= 15) print}'); then
             echo "::error::failed to evaluate benchmark comparison"
             exit 1

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -126,7 +126,11 @@ jobs:
 
   benchmarks:
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    # A normal run is ~50 minutes: two ~24 minute measurement passes plus setup.
+    # A confirmation re-measures only the flagged benchmarks, but a broad
+    # regression can flag most of them, so budget for it costing as much as a
+    # third and fourth pass. Unused minutes are not billed.
+    timeout-minutes: 120
     permissions:
       contents: read
       pull-requests: write
@@ -322,10 +326,10 @@ jobs:
           for f in msdsn/*_benchmark_test.go; do cp -v "$f" ../main-recheck/msdsn/; done
           shopt -u nullglob
           ( cd ../main-recheck && go test -run='^$' -bench="$PATTERN" \
-            -benchtime=1s -count=10 -benchmem -timeout=15m . ./msdsn ) 2>&1 \
+            -benchtime=1s -count=10 -benchmem -timeout=25m . ./msdsn ) 2>&1 \
             | tee recheck_old_full.log
           go test -run='^$' -bench="$PATTERN" \
-            -benchtime=1s -count=10 -benchmem -timeout=15m . ./msdsn 2>&1 \
+            -benchtime=1s -count=10 -benchmem -timeout=25m . ./msdsn 2>&1 \
             | tee recheck_new_full.log
           git worktree remove ../main-recheck --force
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -66,7 +66,8 @@ jobs:
           # failing to start at it. MSSQL_MEMORY_LIMIT_MB stays under the container
           # cap so the engine leaves room for the rest of the container.
           docker run -m 4GB -e ACCEPT_EULA=1 -e MSSQL_MEMORY_LIMIT_MB=3072 -d --name sqlserver -p 1433:1433 -e SA_PASSWORD=$SQLCMDPASSWORD mcr.microsoft.com/mssql/server:${{ matrix.sqlImage }}
-          # Wait for SQL Server to be ready - retry up to 60 seconds (30 attempts x 2s)
+          # Wait for SQL Server to be ready: 30 attempts, 2s apart. Wall time is well
+          # over 60s because a failed sqlcmd blocks on its own connect timeout first.
           READY=0
           for i in {1..30}; do
             if sqlcmd -S localhost -U sa -P "$SQLCMDPASSWORD" -C -Q "SELECT 1" > /dev/null 2>&1; then
@@ -78,7 +79,7 @@ jobs:
             sleep 2
           done
           if [ "$READY" -eq 0 ]; then
-            echo "SQL Server did not become ready within 60 seconds; aborting tests."
+            echo "SQL Server did not become ready after 30 attempts; aborting tests."
             exit 1
           fi
           go test -coverprofile=coverage.out -covermode=atomic -v ./...

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -229,7 +229,7 @@ jobs:
             echo "::error::benchstat produced no output; cannot evaluate regressions"
             exit 1
           fi
-          if ! ROWS=$(grep_ok -cE '^[^[:space:]]+[[:space:]]+.+(±|~|[+-][0-9])' bench_diff.txt); then
+          if ! ROWS=$(grep_ok -cE '^[^[:space:]]+[[:space:]]+.+(±|~|[0-9]%)' bench_diff.txt); then
             echo "::error::failed to scan benchstat output; cannot evaluate regressions"
             exit 1
           fi
@@ -254,7 +254,7 @@ jobs:
           if ! REGRESSED=$(grep_ok -v '~' bench_diff.txt \
                 | grep_ok -v 'TdsBuffer_Write_Large' \
                 | grep_ok -E '^[^[:space:]]+[[:space:]]+.+[[:space:]]+\+[0-9]+(\.[0-9]+)?%' \
-                | awk -F'+' '{split($2,a,"%"); if (a[1]+0 >= 15) print}'); then
+                | awk '{ if (match($0, /\+[0-9]+(\.[0-9]+)?%/) && substr($0, RSTART+1, RLENGTH-2)+0 >= 15) print }'); then
             echo "::error::failed to evaluate benchmark comparison"
             exit 1
           fi

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -186,7 +186,8 @@ jobs:
       - name: Compare benchmarks
         shell: bash
         run: |
-          go install golang.org/x/perf/cmd/benchstat@latest
+          # Last x/perf commit before its go directive moved to 1.26; setup-go sets GOTOOLCHAIN=local.
+          go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260813145340-fd4a688df892
           echo "## Benchmark Comparison (main vs PR)" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           benchstat -alpha=0.01 bench_old.txt bench_new.txt | tee -a "$GITHUB_STEP_SUMMARY"

--- a/internal/benchgate/benchgate.go
+++ b/internal/benchgate/benchgate.go
@@ -88,10 +88,15 @@ func Parse(r io.Reader) ([]Row, error) {
 		case len(rec) >= 3 && rec[0] == "" && rec[2] == "CI":
 			unit = rec[1]
 			continue
-		case len(rec) > 0 && rec[0] == "":
+		case len(rec) >= 3 && rec[0] == "" && rec[2] == "":
 			// File-list line between tables; the next header sets the unit again.
+			// It is told apart from a header by the empty CI column, so a header
+			// we no longer recognise cannot pass as a separator and quietly drop
+			// its whole table.
 			unit = ""
 			continue
+		case len(rec) > 0 && rec[0] == "":
+			return nil, fmt.Errorf("unrecognised table header %q", strings.Join(rec, ","))
 		}
 		if unit == "" || rec[0] == "geomean" {
 			continue

--- a/internal/benchgate/benchgate.go
+++ b/internal/benchgate/benchgate.go
@@ -1,0 +1,166 @@
+// Command benchgate decides whether a benchstat comparison contains a real
+// performance regression. It reads benchstat's CSV output rather than its table
+// so that units and row names are fields instead of layout.
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// RegressionThreshold is the percentage change treated as a regression, on top
+// of benchstat's own significance test.
+const RegressionThreshold = 15.0
+
+// Row is one benchmark measurement in one unit.
+type Row struct {
+	Name        string
+	Unit        string
+	Delta       float64 // percent, as benchstat signs it
+	Significant bool
+}
+
+// Key identifies a measurement. A benchmark appears once per unit, and those
+// are separate results: sec/op regressing is not B/op regressing.
+type Key struct {
+	Name string
+	Unit string
+}
+
+func (r Row) Key() Key { return Key{r.Name, r.Unit} }
+
+// lowerIsBetter reports whether a positive delta in this unit is bad. Units not
+// listed here (B/s is the one benchstat emits today) improve as they rise, so
+// treating a positive delta as a regression would fail builds on speedups.
+func lowerIsBetter(unit string) bool {
+	switch unit {
+	case "sec/op", "B/op", "allocs/op":
+		return true
+	}
+	return false
+}
+
+var deltaPattern = regexp.MustCompile(`^[+-][0-9]+(\.[0-9]+)?%$`)
+
+// Parse reads benchstat -format=csv output. Rows outside a recognised table, or
+// whose delta it cannot read, are not returned: callers treat an empty result as
+// "could not evaluate" rather than "nothing regressed".
+func Parse(r io.Reader) ([]Row, error) {
+	cr := csv.NewReader(r)
+	cr.FieldsPerRecord = -1
+	cr.LazyQuotes = true
+
+	var rows []Row
+	unit := ""
+	for {
+		rec, err := cr.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read csv: %w", err)
+		}
+		switch {
+		case len(rec) >= 3 && rec[0] == "" && rec[2] == "CI":
+			unit = rec[1]
+			continue
+		case len(rec) > 0 && rec[0] == "":
+			// File-list line between tables; the next header sets the unit again.
+			unit = ""
+			continue
+		}
+		if unit == "" || len(rec) < 6 || rec[0] == "geomean" {
+			continue
+		}
+		row := Row{Name: rec[0], Unit: unit}
+		switch d := strings.TrimSpace(rec[5]); {
+		case d == "~":
+			row.Significant = false
+		case deltaPattern.MatchString(d):
+			v, err := strconv.ParseFloat(strings.TrimSuffix(d, "%"), 64)
+			if err != nil {
+				continue
+			}
+			row.Delta, row.Significant = v, true
+		default:
+			// Unreadable delta: skip, so format drift shrinks the row count.
+			continue
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+// Regressions returns significant changes at least RegressionThreshold worse,
+// in units where worse means larger.
+func Regressions(rows []Row) []Row {
+	var out []Row
+	for _, r := range rows {
+		if r.Significant && lowerIsBetter(r.Unit) && r.Delta >= RegressionThreshold {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// Improvements is the mirror of Regressions, and knows a rising B/s is good.
+func Improvements(rows []Row) []Row {
+	var out []Row
+	for _, r := range rows {
+		if !r.Significant {
+			continue
+		}
+		if lowerIsBetter(r.Unit) && r.Delta < 0 || !lowerIsBetter(r.Unit) && r.Delta > 0 {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+var procSuffix = regexp.MustCompile(`-[0-9]+$`)
+
+// Selector builds a -bench expression for the benchmarks owning these rows.
+// go test splits -bench at '/' and matches each element separately, so a
+// sub-benchmark is addressed through its parent.
+func Selector(rows []Row) string {
+	seen := map[string]bool{}
+	var names []string
+	for _, r := range rows {
+		n := procSuffix.ReplaceAllString(r.Name, "")
+		if i := strings.Index(n, "/"); i >= 0 {
+			n = n[:i]
+		}
+		if n == "" || seen[n] {
+			continue
+		}
+		seen[n] = true
+		names = append(names, regexp.QuoteMeta(n))
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	sort.Strings(names)
+	return "^Benchmark(" + strings.Join(names, "|") + ")$"
+}
+
+// Confirm returns the flagged measurements that regressed again. Matching is by
+// name and unit: the same benchmark regressing in a different metric is not the
+// candidate reproducing.
+func Confirm(recheck []Row, flagged []Key) []Row {
+	want := make(map[Key]bool, len(flagged))
+	for _, k := range flagged {
+		want[k] = true
+	}
+	var out []Row
+	for _, r := range Regressions(recheck) {
+		if want[r.Key()] {
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/internal/benchgate/benchgate.go
+++ b/internal/benchgate/benchgate.go
@@ -175,3 +175,21 @@ func Confirm(recheck []Row, flagged []Key) []Row {
 	}
 	return out
 }
+
+// Unmeasured returns flagged keys the recheck produced no comparable row for.
+// Siblings of a flagged sub-benchmark keep the recheck non-empty, so without
+// this a candidate that never ran again looks the same as one that came back
+// clean, and would be dismissed as runner noise.
+func Unmeasured(recheck []Row, flagged []Key) []Key {
+	seen := make(map[Key]bool, len(recheck))
+	for _, r := range recheck {
+		seen[r.Key()] = true
+	}
+	var out []Key
+	for _, k := range flagged {
+		if !seen[k] {
+			out = append(out, k)
+		}
+	}
+	return out
+}

--- a/internal/benchgate/benchgate.go
+++ b/internal/benchgate/benchgate.go
@@ -34,16 +34,20 @@ type Key struct {
 
 func (r Row) Key() Key { return Key{r.Name, r.Unit} }
 
-// lowerIsBetter reports whether a positive delta in this unit is bad. Units not
-// listed here (B/s is the one benchstat emits today) improve as they rise, so
-// treating a positive delta as a regression would fail builds on speedups.
-func lowerIsBetter(unit string) bool {
-	switch unit {
-	case "sec/op", "B/op", "allocs/op":
-		return true
-	}
-	return false
+// unitDirection maps a benchstat unit to whether smaller is better. Units are
+// listed explicitly because guessing a direction is worse than not knowing one:
+// an unlisted lower-is-better metric such as errors/op would have a rise
+// reported as an improvement and a fall fail the build.
+var unitDirection = map[string]bool{
+	"sec/op":    true,
+	"ns/op":     true,
+	"B/op":      true,
+	"allocs/op": true,
+	"B/s":       false,
+	"MB/s":      false,
 }
+
+func lowerIsBetter(unit string) bool { return unitDirection[unit] }
 
 var deltaPattern = regexp.MustCompile(`^[+-][0-9]+(\.[0-9]+)?%$`)
 
@@ -97,6 +101,12 @@ func Parse(r io.Reader) ([]Row, error) {
 			// Dropping this row would hide a regression behind the rows that did
 			// parse, so treat unreadable output as format drift and fail closed.
 			return nil, fmt.Errorf("unreadable delta %q for %s (%s)", d, rec[0], unit)
+		}
+		// A significant change in a unit with no known direction cannot be
+		// classified, and guessing would invert it. An insignificant row is
+		// harmless whatever the unit, so it does not need a direction.
+		if _, known := unitDirection[unit]; !known && row.Significant {
+			return nil, fmt.Errorf("unit %q for %s has no known direction; add it to unitDirection in internal/benchgate", unit, rec[0])
 		}
 		rows = append(rows, row)
 	}

--- a/internal/benchgate/benchgate.go
+++ b/internal/benchgate/benchgate.go
@@ -99,11 +99,11 @@ func Parse(r io.Reader) ([]Row, error) {
 			return nil, fmt.Errorf("unrecognised table header %q", strings.Join(rec, ","))
 		}
 		if unit == "" {
-			// The goos/goarch/pkg preamble arrives before any header and is a
-			// single column. A full-width record here means a header went
-			// missing, and skipping it would drop whatever it says behind the
-			// tables that did parse.
-			if len(rec) >= 6 && rec[0] != "" {
+			// benchstat's preamble (goos, goarch, pkg, cpu) is single-column, so
+			// anything wider with no table in scope means a header went missing.
+			// Skipping it would drop whatever it says behind the tables that did
+			// parse, whatever its width.
+			if len(rec) > 1 {
 				return nil, fmt.Errorf("record outside any table: %q", strings.Join(rec, ","))
 			}
 			continue

--- a/internal/benchgate/benchgate.go
+++ b/internal/benchgate/benchgate.go
@@ -47,10 +47,10 @@ func lowerIsBetter(unit string) bool {
 
 var deltaPattern = regexp.MustCompile(`^[+-][0-9]+(\.[0-9]+)?%$`)
 
-// Parse reads benchstat -format=csv output. Rows outside a recognised table, or
-// whose delta it cannot read, are not returned: callers treat an empty result as
-// "could not evaluate" rather than "nothing regressed". A delta that has the
-// expected shape but will not convert is an error, not a dropped row.
+// Parse reads benchstat -format=csv output. Rows outside a recognised table are
+// ignored, and rows whose delta it cannot read are an error rather than a silent
+// drop, so format drift cannot hide a regression behind the rows that did parse.
+// Benchmarks present on only one side carry no delta and are skipped.
 func Parse(r io.Reader) ([]Row, error) {
 	cr := csv.NewReader(r)
 	cr.FieldsPerRecord = -1
@@ -80,6 +80,9 @@ func Parse(r io.Reader) ([]Row, error) {
 		}
 		row := Row{Name: rec[0], Unit: unit}
 		switch d := strings.TrimSpace(rec[5]); {
+		case d == "":
+			// Benchmark present on only one side, so there is nothing to compare.
+			continue
 		case d == "~":
 			row.Significant = false
 		case deltaPattern.MatchString(d):
@@ -91,20 +94,25 @@ func Parse(r io.Reader) ([]Row, error) {
 			}
 			row.Delta, row.Significant = v, true
 		default:
-			// Unreadable delta: skip, so format drift shrinks the row count.
-			continue
+			// Dropping this row would hide a regression behind the rows that did
+			// parse, so treat unreadable output as format drift and fail closed.
+			return nil, fmt.Errorf("unreadable delta %q for %s (%s)", d, rec[0], unit)
 		}
 		rows = append(rows, row)
 	}
 	return rows, nil
 }
 
-// Regressions returns significant changes at least RegressionThreshold worse,
-// in units where worse means larger.
+// Regressions returns significant changes at least RegressionThreshold worse.
+// Worse means larger for units like sec/op and smaller for throughput.
 func Regressions(rows []Row) []Row {
 	var out []Row
 	for _, r := range rows {
-		if r.Significant && lowerIsBetter(r.Unit) && r.Delta >= RegressionThreshold {
+		if !r.Significant {
+			continue
+		}
+		if lowerIsBetter(r.Unit) && r.Delta >= RegressionThreshold ||
+			!lowerIsBetter(r.Unit) && r.Delta <= -RegressionThreshold {
 			out = append(out, r)
 		}
 	}

--- a/internal/benchgate/benchgate.go
+++ b/internal/benchgate/benchgate.go
@@ -98,7 +98,17 @@ func Parse(r io.Reader) ([]Row, error) {
 		case len(rec) > 0 && rec[0] == "":
 			return nil, fmt.Errorf("unrecognised table header %q", strings.Join(rec, ","))
 		}
-		if unit == "" || rec[0] == "geomean" {
+		if unit == "" {
+			// The goos/goarch/pkg preamble arrives before any header and is a
+			// single column. A full-width record here means a header went
+			// missing, and skipping it would drop whatever it says behind the
+			// tables that did parse.
+			if len(rec) >= 6 && rec[0] != "" {
+				return nil, fmt.Errorf("record outside any table: %q", strings.Join(rec, ","))
+			}
+			continue
+		}
+		if rec[0] == "geomean" {
 			continue
 		}
 		if len(rec) < 6 {

--- a/internal/benchgate/benchgate.go
+++ b/internal/benchgate/benchgate.go
@@ -49,7 +49,8 @@ var deltaPattern = regexp.MustCompile(`^[+-][0-9]+(\.[0-9]+)?%$`)
 
 // Parse reads benchstat -format=csv output. Rows outside a recognised table, or
 // whose delta it cannot read, are not returned: callers treat an empty result as
-// "could not evaluate" rather than "nothing regressed".
+// "could not evaluate" rather than "nothing regressed". A delta that has the
+// expected shape but will not convert is an error, not a dropped row.
 func Parse(r io.Reader) ([]Row, error) {
 	cr := csv.NewReader(r)
 	cr.FieldsPerRecord = -1
@@ -84,7 +85,9 @@ func Parse(r io.Reader) ([]Row, error) {
 		case deltaPattern.MatchString(d):
 			v, err := strconv.ParseFloat(strings.TrimSuffix(d, "%"), 64)
 			if err != nil {
-				continue
+				// The delta has the expected shape but will not convert, so our
+				// own assumption is broken. Fail closed rather than drop the row.
+				return nil, fmt.Errorf("delta %q for %s: %w", d, rec[0], err)
 			}
 			row.Delta, row.Significant = v, true
 		default:

--- a/internal/benchgate/benchgate.go
+++ b/internal/benchgate/benchgate.go
@@ -49,6 +49,21 @@ var unitDirection = map[string]bool{
 
 func lowerIsBetter(unit string) bool { return unitDirection[unit] }
 
+// field returns a trimmed column, or "" when the record is shorter than that.
+func field(rec []string, i int) string {
+	if i >= len(rec) {
+		return ""
+	}
+	return strings.TrimSpace(rec[i])
+}
+
+// bothSidesMeasured reports whether the record carries an old and a new
+// measurement. benchstat writes only one side's columns for a benchmark that
+// ran on one side alone, so both being present means a delta should exist.
+func bothSidesMeasured(rec []string) bool {
+	return field(rec, 1) != "" && field(rec, 3) != ""
+}
+
 var deltaPattern = regexp.MustCompile(`^[+-][0-9]+(\.[0-9]+)?%$`)
 
 // Parse reads benchstat -format=csv output. Rows outside a recognised table are
@@ -58,7 +73,6 @@ var deltaPattern = regexp.MustCompile(`^[+-][0-9]+(\.[0-9]+)?%$`)
 func Parse(r io.Reader) ([]Row, error) {
 	cr := csv.NewReader(r)
 	cr.FieldsPerRecord = -1
-	cr.LazyQuotes = true
 
 	var rows []Row
 	unit := ""
@@ -79,13 +93,24 @@ func Parse(r io.Reader) ([]Row, error) {
 			unit = ""
 			continue
 		}
-		if unit == "" || len(rec) < 6 || rec[0] == "geomean" {
+		if unit == "" || rec[0] == "geomean" {
+			continue
+		}
+		if len(rec) < 6 {
+			// benchstat truncates rows for benchmarks measured on only one side.
+			// A short row carrying both measurements is drift, not one-sided.
+			if bothSidesMeasured(rec) {
+				return nil, fmt.Errorf("row for %s (%s) has both measurements but no delta", rec[0], unit)
+			}
 			continue
 		}
 		row := Row{Name: rec[0], Unit: unit}
 		switch d := strings.TrimSpace(rec[5]); {
 		case d == "":
-			// Benchmark present on only one side, so there is nothing to compare.
+			if bothSidesMeasured(rec) {
+				return nil, fmt.Errorf("empty delta for %s (%s) with both measurements present", rec[0], unit)
+			}
+			// Measured on only one side, so there is nothing to compare.
 			continue
 		case d == "~":
 			row.Significant = false

--- a/internal/benchgate/benchgate.go
+++ b/internal/benchgate/benchgate.go
@@ -19,20 +19,22 @@ const RegressionThreshold = 15.0
 
 // Row is one benchmark measurement in one unit.
 type Row struct {
+	Package     string
 	Name        string
 	Unit        string
 	Delta       float64 // percent, as benchstat signs it
 	Significant bool
 }
 
-// Key identifies a measurement. A benchmark appears once per unit, and those
-// are separate results: sec/op regressing is not B/op regressing.
+// Key identifies a measurement. Package and unit are both significant: the
+// workflow measures multiple packages, and each benchmark appears once per unit.
 type Key struct {
-	Name string
-	Unit string
+	Package string
+	Name    string
+	Unit    string
 }
 
-func (r Row) Key() Key { return Key{r.Name, r.Unit} }
+func (r Row) Key() Key { return Key{r.Package, r.Name, r.Unit} }
 
 // unitDirection maps a benchstat unit to whether smaller is better. Units are
 // listed explicitly because guessing a direction is worse than not knowing one:
@@ -75,6 +77,7 @@ func Parse(r io.Reader) ([]Row, error) {
 	cr.FieldsPerRecord = -1
 
 	var rows []Row
+	pkg := ""
 	unit := ""
 	for {
 		rec, err := cr.Read()
@@ -83,6 +86,10 @@ func Parse(r io.Reader) ([]Row, error) {
 		}
 		if err != nil {
 			return nil, fmt.Errorf("read csv: %w", err)
+		}
+		if len(rec) == 1 && strings.HasPrefix(rec[0], "pkg: ") {
+			pkg = strings.TrimSpace(strings.TrimPrefix(rec[0], "pkg: "))
+			continue
 		}
 		switch {
 		case len(rec) >= 3 && rec[0] == "" && rec[2] == "CI":
@@ -119,7 +126,7 @@ func Parse(r io.Reader) ([]Row, error) {
 			}
 			continue
 		}
-		row := Row{Name: rec[0], Unit: unit}
+		row := Row{Package: pkg, Name: rec[0], Unit: unit}
 		switch d := strings.TrimSpace(rec[5]); {
 		case d == "":
 			if bothSidesMeasured(rec) {
@@ -210,8 +217,8 @@ func Selector(rows []Row) string {
 }
 
 // Confirm returns the flagged measurements that regressed again. Matching is by
-// name and unit: the same benchmark regressing in a different metric is not the
-// candidate reproducing.
+// package, name, and unit so a same-named benchmark or different metric is not
+// mistaken for the candidate reproducing.
 func Confirm(recheck []Row, flagged []Key) []Row {
 	want := make(map[Key]bool, len(flagged))
 	for _, k := range flagged {

--- a/internal/benchgate/benchgate_test.go
+++ b/internal/benchgate/benchgate_test.go
@@ -70,14 +70,14 @@ func TestParseHandlesQuotedNameContainingComma(t *testing.T) {
 }
 
 // If benchstat renames a header column the rows are no longer interpretable.
-// Returning none makes the caller fail closed instead of reporting "clean".
+// Erroring keeps the caller from reporting "clean" off a table it cannot read.
 func TestParseFailsClosedOnHeaderDrift(t *testing.T) {
 	const in = `,old,,new,,,
 ,sec/op,Confidence,sec/op,Confidence,vs base,P
 Foo-4,1e-07,0%,1.25e-07,0%,+22.00%,p=0.000 n=10
 `
-	if rows := parseString(t, in); len(rows) != 0 {
-		t.Fatalf("got %d rows, want 0: %+v", len(rows), rows)
+	if _, err := Parse(strings.NewReader(in)); err == nil {
+		t.Fatal("want an error for a drifted header")
 	}
 }
 

--- a/internal/benchgate/benchgate_test.go
+++ b/internal/benchgate/benchgate_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Shapes below are real `benchstat -format=csv` output, including the header
+// lines it prints before each table.
+const secOpTable = `goos: linux
+goarch: amd64
+pkg: github.com/microsoft/go-mssqldb
+cpu: Test
+,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Foo-4,1e-07,0%,1.25e-07,0%,+25.00%,p=0.000 n=10
+Bar-4,1e-07,0%,1.01e-07,0%,~,p=0.400 n=10
+geomean,1e-07,,1.12e-07,,+12.00%,
+`
+
+func parseString(t *testing.T, s string) []Row {
+	t.Helper()
+	rows, err := Parse(strings.NewReader(s))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	return rows
+}
+
+func TestParseReadsNameUnitAndDelta(t *testing.T) {
+	rows := parseString(t, secOpTable)
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (geomean must be excluded): %+v", len(rows), rows)
+	}
+	if rows[0] != (Row{Name: "Foo-4", Unit: "sec/op", Delta: 25, Significant: true}) {
+		t.Errorf("first row = %+v", rows[0])
+	}
+	if rows[1].Significant {
+		t.Errorf("~ must not be significant: %+v", rows[1])
+	}
+}
+
+// geomean carries a percentage but is a summary. Selecting it with -bench
+// matches no benchmark, so it must never reach the flagged set.
+func TestParseExcludesGeomean(t *testing.T) {
+	for _, r := range parseString(t, secOpTable) {
+		if r.Name == "geomean" {
+			t.Fatal("geomean was parsed as a benchmark row")
+		}
+	}
+}
+
+// benchstat quotes names containing commas. Splitting on commas shifts every
+// field and silently drops the row.
+func TestParseHandlesQuotedNameContainingComma(t *testing.T) {
+	const in = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+"Foo/size=1,024-4",1e-07,0%,1.25e-07,0%,+25.00%,p=0.000 n=10
+`
+	rows := parseString(t, in)
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1: %+v", len(rows), rows)
+	}
+	if rows[0].Name != "Foo/size=1,024-4" {
+		t.Errorf("name = %q", rows[0].Name)
+	}
+	if got := Regressions(rows); len(got) != 1 {
+		t.Errorf("regression on a comma-named benchmark was dropped")
+	}
+}
+
+// If benchstat renames a header column the rows are no longer interpretable.
+// Returning none makes the caller fail closed instead of reporting "clean".
+func TestParseFailsClosedOnHeaderDrift(t *testing.T) {
+	const in = `,old,,new,,,
+,sec/op,Confidence,sec/op,Confidence,vs base,P
+Foo-4,1e-07,0%,1.25e-07,0%,+22.00%,p=0.000 n=10
+`
+	if rows := parseString(t, in); len(rows) != 0 {
+		t.Fatalf("got %d rows, want 0: %+v", len(rows), rows)
+	}
+}
+
+func TestParseFailsClosedOnUnreadableDelta(t *testing.T) {
+	const in = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Foo-4,1e-07,0%,1.25e-07,0%,20 percent worse,p=0.000 n=10
+`
+	if rows := parseString(t, in); len(rows) != 0 {
+		t.Fatalf("got %d rows, want 0: %+v", len(rows), rows)
+	}
+}
+
+// A unit must not carry over into the next table.
+func TestParseResetsUnitBetweenTables(t *testing.T) {
+	const in = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Foo-4,1e-07,0%,1.01e-07,0%,~,p=0.400 n=10
+
+,old,,new,,,
+,B/s,CI,B/s,CI,vs base,P
+Bar-4,5e+07,0%,6.25e+07,0%,+25.00%,p=0.000 n=10
+`
+	rows := parseString(t, in)
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows: %+v", len(rows), rows)
+	}
+	if rows[1].Unit != "B/s" {
+		t.Errorf("second row unit = %q, want B/s", rows[1].Unit)
+	}
+}
+
+// The gated benchmarks call SetBytes, so a speedup shows as -20% sec/op and
+// +25% B/s. Treating any positive delta as worse fails the build on a win.
+func TestRegressionsIgnoreThroughputGains(t *testing.T) {
+	rows := []Row{
+		{Name: "Foo-4", Unit: "sec/op", Delta: -20, Significant: true},
+		{Name: "Foo-4", Unit: "B/s", Delta: +25, Significant: true},
+	}
+	if got := Regressions(rows); len(got) != 0 {
+		t.Fatalf("a 20%% speedup was reported as a regression: %+v", got)
+	}
+	if got := Improvements(rows); len(got) != 2 {
+		t.Errorf("want both rows reported as improvements, got %+v", got)
+	}
+}
+
+func TestRegressionsThreshold(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		row   Row
+		wants bool
+	}{
+		{"above threshold", Row{"Foo-4", "sec/op", 25, true}, true},
+		{"exactly at threshold", Row{"Foo-4", "sec/op", 15, true}, true},
+		{"below threshold", Row{"Foo-4", "sec/op", 14.99, true}, false},
+		{"not significant", Row{"Foo-4", "sec/op", 25, false}, false},
+		{"allocs count", Row{"Foo-4", "allocs/op", 25, true}, true},
+		{"bytes per op", Row{"Foo-4", "B/op", 25, true}, true},
+		{"throughput", Row{"Foo-4", "B/s", 25, true}, false},
+		{"unknown unit", Row{"Foo-4", "widgets/op", 25, true}, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := len(Regressions([]Row{tt.row})) == 1
+			if got != tt.wants {
+				t.Errorf("Regressions(%+v) flagged=%v, want %v", tt.row, got, tt.wants)
+			}
+		})
+	}
+}
+
+func TestSelector(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		rows []Row
+		want string
+	}{
+		{"top level", []Row{{Name: "Foo-4"}}, "^Benchmark(Foo)$"},
+		{"sub-benchmark uses its parent", []Row{{Name: "Foo/Sub-4"}}, "^Benchmark(Foo)$"},
+		{"two subs collapse to one parent", []Row{{Name: "Foo/A-4"}, {Name: "Foo/B-4"}}, "^Benchmark(Foo)$"},
+		{"sorted and deduplicated", []Row{{Name: "Zed-4"}, {Name: "Abc-4"}, {Name: "Zed-4"}}, "^Benchmark(Abc|Zed)$"},
+		{"digits in the name survive", []Row{{Name: "ParseError72-4"}}, "^Benchmark(ParseError72)$"},
+		{"same benchmark two units", []Row{{Name: "Foo-4", Unit: "sec/op"}, {Name: "Foo-4", Unit: "B/op"}}, "^Benchmark(Foo)$"},
+		{"nothing flagged", nil, ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Selector(tt.rows); got != tt.want {
+				t.Errorf("Selector() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A name reaching a regex must not be able to change its meaning.
+func TestSelectorQuotesMetacharacters(t *testing.T) {
+	got := Selector([]Row{{Name: "Foo.Bar+Baz-4"}})
+	if strings.Contains(got, "Foo.Bar+Baz") {
+		t.Fatalf("metacharacters were not quoted: %s", got)
+	}
+}
+
+func TestConfirmMatchesNameAndUnit(t *testing.T) {
+	flagged := []Key{{Name: "Foo-4", Unit: "sec/op"}}
+
+	sameMetric := []Row{{Name: "Foo-4", Unit: "sec/op", Delta: 25, Significant: true}}
+	if got := Confirm(sameMetric, flagged); len(got) != 1 {
+		t.Errorf("a reproduced sec/op regression was not confirmed")
+	}
+
+	// The flagged timing regression did not reproduce; allocations regressed
+	// instead. That is a different result, not a confirmation.
+	otherMetric := []Row{
+		{Name: "Foo-4", Unit: "sec/op", Delta: 1, Significant: false},
+		{Name: "Foo-4", Unit: "B/op", Delta: 25, Significant: true},
+	}
+	if got := Confirm(otherMetric, flagged); len(got) != 0 {
+		t.Errorf("a different metric confirmed the candidate: %+v", got)
+	}
+
+	otherBenchmark := []Row{{Name: "Bar-4", Unit: "sec/op", Delta: 25, Significant: true}}
+	if got := Confirm(otherBenchmark, flagged); len(got) != 0 {
+		t.Errorf("a different benchmark confirmed the candidate: %+v", got)
+	}
+}
+
+func TestConfirmRequiresReproduction(t *testing.T) {
+	flagged := []Key{{Name: "Foo-4", Unit: "sec/op"}}
+	notAgain := []Row{{Name: "Foo-4", Unit: "sec/op", Delta: 1.2, Significant: true}}
+	if got := Confirm(notAgain, flagged); len(got) != 0 {
+		t.Errorf("a 1.2%% second measurement confirmed a 25%% candidate: %+v", got)
+	}
+}

--- a/internal/benchgate/benchgate_test.go
+++ b/internal/benchgate/benchgate_test.go
@@ -32,7 +32,7 @@ func TestParseReadsNameUnitAndDelta(t *testing.T) {
 	if len(rows) != 2 {
 		t.Fatalf("got %d rows, want 2 (geomean must be excluded): %+v", len(rows), rows)
 	}
-	if rows[0] != (Row{Name: "Foo-4", Unit: "sec/op", Delta: 25, Significant: true}) {
+	if rows[0] != (Row{Package: "github.com/microsoft/go-mssqldb", Name: "Foo-4", Unit: "sec/op", Delta: 25, Significant: true}) {
 		t.Errorf("first row = %+v", rows[0])
 	}
 	if rows[1].Significant {
@@ -165,6 +165,26 @@ Bar-4,5e+07,0%,6.25e+07,0%,+25.00%,p=0.000 n=10
 	}
 }
 
+func TestParseTracksPackagePreamble(t *testing.T) {
+	const in = `pkg: example.com/root
+,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Foo-4,1e-07,0%,1.25e-07,0%,+25.00%,p=0.000 n=10
+
+pkg: example.com/root/msdsn
+,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Foo-4,1e-07,0%,1.25e-07,0%,+25.00%,p=0.000 n=10
+`
+	rows := parseString(t, in)
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2: %+v", len(rows), rows)
+	}
+	if rows[0].Package != "example.com/root" || rows[1].Package != "example.com/root/msdsn" {
+		t.Errorf("packages = %q, %q", rows[0].Package, rows[1].Package)
+	}
+}
+
 // The mirror of the gain case: throughput falling is a regression even though
 // the delta is negative, so the threshold applies in the opposite direction.
 func TestRegressionsCatchThroughputLosses(t *testing.T) {
@@ -211,14 +231,14 @@ func TestRegressionsThreshold(t *testing.T) {
 		row   Row
 		wants bool
 	}{
-		{"above threshold", Row{"Foo-4", "sec/op", 25, true}, true},
-		{"exactly at threshold", Row{"Foo-4", "sec/op", 15, true}, true},
-		{"below threshold", Row{"Foo-4", "sec/op", 14.99, true}, false},
-		{"not significant", Row{"Foo-4", "sec/op", 25, false}, false},
-		{"allocs count", Row{"Foo-4", "allocs/op", 25, true}, true},
-		{"bytes per op", Row{"Foo-4", "B/op", 25, true}, true},
-		{"throughput", Row{"Foo-4", "B/s", 25, true}, false},
-		{"unknown unit", Row{"Foo-4", "widgets/op", 25, true}, false},
+		{"above threshold", Row{Name: "Foo-4", Unit: "sec/op", Delta: 25, Significant: true}, true},
+		{"exactly at threshold", Row{Name: "Foo-4", Unit: "sec/op", Delta: 15, Significant: true}, true},
+		{"below threshold", Row{Name: "Foo-4", Unit: "sec/op", Delta: 14.99, Significant: true}, false},
+		{"not significant", Row{Name: "Foo-4", Unit: "sec/op", Delta: 25}, false},
+		{"allocs count", Row{Name: "Foo-4", Unit: "allocs/op", Delta: 25, Significant: true}, true},
+		{"bytes per op", Row{Name: "Foo-4", Unit: "B/op", Delta: 25, Significant: true}, true},
+		{"throughput", Row{Name: "Foo-4", Unit: "B/s", Delta: 25, Significant: true}, false},
+		{"unknown unit", Row{Name: "Foo-4", Unit: "widgets/op", Delta: 25, Significant: true}, false},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := len(Regressions([]Row{tt.row})) == 1
@@ -288,5 +308,16 @@ func TestConfirmRequiresReproduction(t *testing.T) {
 	notAgain := []Row{{Name: "Foo-4", Unit: "sec/op", Delta: 1.2, Significant: true}}
 	if got := Confirm(notAgain, flagged); len(got) != 0 {
 		t.Errorf("a 1.2%% second measurement confirmed a 25%% candidate: %+v", got)
+	}
+}
+
+func TestConfirmMatchesPackage(t *testing.T) {
+	flagged := []Key{{Package: "example.com/root", Name: "Foo-4", Unit: "sec/op"}}
+	recheck := []Row{
+		{Package: "example.com/root", Name: "Foo-4", Unit: "sec/op", Delta: 1, Significant: false},
+		{Package: "example.com/root/msdsn", Name: "Foo-4", Unit: "sec/op", Delta: 25, Significant: true},
+	}
+	if got := Confirm(recheck, flagged); len(got) != 0 {
+		t.Errorf("a same-named benchmark in another package confirmed the candidate: %+v", got)
 	}
 }

--- a/internal/benchgate/benchgate_test.go
+++ b/internal/benchgate/benchgate_test.go
@@ -81,13 +81,68 @@ Foo-4,1e-07,0%,1.25e-07,0%,+22.00%,p=0.000 n=10
 	}
 }
 
+// An unreadable delta must be an error, not a dropped row: dropping it would
+// let a regression hide behind the rows that did parse.
 func TestParseFailsClosedOnUnreadableDelta(t *testing.T) {
 	const in = `,old,,new,,,
 ,sec/op,CI,sec/op,CI,vs base,P
 Foo-4,1e-07,0%,1.25e-07,0%,20 percent worse,p=0.000 n=10
 `
-	if rows := parseString(t, in); len(rows) != 0 {
-		t.Fatalf("got %d rows, want 0: %+v", len(rows), rows)
+	if _, err := Parse(strings.NewReader(in)); err == nil {
+		t.Fatal("want an error for an unreadable delta")
+	}
+}
+
+// The dangerous shape: one row parses clean and the regression is unreadable.
+// A row count alone would look healthy, so this must fail the whole parse.
+func TestParseFailsClosedOnMixedValidAndUnreadableRows(t *testing.T) {
+	const in = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Clean-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
+Regressed-4,1e-07,0%,1.25e-07,0%,25 percent worse,p=0.000 n=10
+`
+	rows, err := Parse(strings.NewReader(in))
+	if err == nil {
+		t.Fatalf("unreadable regression was hidden behind a clean row: %+v", rows)
+	}
+	if !strings.Contains(err.Error(), "Regressed-4") {
+		t.Errorf("error = %v, want it to name the offending row", err)
+	}
+}
+
+// Benchmarks present on only one side have no delta to read. benchstat emits
+// them as short rows, and they must not be mistaken for format drift.
+func TestParseSkipsOneSidedBenchmarks(t *testing.T) {
+	const in = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Removed-4,1e-06,∞
+Added-4,,,1.5e-06,∞
+Both-4,2e-06,0%,2e-06,0%,~,p=0.900 n=10
+`
+	rows, err := Parse(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Name != "Both-4" {
+		t.Fatalf("got %+v, want only Both-4", rows)
+	}
+}
+
+// Today benchstat truncates one-sided rows, so this full-width shape does not
+// occur. A blank delta still means "no comparison", which is a skip and not the
+// format drift that must fail the parse.
+func TestParseSkipsFullWidthRowWithBlankDelta(t *testing.T) {
+	const in = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Added-4,,,1.5e-06,∞,,
+Both-4,2e-06,0%,2e-06,0%,~,p=0.900 n=10
+`
+	rows, err := Parse(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Name != "Both-4" {
+		t.Fatalf("got %+v, want only Both-4", rows)
 	}
 }
 
@@ -107,6 +162,31 @@ Bar-4,5e+07,0%,6.25e+07,0%,+25.00%,p=0.000 n=10
 	}
 	if rows[1].Unit != "B/s" {
 		t.Errorf("second row unit = %q, want B/s", rows[1].Unit)
+	}
+}
+
+// The mirror of the gain case: throughput falling is a regression even though
+// the delta is negative, so the threshold applies in the opposite direction.
+func TestRegressionsCatchThroughputLosses(t *testing.T) {
+	rows := []Row{
+		{Name: "Foo-4", Unit: "B/s", Delta: -20, Significant: true},
+	}
+	got := Regressions(rows)
+	if len(got) != 1 {
+		t.Fatalf("a 20%% throughput loss was not flagged: %+v", got)
+	}
+	if got[0].Unit != "B/s" {
+		t.Errorf("unit = %q, want B/s", got[0].Unit)
+	}
+	if imp := Improvements(rows); len(imp) != 0 {
+		t.Errorf("a throughput loss was reported as an improvement: %+v", imp)
+	}
+}
+
+func TestRegressionsIgnoreSmallThroughputLosses(t *testing.T) {
+	rows := []Row{{Name: "Foo-4", Unit: "B/s", Delta: -14.9, Significant: true}}
+	if got := Regressions(rows); len(got) != 0 {
+		t.Fatalf("a sub-threshold throughput loss was flagged: %+v", got)
 	}
 }
 

--- a/internal/benchgate/main.go
+++ b/internal/benchgate/main.go
@@ -120,14 +120,21 @@ func confirm(args []string) (int, error) {
 		return exitFailure, fmt.Errorf("no flagged rows in %s", *flaggedPath)
 	}
 	got := Confirm(rows, flagged)
-	if len(got) == 0 {
-		fmt.Println("::warning::Flagged regression did not reproduce; treating the first measurement as runner noise.")
-		return exitClean, nil
+	if len(got) > 0 {
+		for _, r := range got {
+			fmt.Printf("  reproduced: %s %+.2f%% %s\n", r.Name, r.Delta, r.Unit)
+		}
+		return exitFound, nil
 	}
-	for _, r := range got {
-		fmt.Printf("  reproduced: %s %+.2f%% %s\n", r.Name, r.Delta, r.Unit)
+	if un := Unmeasured(rows, flagged); len(un) > 0 {
+		names := make([]string, len(un))
+		for i, k := range un {
+			names[i] = fmt.Sprintf("%s (%s)", k.Name, k.Unit)
+		}
+		return exitFailure, fmt.Errorf("confirmation run did not remeasure %s; the candidate is unevaluated, not noise", strings.Join(names, ", "))
 	}
-	return exitFound, nil
+	fmt.Println("::warning::Flagged regression did not reproduce; treating the first measurement as runner noise.")
+	return exitClean, nil
 }
 
 func writeFlagged(path string, rows []Row) error {

--- a/internal/benchgate/main.go
+++ b/internal/benchgate/main.go
@@ -23,7 +23,7 @@ func main() {
 // run holds everything main does apart from exiting, so it can be tested.
 func run(args []string, out io.Writer) int {
 	if len(args) < 1 {
-		fmt.Fprintln(out, "usage: benchgate detect|confirm [flags]")
+		_, _ = fmt.Fprintln(out, "usage: benchgate detect|confirm [flags]")
 		return exitFailure
 	}
 	var err error
@@ -38,7 +38,7 @@ func run(args []string, out io.Writer) int {
 		code = exitFailure
 	}
 	if err != nil {
-		fmt.Fprintf(out, "::error::%v\n", err)
+		_, _ = fmt.Fprintf(out, "::error::%v\n", err)
 		return exitFailure
 	}
 	return code
@@ -49,7 +49,7 @@ func parseFile(path string) ([]Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return Parse(f)
 }
 
@@ -133,7 +133,7 @@ func confirm(args []string) (int, error) {
 func writeFlagged(path string, rows []Row) error {
 	var b strings.Builder
 	for _, r := range rows {
-		fmt.Fprintf(&b, "%s\t%s\n", r.Name, r.Unit)
+		_, _ = fmt.Fprintf(&b, "%s\t%s\n", r.Name, r.Unit)
 	}
 	return os.WriteFile(path, []byte(b.String()), 0o644)
 }
@@ -143,7 +143,7 @@ func readFlagged(path string) ([]Key, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	var keys []Key
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {

--- a/internal/benchgate/main.go
+++ b/internal/benchgate/main.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Exit codes the workflow branches on.
+const (
+	exitClean   = 0
+	exitFailure = 1 // could not evaluate; fail closed
+	exitFound   = 2 // regressions detected or reproduced
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: benchgate detect|confirm [flags]")
+		os.Exit(exitFailure)
+	}
+	var err error
+	var code int
+	switch os.Args[1] {
+	case "detect":
+		code, err = detect(os.Args[2:])
+	case "confirm":
+		code, err = confirm(os.Args[2:])
+	default:
+		err = fmt.Errorf("unknown subcommand %q", os.Args[1])
+		code = exitFailure
+	}
+	if err != nil {
+		fmt.Printf("::error::%v\n", err)
+		os.Exit(exitFailure)
+	}
+	os.Exit(code)
+}
+
+func parseFile(path string) ([]Row, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return Parse(f)
+}
+
+func detect(args []string) (int, error) {
+	fs := flag.NewFlagSet("detect", flag.ContinueOnError)
+	csvPath := fs.String("csv", "", "benchstat -format=csv output")
+	flaggedPath := fs.String("flagged", "", "file to write flagged name/unit pairs to")
+	selectorPath := fs.String("selector", "", "file to write the -bench selector to")
+	if err := fs.Parse(args); err != nil {
+		return exitFailure, err
+	}
+	rows, err := parseFile(*csvPath)
+	if err != nil {
+		return exitFailure, err
+	}
+	if len(rows) == 0 {
+		return exitFailure, fmt.Errorf("no comparable rows in %s; benchstat output not recognised", *csvPath)
+	}
+	fmt.Printf("Parsed %d benchmark rows.\n", len(rows))
+
+	if imp := Improvements(rows); len(imp) > 0 {
+		for _, r := range imp {
+			fmt.Printf("  improved: %s %+.2f%% %s\n", r.Name, r.Delta, r.Unit)
+		}
+		fmt.Println("::notice::Performance improvements detected (see above)")
+	}
+
+	reg := Regressions(rows)
+	if len(reg) == 0 {
+		fmt.Println("No significant regressions detected.")
+		return exitClean, nil
+	}
+	for _, r := range reg {
+		fmt.Printf("  candidate: %s %+.2f%% %s\n", r.Name, r.Delta, r.Unit)
+	}
+	if *flaggedPath != "" {
+		if err := writeFlagged(*flaggedPath, reg); err != nil {
+			return exitFailure, err
+		}
+	}
+	if *selectorPath != "" {
+		if err := os.WriteFile(*selectorPath, []byte(Selector(reg)+"\n"), 0o644); err != nil {
+			return exitFailure, err
+		}
+	}
+	return exitFound, nil
+}
+
+func confirm(args []string) (int, error) {
+	fs := flag.NewFlagSet("confirm", flag.ContinueOnError)
+	csvPath := fs.String("csv", "", "benchstat -format=csv output for the confirmation run")
+	flaggedPath := fs.String("flagged", "", "name/unit pairs written by detect")
+	if err := fs.Parse(args); err != nil {
+		return exitFailure, err
+	}
+	rows, err := parseFile(*csvPath)
+	if err != nil {
+		return exitFailure, err
+	}
+	if len(rows) == 0 {
+		return exitFailure, fmt.Errorf("no comparable rows in %s; confirmation run produced nothing to evaluate", *csvPath)
+	}
+	flagged, err := readFlagged(*flaggedPath)
+	if err != nil {
+		return exitFailure, err
+	}
+	if len(flagged) == 0 {
+		return exitFailure, fmt.Errorf("no flagged rows in %s", *flaggedPath)
+	}
+	got := Confirm(rows, flagged)
+	if len(got) == 0 {
+		fmt.Println("::warning::Flagged regression did not reproduce; treating the first measurement as runner noise.")
+		return exitClean, nil
+	}
+	for _, r := range got {
+		fmt.Printf("  reproduced: %s %+.2f%% %s\n", r.Name, r.Delta, r.Unit)
+	}
+	return exitFound, nil
+}
+
+func writeFlagged(path string, rows []Row) error {
+	var b strings.Builder
+	for _, r := range rows {
+		fmt.Fprintf(&b, "%s\t%s\n", r.Name, r.Unit)
+	}
+	return os.WriteFile(path, []byte(b.String()), 0o644)
+}
+
+func readFlagged(path string) ([]Key, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var keys []Key
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		parts := strings.SplitN(sc.Text(), "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		keys = append(keys, Key{parts[0], parts[1]})
+	}
+	return keys, sc.Err()
+}

--- a/internal/benchgate/main.go
+++ b/internal/benchgate/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
@@ -16,26 +17,31 @@ const (
 )
 
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: benchgate detect|confirm [flags]")
-		os.Exit(exitFailure)
+	os.Exit(run(os.Args[1:], os.Stdout))
+}
+
+// run holds everything main does apart from exiting, so it can be tested.
+func run(args []string, out io.Writer) int {
+	if len(args) < 1 {
+		fmt.Fprintln(out, "usage: benchgate detect|confirm [flags]")
+		return exitFailure
 	}
 	var err error
 	var code int
-	switch os.Args[1] {
+	switch args[0] {
 	case "detect":
-		code, err = detect(os.Args[2:])
+		code, err = detect(args[1:])
 	case "confirm":
-		code, err = confirm(os.Args[2:])
+		code, err = confirm(args[1:])
 	default:
-		err = fmt.Errorf("unknown subcommand %q", os.Args[1])
+		err = fmt.Errorf("unknown subcommand %q", args[0])
 		code = exitFailure
 	}
 	if err != nil {
-		fmt.Printf("::error::%v\n", err)
-		os.Exit(exitFailure)
+		fmt.Fprintf(out, "::error::%v\n", err)
+		return exitFailure
 	}
-	os.Exit(code)
+	return code
 }
 
 func parseFile(path string) ([]Row, error) {

--- a/internal/benchgate/main.go
+++ b/internal/benchgate/main.go
@@ -56,7 +56,7 @@ func parseFile(path string) ([]Row, error) {
 func detect(args []string) (int, error) {
 	fs := flag.NewFlagSet("detect", flag.ContinueOnError)
 	csvPath := fs.String("csv", "", "benchstat -format=csv output")
-	flaggedPath := fs.String("flagged", "", "file to write flagged name/unit pairs to")
+	flaggedPath := fs.String("flagged", "", "file to write flagged package/name/unit keys to")
 	selectorPath := fs.String("selector", "", "file to write the -bench selector to")
 	if err := fs.Parse(args); err != nil {
 		return exitFailure, err
@@ -101,7 +101,7 @@ func detect(args []string) (int, error) {
 func confirm(args []string) (int, error) {
 	fs := flag.NewFlagSet("confirm", flag.ContinueOnError)
 	csvPath := fs.String("csv", "", "benchstat -format=csv output for the confirmation run")
-	flaggedPath := fs.String("flagged", "", "name/unit pairs written by detect")
+	flaggedPath := fs.String("flagged", "", "package/name/unit keys written by detect")
 	if err := fs.Parse(args); err != nil {
 		return exitFailure, err
 	}
@@ -140,7 +140,7 @@ func confirm(args []string) (int, error) {
 func writeFlagged(path string, rows []Row) error {
 	var b strings.Builder
 	for _, r := range rows {
-		_, _ = fmt.Fprintf(&b, "%s\t%s\n", r.Name, r.Unit)
+		_, _ = fmt.Fprintf(&b, "%s\t%s\t%s\n", r.Package, r.Name, r.Unit)
 	}
 	return os.WriteFile(path, []byte(b.String()), 0o644)
 }
@@ -154,11 +154,11 @@ func readFlagged(path string) ([]Key, error) {
 	var keys []Key
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
-		parts := strings.SplitN(sc.Text(), "\t", 2)
-		if len(parts) != 2 {
+		parts := strings.SplitN(sc.Text(), "\t", 3)
+		if len(parts) != 3 {
 			continue
 		}
-		keys = append(keys, Key{parts[0], parts[1]})
+		keys = append(keys, Key{parts[0], parts[1], parts[2]})
 	}
 	return keys, sc.Err()
 }

--- a/internal/benchgate/main_test.go
+++ b/internal/benchgate/main_test.go
@@ -15,12 +15,14 @@ func writeTemp(t *testing.T, name, content string) string {
 	return p
 }
 
-const cleanCSV = `,old,,new,,,
+const cleanCSV = `pkg: example.com/root
+,old,,new,,,
 ,sec/op,CI,sec/op,CI,vs base,P
 Foo-4,1e-07,0%,1.01e-07,0%,~,p=0.400 n=10
 `
 
-const regressedCSV = `,old,,new,,,
+const regressedCSV = `pkg: example.com/root
+,old,,new,,,
 ,sec/op,CI,sec/op,CI,vs base,P
 Foo-4,1e-07,0%,1.25e-07,0%,+25.00%,p=0.000 n=10
 `
@@ -76,7 +78,7 @@ func TestDetectWritesFlaggedAndSelector(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(got) != "Foo-4\tsec/op\n" {
+	if string(got) != "example.com/root\tFoo-4\tsec/op\n" {
 		t.Errorf("flagged = %q", got)
 	}
 	sel, err := os.ReadFile(selector)
@@ -95,7 +97,7 @@ func TestDetectMissingFile(t *testing.T) {
 }
 
 func TestConfirmExitCodes(t *testing.T) {
-	flagged := writeTemp(t, "flagged.tsv", "Foo-4\tsec/op\n")
+	flagged := writeTemp(t, "flagged.tsv", "example.com/root\tFoo-4\tsec/op\n")
 
 	code, err := confirm([]string{"-csv", writeTemp(t, "a.csv", regressedCSV), "-flagged", flagged})
 	if err != nil || code != exitFound {
@@ -121,8 +123,8 @@ func TestConfirmExitCodes(t *testing.T) {
 func TestFlaggedRoundTrip(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "flagged.tsv")
 	rows := []Row{
-		{Name: "Foo/size=1,024-4", Unit: "sec/op"},
-		{Name: "Bar-4", Unit: "B/op"},
+		{Package: "example.com/root", Name: "Foo/size=1,024-4", Unit: "sec/op"},
+		{Package: "example.com/root/msdsn", Name: "Bar-4", Unit: "B/op"},
 	}
 	if err := writeFlagged(p, rows); err != nil {
 		t.Fatal(err)
@@ -131,7 +133,10 @@ func TestFlaggedRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []Key{{"Foo/size=1,024-4", "sec/op"}, {"Bar-4", "B/op"}}
+	want := []Key{
+		{Package: "example.com/root", Name: "Foo/size=1,024-4", Unit: "sec/op"},
+		{Package: "example.com/root/msdsn", Name: "Bar-4", Unit: "B/op"},
+	}
 	if len(got) != len(want) {
 		t.Fatalf("got %d keys, want %d", len(got), len(want))
 	}
@@ -143,7 +148,7 @@ func TestFlaggedRoundTrip(t *testing.T) {
 }
 
 func TestReadFlaggedSkipsMalformedLines(t *testing.T) {
-	p := writeTemp(t, "flagged.tsv", "Foo-4\tsec/op\nnotabhere\n\nBar-4\tB/op\n")
+	p := writeTemp(t, "flagged.tsv", "example.com/root\tFoo-4\tsec/op\nnotabhere\n\nexample.com/root/msdsn\tBar-4\tB/op\n")
 	got, err := readFlagged(p)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/benchgate/main_test.go
+++ b/internal/benchgate/main_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTemp(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+const cleanCSV = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Foo-4,1e-07,0%,1.01e-07,0%,~,p=0.400 n=10
+`
+
+const regressedCSV = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Foo-4,1e-07,0%,1.25e-07,0%,+25.00%,p=0.000 n=10
+`
+
+func TestDetectExitCodes(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		csv  string
+		want int
+	}{
+		{"nothing significant", cleanCSV, exitClean},
+		{"a regression", regressedCSV, exitFound},
+		{"unrecognised output fails closed", "not benchstat output\n", exitFailure},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			code, err := detect([]string{
+				"-csv", writeTemp(t, "in.csv", tt.csv),
+				"-flagged", filepath.Join(dir, "flagged.tsv"),
+				"-selector", filepath.Join(dir, "selector.txt"),
+			})
+			if tt.want == exitFailure {
+				if err == nil {
+					t.Fatalf("want an error, got code=%d", code)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("detect: %v", err)
+			}
+			if code != tt.want {
+				t.Errorf("code = %d, want %d", code, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectWritesFlaggedAndSelector(t *testing.T) {
+	dir := t.TempDir()
+	flagged := filepath.Join(dir, "flagged.tsv")
+	selector := filepath.Join(dir, "selector.txt")
+
+	code, err := detect([]string{
+		"-csv", writeTemp(t, "in.csv", regressedCSV),
+		"-flagged", flagged,
+		"-selector", selector,
+	})
+	if err != nil || code != exitFound {
+		t.Fatalf("detect: code=%d err=%v", code, err)
+	}
+
+	got, err := os.ReadFile(flagged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "Foo-4\tsec/op\n" {
+		t.Errorf("flagged = %q", got)
+	}
+	sel, err := os.ReadFile(selector)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sel) != "^Benchmark(Foo)$\n" {
+		t.Errorf("selector = %q", sel)
+	}
+}
+
+func TestDetectMissingFile(t *testing.T) {
+	if _, err := detect([]string{"-csv", filepath.Join(t.TempDir(), "absent.csv")}); err == nil {
+		t.Fatal("want an error for a missing csv")
+	}
+}
+
+func TestConfirmExitCodes(t *testing.T) {
+	flagged := writeTemp(t, "flagged.tsv", "Foo-4\tsec/op\n")
+
+	code, err := confirm([]string{"-csv", writeTemp(t, "a.csv", regressedCSV), "-flagged", flagged})
+	if err != nil || code != exitFound {
+		t.Errorf("reproduced: code=%d err=%v, want %d", code, err, exitFound)
+	}
+
+	code, err = confirm([]string{"-csv", writeTemp(t, "b.csv", cleanCSV), "-flagged", flagged})
+	if err != nil || code != exitClean {
+		t.Errorf("not reproduced: code=%d err=%v, want %d", code, err, exitClean)
+	}
+
+	// A confirmation that measured nothing must not read as "did not reproduce".
+	if _, err := confirm([]string{"-csv", writeTemp(t, "c.csv", "junk\n"), "-flagged", flagged}); err == nil {
+		t.Error("want an error when the confirmation produced no comparable rows")
+	}
+
+	empty := writeTemp(t, "empty.tsv", "")
+	if _, err := confirm([]string{"-csv", writeTemp(t, "d.csv", regressedCSV), "-flagged", empty}); err == nil {
+		t.Error("want an error when no rows were flagged")
+	}
+}
+
+func TestFlaggedRoundTrip(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "flagged.tsv")
+	rows := []Row{
+		{Name: "Foo/size=1,024-4", Unit: "sec/op"},
+		{Name: "Bar-4", Unit: "B/op"},
+	}
+	if err := writeFlagged(p, rows); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readFlagged(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Key{{"Foo/size=1,024-4", "sec/op"}, {"Bar-4", "B/op"}}
+	if len(got) != len(want) {
+		t.Fatalf("got %d keys, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("key %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestReadFlaggedSkipsMalformedLines(t *testing.T) {
+	p := writeTemp(t, "flagged.tsv", "Foo-4\tsec/op\nnotabhere\n\nBar-4\tB/op\n")
+	got, err := readFlagged(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d keys, want 2: %+v", len(got), got)
+	}
+}

--- a/internal/benchgate/run_test.go
+++ b/internal/benchgate/run_test.go
@@ -205,6 +205,53 @@ func TestUnmeasured(t *testing.T) {
 	}
 }
 
+// An unlisted unit has no direction, so a significant change in it cannot be
+// classified. Guessing inverts it: errors/op rising would read as an
+// improvement and errors/op falling would fail the build.
+func TestParseFailsClosedOnUnknownUnitWithSignificantDelta(t *testing.T) {
+	const in = `,old,,new,,,
+,errors/op,CI,errors/op,CI,vs base,P
+Foo-4,1,0%,1.25,0%,+25.00%,p=0.000 n=10
+`
+	_, err := Parse(strings.NewReader(in))
+	if err == nil {
+		t.Fatal("want an error for a significant delta in a unit with no known direction")
+	}
+	if !strings.Contains(err.Error(), "errors/op") {
+		t.Errorf("error = %v, want it to name the unit", err)
+	}
+}
+
+// An unknown unit that did not move cannot be misclassified, so it must not
+// fail the build: benchmarks report descriptive metrics like msgs/op that are
+// stable and irrelevant to the gate.
+func TestParseAllowsUnknownUnitWithoutSignificantDelta(t *testing.T) {
+	const in = `,old,,new,,,
+,msgs/op,CI,msgs/op,CI,vs base,P
+Foo-4,10,0%,10,0%,~,p=0.900 n=10
+`
+	rows, err := Parse(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Significant {
+		t.Fatalf("got %+v, want one insignificant row", rows)
+	}
+}
+
+func TestUnitDirectionCoversBenchstatUnits(t *testing.T) {
+	for _, u := range []string{"sec/op", "ns/op", "B/op", "allocs/op"} {
+		if !lowerIsBetter(u) {
+			t.Errorf("%s should be lower-is-better", u)
+		}
+	}
+	for _, u := range []string{"B/s", "MB/s"} {
+		if lowerIsBetter(u) {
+			t.Errorf("%s should be higher-is-better", u)
+		}
+	}
+}
+
 func TestRunReturnsFoundOnRegression(t *testing.T) {
 	var out strings.Builder
 	if got := run([]string{"detect", "-csv", writeTemp(t, "x.csv", regressedCSV)}, &out); got != exitFound {

--- a/internal/benchgate/run_test.go
+++ b/internal/benchgate/run_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestRunDispatch(t *testing.T) {
 	csv := writeTemp(t, "in.csv", cleanCSV)
-	flagged := writeTemp(t, "flagged.tsv", "Foo-4\tsec/op\n")
+	flagged := writeTemp(t, "flagged.tsv", "example.com/root\tFoo-4\tsec/op\n")
 
 	for _, tt := range []struct {
 		name string
@@ -59,7 +59,7 @@ func TestConfirmRejectsUnknownFlag(t *testing.T) {
 
 func TestConfirmMissingFiles(t *testing.T) {
 	csv := writeTemp(t, "in.csv", regressedCSV)
-	flagged := writeTemp(t, "flagged.tsv", "Foo-4\tsec/op\n")
+	flagged := writeTemp(t, "flagged.tsv", "example.com/root\tFoo-4\tsec/op\n")
 
 	if _, err := confirm([]string{"-csv", filepath.Join(t.TempDir(), "absent.csv"), "-flagged", flagged}); err == nil {
 		t.Error("want an error for a missing csv file")
@@ -144,12 +144,13 @@ func TestWriteFlaggedSurfacesErrors(t *testing.T) {
 // recheck can come back full of siblings while the candidate itself never ran.
 // Non-empty output must not be read as "the candidate came back clean".
 func TestConfirmFailsWhenCandidateWasNotRemeasured(t *testing.T) {
-	const siblingsOnly = `,old,,new,,,
+	const siblingsOnly = `pkg: example.com/root
+,old,,new,,,
 ,sec/op,CI,sec/op,CI,vs base,P
 Parent/Other-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
 `
 	csv := writeTemp(t, "recheck.csv", siblingsOnly)
-	flagged := writeTemp(t, "flagged.tsv", "Parent/Sub-4\tsec/op\n")
+	flagged := writeTemp(t, "flagged.tsv", "example.com/root\tParent/Sub-4\tsec/op\n")
 
 	code, err := confirm([]string{"-csv", csv, "-flagged", flagged})
 	if err == nil {
@@ -165,13 +166,14 @@ Parent/Other-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
 
 // A candidate that was remeasured and came back clean is still noise.
 func TestConfirmAcceptsNoiseOnlyWhenCandidateWasRemeasured(t *testing.T) {
-	const remeasured = `,old,,new,,,
+	const remeasured = `pkg: example.com/root
+,old,,new,,,
 ,sec/op,CI,sec/op,CI,vs base,P
 Parent/Sub-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
 Parent/Other-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
 `
 	csv := writeTemp(t, "recheck.csv", remeasured)
-	flagged := writeTemp(t, "flagged.tsv", "Parent/Sub-4\tsec/op\n")
+	flagged := writeTemp(t, "flagged.tsv", "example.com/root\tParent/Sub-4\tsec/op\n")
 
 	code, err := confirm([]string{"-csv", csv, "-flagged", flagged})
 	if err != nil {
@@ -192,10 +194,11 @@ func TestUnmeasured(t *testing.T) {
 		flagged []Key
 		want    int
 	}{
-		{"all present", []Key{{"Foo-4", "sec/op"}}, 0},
-		{"name absent", []Key{{"Bar-4", "sec/op"}}, 1},
-		{"same name, different unit", []Key{{"Foo-4", "allocs/op"}}, 1},
-		{"mixed", []Key{{"Foo-4", "sec/op"}, {"Bar-4", "sec/op"}}, 1},
+		{"all present", []Key{{Name: "Foo-4", Unit: "sec/op"}}, 0},
+		{"name absent", []Key{{Name: "Bar-4", Unit: "sec/op"}}, 1},
+		{"same name, different unit", []Key{{Name: "Foo-4", Unit: "allocs/op"}}, 1},
+		{"same name and unit, different package", []Key{{Package: "example.com/other", Name: "Foo-4", Unit: "sec/op"}}, 1},
+		{"mixed", []Key{{Name: "Foo-4", Unit: "sec/op"}, {Name: "Bar-4", Unit: "sec/op"}}, 1},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := Unmeasured(rows, tt.flagged); len(got) != tt.want {

--- a/internal/benchgate/run_test.go
+++ b/internal/benchgate/run_test.go
@@ -252,6 +252,55 @@ func TestUnitDirectionCoversBenchstatUnits(t *testing.T) {
 	}
 }
 
+// LazyQuotes would turn an unterminated quote into a silently truncated record
+// instead of an error, and the short-row skip would then drop the regression
+// while the clean row kept the result non-empty.
+func TestParseFailsClosedOnUnterminatedQuote(t *testing.T) {
+	const in = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Clean-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
+"Regressed/size=1,024-4,1e-07,0%,1.25e-07,0%,+25.00%,p=0.000 n=10
+`
+	rows, err := Parse(strings.NewReader(in))
+	if err == nil {
+		t.Fatalf("malformed quoting was accepted: %+v", rows)
+	}
+}
+
+// A short row is only legitimate when one side was not measured. Both sides
+// present with no delta column is drift, and skipping it would hide whatever
+// the comparison would have said.
+func TestParseFailsClosedOnShortRowWithBothMeasurements(t *testing.T) {
+	const in = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Clean-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
+Truncated-4,1e-07,0%,1.25e-07,0%
+`
+	rows, err := Parse(strings.NewReader(in))
+	if err == nil {
+		t.Fatalf("a truncated comparison row was skipped: %+v", rows)
+	}
+	if !strings.Contains(err.Error(), "Truncated-4") {
+		t.Errorf("error = %v, want it to name the offending row", err)
+	}
+}
+
+// Same rule at full width: a blank delta is only acceptable when a side is
+// missing.
+func TestParseFailsClosedOnBlankDeltaWithBothMeasurements(t *testing.T) {
+	const in = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Both-4,1e-07,0%,1.25e-07,0%,,
+`
+	_, err := Parse(strings.NewReader(in))
+	if err == nil {
+		t.Fatal("want an error for a blank delta with both measurements present")
+	}
+	if !strings.Contains(err.Error(), "Both-4") {
+		t.Errorf("error = %v, want it to name the offending row", err)
+	}
+}
+
 func TestRunReturnsFoundOnRegression(t *testing.T) {
 	var out strings.Builder
 	if got := run([]string{"detect", "-csv", writeTemp(t, "x.csv", regressedCSV)}, &out); got != exitFound {

--- a/internal/benchgate/run_test.go
+++ b/internal/benchgate/run_test.go
@@ -140,6 +140,71 @@ func TestWriteFlaggedSurfacesErrors(t *testing.T) {
 	}
 }
 
+// The selector addresses a flagged sub-benchmark through its parent, so the
+// recheck can come back full of siblings while the candidate itself never ran.
+// Non-empty output must not be read as "the candidate came back clean".
+func TestConfirmFailsWhenCandidateWasNotRemeasured(t *testing.T) {
+	const siblingsOnly = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Parent/Other-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
+`
+	csv := writeTemp(t, "recheck.csv", siblingsOnly)
+	flagged := writeTemp(t, "flagged.tsv", "Parent/Sub-4\tsec/op\n")
+
+	code, err := confirm([]string{"-csv", csv, "-flagged", flagged})
+	if err == nil {
+		t.Fatal("an unmeasured candidate was accepted as runner noise")
+	}
+	if code != exitFailure {
+		t.Errorf("code = %d, want %d", code, exitFailure)
+	}
+	if !strings.Contains(err.Error(), "Parent/Sub-4") {
+		t.Errorf("error = %v, want it to name the unmeasured candidate", err)
+	}
+}
+
+// A candidate that was remeasured and came back clean is still noise.
+func TestConfirmAcceptsNoiseOnlyWhenCandidateWasRemeasured(t *testing.T) {
+	const remeasured = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Parent/Sub-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
+Parent/Other-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
+`
+	csv := writeTemp(t, "recheck.csv", remeasured)
+	flagged := writeTemp(t, "flagged.tsv", "Parent/Sub-4\tsec/op\n")
+
+	code, err := confirm([]string{"-csv", csv, "-flagged", flagged})
+	if err != nil {
+		t.Fatalf("confirm: %v", err)
+	}
+	if code != exitClean {
+		t.Errorf("code = %d, want %d", code, exitClean)
+	}
+}
+
+func TestUnmeasured(t *testing.T) {
+	rows := []Row{
+		{Name: "Foo-4", Unit: "sec/op"},
+		{Name: "Foo-4", Unit: "B/s"},
+	}
+	for _, tt := range []struct {
+		name    string
+		flagged []Key
+		want    int
+	}{
+		{"all present", []Key{{"Foo-4", "sec/op"}}, 0},
+		{"name absent", []Key{{"Bar-4", "sec/op"}}, 1},
+		{"same name, different unit", []Key{{"Foo-4", "allocs/op"}}, 1},
+		{"mixed", []Key{{"Foo-4", "sec/op"}, {"Bar-4", "sec/op"}}, 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Unmeasured(rows, tt.flagged); len(got) != tt.want {
+				t.Errorf("Unmeasured() = %+v, want %d entries", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunReturnsFoundOnRegression(t *testing.T) {
 	var out strings.Builder
 	if got := run([]string{"detect", "-csv", writeTemp(t, "x.csv", regressedCSV)}, &out); got != exitFound {

--- a/internal/benchgate/run_test.go
+++ b/internal/benchgate/run_test.go
@@ -301,6 +301,24 @@ Both-4,1e-07,0%,1.25e-07,0%,,
 	}
 }
 
+// A drifted header must not be mistaken for the file-list line that separates
+// tables. Treating it as a separator resets the unit and silently skips the
+// whole table, which a preceding intact table would then mask.
+func TestParseFailsClosedOnDriftedHeaderAfterGoodTable(t *testing.T) {
+	const in = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Foo-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
+
+,old,,new,,,
+,B/op,Confidence,B/op,Confidence,vs base,P
+Foo-4,100,0%,125,0%,+25.00%,p=0.000 n=10
+`
+	rows, err := Parse(strings.NewReader(in))
+	if err == nil {
+		t.Fatalf("a drifted header was skipped behind an intact table: %+v", rows)
+	}
+}
+
 func TestRunReturnsFoundOnRegression(t *testing.T) {
 	var out strings.Builder
 	if got := run([]string{"detect", "-csv", writeTemp(t, "x.csv", regressedCSV)}, &out); got != exitFound {

--- a/internal/benchgate/run_test.go
+++ b/internal/benchgate/run_test.go
@@ -358,6 +358,26 @@ Foo-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
 	}
 }
 
+// The width of an orphaned record does not matter. benchstat's preamble is
+// single-column, so anything wider with no table in scope is drift, including a
+// short row that would otherwise look like a one-sided benchmark.
+func TestParseFailsClosedOnNarrowRowOutsideAnyTable(t *testing.T) {
+	const in = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Foo-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
+
+,old,,new,,,
+Bar-4,100,0%,125,0%
+`
+	rows, err := Parse(strings.NewReader(in))
+	if err == nil {
+		t.Fatalf("a narrow row outside any table was skipped: %+v", rows)
+	}
+	if !strings.Contains(err.Error(), "Bar-4") {
+		t.Errorf("error = %v, want it to name the offending record", err)
+	}
+}
+
 func TestRunReturnsFoundOnRegression(t *testing.T) {
 	var out strings.Builder
 	if got := run([]string{"detect", "-csv", writeTemp(t, "x.csv", regressedCSV)}, &out); got != exitFound {

--- a/internal/benchgate/run_test.go
+++ b/internal/benchgate/run_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunDispatch(t *testing.T) {
+	csv := writeTemp(t, "in.csv", cleanCSV)
+	flagged := writeTemp(t, "flagged.tsv", "Foo-4\tsec/op\n")
+
+	for _, tt := range []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"no arguments", nil, exitFailure},
+		{"unknown subcommand", []string{"explode"}, exitFailure},
+		{"detect with nothing significant", []string{"detect", "-csv", csv}, exitClean},
+		{"detect surfacing an error", []string{"detect", "-csv", "no-such-file.csv"}, exitFailure},
+		{"confirm not reproduced", []string{"confirm", "-csv", csv, "-flagged", flagged}, exitClean},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var out strings.Builder
+			if got := run(tt.args, &out); got != tt.want {
+				t.Errorf("run(%v) = %d, want %d (output: %s)", tt.args, got, tt.want, out.String())
+			}
+		})
+	}
+}
+
+func TestRunReportsUsageAndErrors(t *testing.T) {
+	var out strings.Builder
+	run(nil, &out)
+	if !strings.Contains(out.String(), "usage:") {
+		t.Errorf("no usage line: %q", out.String())
+	}
+
+	out.Reset()
+	run([]string{"explode"}, &out)
+	if !strings.Contains(out.String(), "::error::") {
+		t.Errorf("no error annotation: %q", out.String())
+	}
+}
+
+func TestDetectRejectsUnknownFlag(t *testing.T) {
+	if _, err := detect([]string{"-nosuchflag"}); err == nil {
+		t.Fatal("want an error for an unknown flag")
+	}
+}
+
+func TestConfirmRejectsUnknownFlag(t *testing.T) {
+	if _, err := confirm([]string{"-nosuchflag"}); err == nil {
+		t.Fatal("want an error for an unknown flag")
+	}
+}
+
+func TestConfirmMissingFiles(t *testing.T) {
+	csv := writeTemp(t, "in.csv", regressedCSV)
+	flagged := writeTemp(t, "flagged.tsv", "Foo-4\tsec/op\n")
+
+	if _, err := confirm([]string{"-csv", filepath.Join(t.TempDir(), "absent.csv"), "-flagged", flagged}); err == nil {
+		t.Error("want an error for a missing csv file")
+	}
+	if _, err := confirm([]string{"-csv", csv, "-flagged", filepath.Join(t.TempDir(), "absent.tsv")}); err == nil {
+		t.Error("want an error for a missing flagged file")
+	}
+}
+
+// A CSV containing improvements exercises the reporting path.
+func TestDetectReportsImprovements(t *testing.T) {
+	const improved = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Foo-4,1.25e-07,0%,1e-07,0%,-20.00%,p=0.000 n=10
+`
+	code, err := detect([]string{"-csv", writeTemp(t, "in.csv", improved)})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if code != exitClean {
+		t.Errorf("code = %d, want %d", code, exitClean)
+	}
+}
+
+// Writing to a path that is a directory fails, which covers the write paths.
+func TestDetectSurfacesWriteErrors(t *testing.T) {
+	dir := t.TempDir()
+	csv := writeTemp(t, "in.csv", regressedCSV)
+
+	if _, err := detect([]string{"-csv", csv, "-flagged", dir}); err == nil {
+		t.Error("want an error when the flagged path cannot be written")
+	}
+	if _, err := detect([]string{"-csv", csv, "-flagged", filepath.Join(dir, "ok.tsv"), "-selector", dir}); err == nil {
+		t.Error("want an error when the selector path cannot be written")
+	}
+}
+
+func TestReadFlaggedMissingFile(t *testing.T) {
+	if _, err := readFlagged(filepath.Join(t.TempDir(), "absent.tsv")); err == nil {
+		t.Fatal("want an error for a missing file")
+	}
+}
+
+type failingReader struct{ err error }
+
+func (f failingReader) Read([]byte) (int, error) { return 0, f.err }
+
+func TestParseSurfacesCSVErrors(t *testing.T) {
+	_, err := Parse(failingReader{err: errors.New("disk fell over")})
+	if err == nil {
+		t.Fatal("want an error when the reader fails")
+	}
+	if !strings.Contains(err.Error(), "read csv") {
+		t.Errorf("error = %v, want it wrapped with 'read csv'", err)
+	}
+	if !strings.Contains(err.Error(), "disk fell over") {
+		t.Errorf("error = %v, want the underlying cause preserved", err)
+	}
+}
+
+// A delta the shape check accepts but ParseFloat cannot represent means our own
+// assumption is broken, so it must fail closed rather than drop the row.
+func TestParseFailsClosedOnOutOfRangeDelta(t *testing.T) {
+	huge := "+" + strings.Repeat("9", 400) + ".00%"
+	in := ",old,,new,,,\n,sec/op,CI,sec/op,CI,vs base,P\nFoo-4,1e-07,0%,1e-07,0%," + huge + ",p=0.000 n=10\n"
+	_, err := Parse(strings.NewReader(in))
+	if err == nil {
+		t.Fatal("want an error for a delta that cannot be represented")
+	}
+	if !strings.Contains(err.Error(), "Foo-4") {
+		t.Errorf("error = %v, want it to name the offending row", err)
+	}
+}
+
+func TestWriteFlaggedSurfacesErrors(t *testing.T) {
+	if err := writeFlagged(t.TempDir(), []Row{{Name: "Foo-4", Unit: "sec/op"}}); err == nil {
+		t.Fatal("want an error writing to a directory")
+	}
+}
+
+func TestRunReturnsFoundOnRegression(t *testing.T) {
+	var out strings.Builder
+	if got := run([]string{"detect", "-csv", writeTemp(t, "x.csv", regressedCSV)}, &out); got != exitFound {
+		t.Errorf("run detect on a regression = %d, want %d", got, exitFound)
+	}
+}

--- a/internal/benchgate/run_test.go
+++ b/internal/benchgate/run_test.go
@@ -319,6 +319,45 @@ Foo-4,100,0%,125,0%,+25.00%,p=0.000 n=10
 	}
 }
 
+// A data row after a separator but with no header of its own has no unit.
+// Skipping it drops whatever it says behind the tables that did parse, which is
+// the same masking one level coarser than a drifted header.
+func TestParseFailsClosedOnRowOutsideAnyTable(t *testing.T) {
+	const in = `,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Foo-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
+
+,old,,new,,,
+Bar-4,100,0%,125,0%,+25.00%,p=0.000 n=10
+`
+	rows, err := Parse(strings.NewReader(in))
+	if err == nil {
+		t.Fatalf("a row outside any table was skipped: %+v", rows)
+	}
+	if !strings.Contains(err.Error(), "Bar-4") {
+		t.Errorf("error = %v, want it to name the offending record", err)
+	}
+}
+
+// The goos/goarch/pkg preamble also arrives before any header, and must keep
+// parsing rather than being mistaken for an orphaned row.
+func TestParseSkipsPreambleBeforeFirstTable(t *testing.T) {
+	const in = `goos: windows
+goarch: amd64
+pkg: github.com/microsoft/go-mssqldb
+,old,,new,,,
+,sec/op,CI,sec/op,CI,vs base,P
+Foo-4,1e-07,0%,1e-07,0%,~,p=0.900 n=10
+`
+	rows, err := Parse(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %+v, want the single Foo-4 row", rows)
+	}
+}
+
 func TestRunReturnsFoundOnRegression(t *testing.T) {
 	var out strings.Builder
 	if got := run([]string{"detect", "-csv", writeTemp(t, "x.csv", regressedCSV)}, &out); got != exitFound {


### PR DESCRIPTION
The `benchmarks` job was failing on every branch in the repo, and fixing that surfaced four further defects in the same job. All of them share a shape: a step that could not do its work reported success, or failed with no way to tell why.

Touches `.github/workflows/pr-validation.yml` and adds `internal/benchgate`, a small Go command that holds the regression-gate logic. Section 5 explains why the gate moved out of Bash.

`benchmarks` is a **required check** on `main`, so both directions matter: a false failure blocks every merge, and a false pass lets a regression through unnoticed.

## 1. The job failed on every branch

```
go: golang.org/x/perf/cmd/benchstat@latest: golang.org/x/perf@v0.0.0-20260819171926-ebcb4798430d
   requires go >= 1.26.0 (running go 1.25.7; GOTOOLCHAIN=local)
```

`golang.org/x/perf` moved its `go` directive to `1.26.0` on 2026-08-19 in [`ebcb4798430d`](https://github.com/golang/perf/commit/ebcb4798430d). Nothing in our code changed. Confirmed the same failing step across unrelated branches — [dependabot](https://github.com/microsoft/go-mssqldb/actions/runs/32520510450), [release-please](https://github.com/microsoft/go-mssqldb/actions/runs/32520417314), [dev/saurabh/fix-tx-query-hang](https://github.com/microsoft/go-mssqldb/actions/runs/32520721271).

Worth understanding why *only* that step broke, since the benchmark runs on either side of it were fine. Same toolchain, same directory:

| Command | Constrained by | Result |
|---|---|---|
| `go build ./...` | **our** `go.mod` → `go 1.25.0` | exit 0 |
| `go test -bench ...` | **our** `go.mod` → `go 1.25.0` | exit 0 |
| `go install golang.org/x/perf/cmd/benchstat@latest` | **x/perf's** `go.mod` → `go 1.26.0` | **exit 1** |

`go install pkg@version` runs in an empty main module, so our `go` directive is irrelevant and the tool's own requirement governs. That asymmetry is permanent and cannot be designed away — so this PR makes it cheap instead.

**Fix:** install `benchstat` in its own step immediately after `Setup go`, rather than 46 minutes into the job. Measured from a real run:

```
 7. Run baseline benchmarks (main) | 23 min
 8. Run PR benchmarks             | 23 min
 9. Compare benchmarks            |  0 min   <- the install lived here
```

Failure now surfaces at about minute one. `benchstat` stays on `@latest`: with the fail-fast ordering plus the fail-closed gate below, a pin buys nothing that isn't already covered, and `@latest` surfaces upstream breakage while it is still cheap to fix. `#439` moved this job to Go 1.27, so the original incompatibility is resolved either way.

## 2. The regression gate failed open

`Check for regressions` inferred "no regression" from "my regex matched nothing". Those are different statements and it could not tell them apart. There was a guard, but it tested whether `bench_diff.txt` *exists*, not whether it contains anything.

Running the shipped step against fixtures, before this PR:

| Input | Result |
|---|---|
| Real 22% regression | blocks |
| Regression printed `+22%` instead of `+22.00%` | **passes** |
| Empty `bench_diff.txt` | **passes** |
| `benchstat: no data for bench_old.txt` | **passes** |
| Any change to benchstat's row formatting | **passes** |

Two of those were live gaps, not hypothetical drift: the regex hardcoded a decimal point, and an empty file cleared the `[ ! -f ]` guard.

**Fix:** the gate now parses benchstat's `-format=csv` output with `encoding/csv` and refuses to report "clean" from output it could not interpret. Unreadable rows, header drift and an empty comparison are all errors.

## 3. A clean sweep of improvements aborted the job

Found while testing #2. `REGRESSED=$(...)` aborts under `set -eo pipefail` when the final `grep` matches nothing. Typical runs contain small `+0.38%` entries so the grep matched and this stayed hidden, but a PR where every benchmark improved or was `~` failed with no message.

The first attempt at this wrapped the whole pipeline in `|| true`, which [@copilot-pull-request-reviewer correctly flagged](https://github.com/microsoft/go-mssqldb/pull/437#discussion_r3836474000) as reintroducing the very fail-open being fixed — it also swallowed `grep` exit 2 and any `awk` failure.

**Fix:** superseded by section 5. "No regressions" is now a value the gate returns, not the absence of a pattern match, so the distinction that caused this cannot arise.

## 4. SQL Server never started, and nothing said so

[Run 32585542809](https://github.com/microsoft/go-mssqldb/actions/runs/32585542809) failed with nothing but `Process completed with exit code 1`. Three gaps hid the cause:

```
Waiting for SQL Server... (attempt 29/30)
Waiting for SQL Server... (attempt 30/30)
```

- The readiness loop had no result flag, so it fell through after 30 failures and the step reported **success**.
- The warmup then ran against a dead server with `> /dev/null 2>&1`, so the failure carried no diagnosis.
- `Show SQL Server logs on failure` existed only in the `build` job, so no container logs were captured either.

**Fix:** the `build` job already gets the first and third right, so this applies that existing pattern to `benchmarks` rather than inventing one, and keeps warmup output in a file that is tailed on failure.

**Container memory:** the loop was commented as 60 seconds, but `sqlcmd` burns ~8s per attempt when nothing is listening, so it actually waited **295 seconds** and SQL 2025 still had not started. The cause was `docker run -m 2GB` — the documented minimum for SQL Server 2022 and later, with no headroom. Both jobs now run `-m 4GB` with `MSSQL_MEMORY_LIMIT_MB=3072`.

Microsoft's [container memory guidance](https://learn.microsoft.com/sql/linux/configure/performance-best-practices-sql-server-memory#guidelines-for-setting-memory-limits-on-linux-and-in-containers) requires `MSSQL_MEMORY_LIMIT_MB` to sit below the container limit, and recommends reserving 10-20% of it for the OS and auxiliary processes. 4096 MiB with a 3072 MiB engine limit leaves 1024 MiB, or 25%. Left unset the engine takes 80% of the cgroup limit (3277 MB), so the explicit value is marginally tighter than the default. `ubuntu-latest` on a public repo has [16 GB](https://docs.github.com/en/actions/reference/runners/github-hosted-runners), so 4 GiB does not crowd the toolchain.

The readiness comment now describes the loop in attempts rather than wall time. The real bound is 30 × (connect timeout + 2s), and the abort message is what an operator reads when the job fails, so claiming 60 seconds sends them after the wrong problem.

**OOM diagnostics:** a cgroup memory kill reaches the test process as connection resets and unexpected EOF. In a TDS driver suite that is indistinguishable from a protocol bug. The `Show SQL Server logs on failure` step in both jobs now reports container state before dumping the logs, and names the memory case:

```
sqlserver: oom-killed=true exit=137 status=exited memory-limit=4096 MiB
::error::SQL Server was OOM-killed. Connection errors above are a symptom of the
container memory limit, not of the driver. Raise -m and MSSQL_MEMORY_LIMIT_MB
together, keeping 10-20% headroom between them.
```

Exit 137 without the OOM flag is a warning rather than an error, since nothing in these jobs sends SIGKILL deliberately. Both readiness loops `exit 1` into this same step, so a kill during startup and a kill mid-run are both covered.

## 5. The gate moved from Bash to Go

The gate started as a shell script embedded in YAML. Over five review iterations it accumulated **nine** defects, every one found by review rather than by the job itself:

1. `|| true` masking `grep` exit 2
2. `cp ... 2>/dev/null || true` swallowing real copy errors
3. `^Benchmark(Parent/Sub)$` matching nothing — `go test` splits `-bench` at `/`, so a sub-benchmark must be addressed through its parent
4. **A 20% speedup failing the build** — `SetBytes` renders it as `-20% sec/op` *and* `+25% B/s`, and any-positive-delta called the second one a regression
5. `geomean` reaching the selector as if it were a benchmark
6. The row count failing open on header drift, by counting rows the detector could not interpret
7. Confirmation keyed on benchmark name only, so a different metric could confirm a regression
8. **`awk -F,` is not a CSV parser** — `"Foo/size=1,024-4"` shifted fields, silently dropping a regression while the row count stayed healthy
9. No test anywhere in the repo covering any of it

Each individual fix was reachable in Bash. The pattern was not: this is a required check whose failure mode is silence, and it had no tests, so every defect above would have shipped green.

`internal/benchgate` is that logic as a Go package, and the workflow step is now 61 lines of YAML that builds and calls it:

| | |
|---|---|
| `Parse` | `encoding/csv`, unit-keyed; fails closed on header drift and unreadable deltas |
| `Regressions` / `Improvements` | threshold applied in the correct direction per unit |
| `Selector` | collapses sub-benchmarks to the parent, `regexp.QuoteMeta`, excludes `geomean` |
| `Confirm` / `Unmeasured` | intersects the recheck on name **and** unit, and refuses to clear a candidate that was never remeasured |

Review of the Go version then found **three more fail-open defects**, all fixed here. Each is worth naming, because all three are the same bug class this PR set out to remove — inferring "clean" from an absence:

- **Throughput regressions were never flagged** (`4cb4b23`). `Regressions` gated on `lowerIsBetter`, so a significant `-20% B/s` collapse could not be reported. I had fixed the false-positive direction of #4 and left the false-negative direction open. The threshold now applies in both directions.
- **A malformed row could hide behind a valid one** (`4cb4b23`). Skipping an unreadable delta only failed closed when *every* row was unreadable; one clean row alongside a malformed regression left a non-empty result and reported success. That is #8's exact failure mode. An unreadable delta under a recognised table is now a parse error.
- **An unevaluated candidate was dismissed as noise** (`20e03bf`). Because `Selector` addresses a flagged sub-benchmark through its parent, the recheck returns rows for siblings. If the candidate itself never produced a comparable row, `Confirm` returned empty and the gate treated it as runner noise — on a clean exit. `Unmeasured` now reports flagged keys absent from the recheck, and those fail as unevaluated. Presence counts regardless of significance: a flagged row coming back `~` genuinely is noise; only absence is unevaluated.

## Testing

`go test ./internal/benchgate/` runs with everything else. **99.4%** of statements; the only uncovered statement is `os.Exit(run(os.Args[1:], os.Stdout))`, which has no logic in it — `run(args []string, out io.Writer) int` was extracted precisely so dispatch, usage and error reporting are all exercised.

The regression cases from the original Bash harness are preserved as Go tests, alongside one for each defect above:

```
TestParseHandlesQuotedNameContainingComma            defect 8, uses Foo/size=1,024-4
TestParseFailsClosedOnHeaderDrift                    defect 6
TestParseFailsClosedOnUnreadableDelta                fails the parse, not just the row
TestParseFailsClosedOnMixedValidAndUnreadableRows    one clean row must not mask it
TestParseSkipsOneSidedBenchmarks                     benchstat truncates these rows
TestParseResetsUnitBetweenTables                     unit must not leak across tables
TestRegressionsIgnoreThroughputGains                 defect 4, a speedup is not a failure
TestRegressionsCatchThroughputLosses                 the inverse: -20% B/s must block
TestSelector                                         defect 3, parent/sub collapsing
TestSelectorQuotesMetacharacters                     defect 5 and regex injection
TestConfirmMatchesNameAndUnit                        defect 7
TestConfirmRequiresReproduction
TestConfirmFailsWhenCandidateWasNotRemeasured        the sibling scenario
TestConfirmAcceptsNoiseOnlyWhenCandidateWasRemeasured  the inverse, so noise still clears
TestUnmeasured                                       name/unit matching
```

The one-sided-benchmark handling was checked against benchstat itself rather than assumed, since making unreadable deltas fatal would otherwise hard-fail every PR that adds or removes a benchmark:

```
,sec/op,CI,sec/op,CI,vs base,P
Old-4,1.0000000000000002e-06,∞
Both-4,2.0000000000000003e-06,∞,2.5e-06,∞,~,p=0.333 n=2
New-4,,,1.5e-06,∞
```

benchstat truncates those rows to 3 and 5 fields, so they are dropped on field count and never reach the delta logic. `TestParseSkipsOneSidedBenchmarks` pins that shape so a future benchstat change surfaces as a test failure instead of a CI outage.

Readiness logic verified both ways:

```
server comes up          rc=0  proceeded to benchmarks
server never comes up    rc=1  ::error::SQL Server did not become ready; aborting benchmarks.
```

Also confirmed `benchstat@latest` installs cleanly under `GOTOOLCHAIN=go1.27.0`, reproduced the original failure under `go1.25.7` first, and checked by parsing the YAML that both jobs now carry the log step and only one `go install` remains.

The OOM diagnostic is still Bash, so it is still tested by extraction from the YAML and run under `-eo pipefail` against a stubbed `docker`: an OOM kill, exit 137 without the flag, a healthy running container, a zero and a non-numeric memory limit, and `docker ps` / `inspect` / `logs` each failing — 11 cases, all passing, no `set -e` aborts. The extractor also asserts the logic is identical in both jobs. Then end-to-end against a real engine: a container held at a 16 MiB cap until the kernel killed it renders `true 137 exited 16777216`, confirming the field order and that `.HostConfig.Memory` is bytes.

`actionlint` is clean, `go vet` is clean, and `golangci-lint run ./internal/benchgate/` reports 0 issues.

## Timing

Worst case is a regression that reproduces: baseline pass, PR pass, then both again for confirmation. Measured on run 33399741848 — job 49m23s, baseline pass 23m57s, PR pass 23m52s — so confirmation adds about 48 minutes for a worst case near 97. `timeout-minutes` is 120 and the confirmation `-timeout` is 25m.

## Corrections

Two claims I made earlier in this PR were wrong and are worth flagging for anyone reading the thread history:

- I told @copilot-pull-request-reviewer that `benchmarks` is not a required check, so a red result would never block a merge. It **is** one of the 14 required contexts on `main`. That premise made me under-weight the reviewer's point about untested confirmation logic, which was correct.
- I claimed `BenchmarkSelect` deadlocks past one iteration. It does not — the handler loops, and it completed in a 46.1s run. Its behaviour when run alone is still unexplained, so it stays out of `BENCH_PATTERN` until it is understood.