### PR TITLE
ci: test the supported Go releases and drop the EOL toolchain pin

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,11 @@
 # Go MSSQL Driver Development Container
-# The Go major.minor version here must match the 'go' directive in go.mod.
-# GOTOOLCHAIN=auto lets Go download the exact patch version (e.g. 1.25.9)
+# The Go major.minor version here must be at least the 'go' directive in go.mod.
+# It may be newer: the go directive is the floor we promise consumers, not the
+# version we develop with.
+# GOTOOLCHAIN=auto lets Go download the exact patch version (e.g. 1.26.7)
 # when the base image is slightly behind. Downloads are verified against
 # sum.golang.org.
-FROM mcr.microsoft.com/devcontainers/go:1.25-bookworm
+FROM mcr.microsoft.com/devcontainers/go:1.26-bookworm
 ENV GOTOOLCHAIN=auto
 
 # The base image sets GOPATH=/go owned by root. Override to a user-writable

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,10 +2,12 @@
 # The Go major.minor version here must be at least the 'go' directive in go.mod.
 # It may be newer: the go directive is the floor we promise consumers, not the
 # version we develop with.
-# GOTOOLCHAIN=auto lets Go download the exact patch version (e.g. 1.26.7)
-# when the base image is slightly behind. Downloads are verified against
-# sum.golang.org.
 FROM mcr.microsoft.com/devcontainers/go:1.26-bookworm
+
+# The image's Go already satisfies the go directive, so it is what gets used;
+# auto does not chase newer patch releases. It matters only if go.mod later
+# requires a version newer than the image, where Go fetches it instead of
+# failing. Downloads are verified against sum.golang.org.
 ENV GOTOOLCHAIN=auto
 
 # The base image sets GOPATH=/go owned by root. Override to a user-writable

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -242,7 +242,9 @@ go test ./msdsn -v
 
 ## Go Version Upgrades
 
-Two different numbers live in `go.mod`, and they move for different reasons.
+Two different Go versions matter here and they move for different reasons: the
+floor we promise consumers, which lives in `go.mod`, and the versions CI tests
+against, which live in the workflows.
 
 ### The `go` directive is the consumer floor
 
@@ -254,20 +256,16 @@ There is no `toolchain` directive, deliberately. Toolchain selection only switch
 
 ### CI versions track Go's support policy
 
-Go supports the two most recent majors. `pr-validation.yml` runs the floor plus both supported releases, using `1.2N.x` so security patches are picked up automatically:
+Go supports the two most recent majors. `pr-validation.yml` runs the floor plus both supported releases against every SQL image, using `1.2N.x` so security patches are picked up automatically:
 
 ```yaml
-include:
-  - go: '1.27.x'   # newest supported, crossed with every SQL image
-    sqlImage: '2017-latest'
-  ...
-  - go: '1.26.x'   # supported
-    sqlImage: '2025-latest'
-  - go: '1.25.x'   # floor from the go directive
-    sqlImage: '2025-latest'
+go: ['1.25.x', '1.26.x', '1.27.x']
+sqlImage: ['2017-latest','2019-latest','2022-latest','2025-latest']
 ```
 
-The `build` job sets `GOTOOLCHAIN: local` so the floor leg actually tests the floor. Without it, a `toolchain` line re-added by `go get` would silently upgrade the job.
+`1.25.x` is the floor from the `go` directive; `1.26.x` and `1.27.x` are the supported releases. The full cross product is deliberate: all three Go versions compile identical code (every build constraint in the driver is `go1.9` through `go1.18`), so the only version-dependent behaviour is stdlib runtime, principally `crypto/tls` — and that is exactly where the server version is not orthogonal, since 2017 negotiates TLS 1.2 with older cipher suites and 2025 does TLS 1.3.
+
+The `build` job sets `GOTOOLCHAIN: local` so the floor legs actually test the floor. Without it, a `toolchain` line re-added by `go get` would silently upgrade the job.
 
 ### Places a Go version appears
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -242,36 +242,45 @@ go test ./msdsn -v
 
 ## Go Version Upgrades
 
-When upgrading Go versions, the following files need to be updated:
+Two different numbers live in `go.mod`, and they move for different reasons.
 
-### Files to Update
-1. **`.github/workflows/pr-validation.yml`** - GitHub Actions workflow for pull request validation
-2. **`appveyor.yml`** - AppVeyor configuration for Windows testing
+### The `go` directive is the consumer floor
 
-### GitHub Actions Workflow (.github/workflows/pr-validation.yml)
-Update the Go version in the strategy matrix:
+`go 1.25.0` is the oldest Go anyone importing this driver may use. Raising it is a breaking change for consumers, so it moves only when a dependency forces it or when the driver needs a newer language or stdlib feature. Never set it to a patch version (`go 1.25.7`) — patch releases add no language surface, and a patch floor breaks consumers on distro-packaged Go with `GOTOOLCHAIN=local`.
+
+The floor cannot go below the highest `go` directive of any direct dependency. `azcore` and `azidentity` currently sit at `1.25.0`.
+
+There is no `toolchain` directive, deliberately. Toolchain selection only switches upward, so contributors on any Go >= the floor are unaffected, and there is one fewer version to keep current.
+
+### CI versions track Go's support policy
+
+Go supports the two most recent majors. `pr-validation.yml` runs the floor plus both supported releases, using `1.2N.x` so security patches are picked up automatically:
+
 ```yaml
-strategy:
-  matrix:
-    go: ['1.XX']  # Update this version number
-    sqlImage: ['2019-latest','2022-latest']
+include:
+  - go: '1.27.x'   # newest supported, crossed with every SQL image
+    sqlImage: '2017-latest'
+  ...
+  - go: '1.26.x'   # supported
+    sqlImage: '2025-latest'
+  - go: '1.25.x'   # floor from the go directive
+    sqlImage: '2025-latest'
 ```
 
-### AppVeyor Configuration (appveyor.yml)
-Update multiple `GOVERSION` entries:
-1. **Default GOVERSION** (line ~14): `GOVERSION: 125` (remove dots)
-2. **Matrix entries** (lines ~20-35): Update all GOVERSION values
+The `build` job sets `GOTOOLCHAIN: local` so the floor leg actually tests the floor. Without it, a `toolchain` line re-added by `go get` would silently upgrade the job.
 
-**Version Format Difference:**
-- **GitHub Actions**: Use full version with dots (e.g., `'1.25.7'`)
-- **AppVeyor**: Remove dots and use just numbers (e.g., `125` for Go 1.25)
+### Places a Go version appears
 
-### Complete Upgrade Checklist
-- [ ] Update `.github/workflows/pr-validation.yml`: go version in matrix strategy
-- [ ] Update `appveyor.yml`: default GOVERSION and all matrix entries (typically 4 locations)
-- [ ] Ensure the x86 version maintains its `-x86` suffix
-- [ ] Test changes: verify GitHub Actions and AppVeyor builds complete successfully
-- [ ] Consider updating `go.mod` if using newer Go version than currently required
+| File | What it controls | Moves when |
+|---|---|---|
+| `go.mod` `go` directive | Consumer floor | A dependency forces it |
+| `.github/workflows/pr-validation.yml` | Tested versions | Go releases a new major |
+| `.devcontainer/Dockerfile` | Dev environment | Any time; must be >= the floor |
+| `appveyor.yml` `GOVERSION` | Windows test toolchain | Constrained by the AppVeyor image |
+
+AppVeyor uses no dots (`125` for Go 1.25), and the 32-bit entry keeps its `-x86` suffix. The AppVeyor worker image only carries certain Go versions, so check the image contents before bumping it.
+
+The `Verify Go version alignment` job in `devcontainer.yml` asserts the devcontainer image is at least the `go` directive. Newer is fine and expected.
 
 ## Common Commands and Expected Output
 

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -40,7 +40,7 @@ jobs:
           # Extract the Go version from the Dockerfile base image tag
           DOCKERFILE_TAG=$(sed -n 's/.*devcontainers\/go:\([0-9]*\.[0-9]*\).*/\1/p' .devcontainer/Dockerfile)
 
-          echo "go.mod requires:        go ${GOMOD_VERSION} (major.minor: ${GOMOD_MAJOR_MINOR})"
+          echo "go.mod floor:           go ${GOMOD_VERSION} (major.minor: ${GOMOD_MAJOR_MINOR})"
           echo "Dockerfile base image:  go:${DOCKERFILE_TAG}"
 
           if [[ -z "$GOMOD_MAJOR_MINOR" || -z "$DOCKERFILE_TAG" ]]; then
@@ -48,13 +48,16 @@ jobs:
             exit 1
           fi
 
-          if [[ "$GOMOD_MAJOR_MINOR" != "$DOCKERFILE_TAG" ]]; then
+          # The image may be newer than the go directive -- that is the floor we
+          # promise consumers, not the version we develop with. It must not be older.
+          OLDEST=$(printf '%s\n%s\n' "$GOMOD_MAJOR_MINOR" "$DOCKERFILE_TAG" | sort -V | head -1)
+          if [[ "$OLDEST" != "$GOMOD_MAJOR_MINOR" ]]; then
             echo ""
-            echo "ERROR: Version mismatch!"
-            echo "The devcontainer base image (go:${DOCKERFILE_TAG}) does not match"
-            echo "the Go version required by go.mod (${GOMOD_MAJOR_MINOR})."
+            echo "ERROR: The devcontainer cannot build this module!"
+            echo "The base image (go:${DOCKERFILE_TAG}) is older than the Go version"
+            echo "required by go.mod (${GOMOD_MAJOR_MINOR})."
             echo ""
-            echo "Update .devcontainer/Dockerfile:"
+            echo "Update .devcontainer/Dockerfile to ${GOMOD_MAJOR_MINOR} or newer:"
             echo "  FROM mcr.microsoft.com/devcontainers/go:${GOMOD_MAJOR_MINOR}-bookworm"
             echo ""
             echo "You may also need to update the pinned Go tool versions in the Dockerfile"
@@ -62,7 +65,7 @@ jobs:
             exit 1
           fi
 
-          echo "OK: Versions are aligned."
+          echo "OK: The devcontainer satisfies the go.mod requirement."
 
   build:
     name: Build devcontainer

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -14,10 +14,27 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      # Honour the matrix version instead of upgrading via the go.mod toolchain line.
+      GOTOOLCHAIN: local
     strategy:
+      fail-fast: false
       matrix:
-        go: ['1.25.7']
-        sqlImage: ['2017-latest','2019-latest','2022-latest','2025-latest']
+        # 1.27 and 1.26 are the supported Go releases; 1.25 is the floor declared
+        # by the go directive. Only the newest is crossed with every SQL image.
+        include:
+          - go: '1.27.x'
+            sqlImage: '2017-latest'
+          - go: '1.27.x'
+            sqlImage: '2019-latest'
+          - go: '1.27.x'
+            sqlImage: '2022-latest'
+          - go: '1.27.x'
+            sqlImage: '2025-latest'
+          - go: '1.26.x'
+            sqlImage: '2025-latest'
+          - go: '1.25.x'
+            sqlImage: '2025-latest'
     steps:
       # actions/checkout v6
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -105,7 +122,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25.7'
+          go-version: '1.27.x'
       - name: Install sqlcmd
         run: |
           curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,20 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         # 1.27 and 1.26 are the supported Go releases; 1.25 is the floor declared
-        # by the go directive. Only the newest is crossed with every SQL image.
-        include:
-          - go: '1.27.x'
-            sqlImage: '2017-latest'
-          - go: '1.27.x'
-            sqlImage: '2019-latest'
-          - go: '1.27.x'
-            sqlImage: '2022-latest'
-          - go: '1.27.x'
-            sqlImage: '2025-latest'
-          - go: '1.26.x'
-            sqlImage: '2025-latest'
-          - go: '1.25.x'
-            sqlImage: '2025-latest'
+        # by the go directive. Crossed with every SQL image because crypto/tls
+        # changes between Go releases and TLS negotiation differs by server version.
+        go: ['1.25.x', '1.26.x', '1.27.x']
+        sqlImage: ['2017-latest','2019-latest','2022-latest','2025-latest']
     steps:
       # actions/checkout v6
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/microsoft/go-mssqldb
 
 go 1.25.0
 
-toolchain go1.25.7
-
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0


### PR DESCRIPTION
Fixes #438

## Problem

Go 1.27.0 released **2026-08-19**, which put Go 1.25 out of support the same day. We pinned `toolchain go1.25.7` (released 2026-02-04) — 7 patch releases behind the end of an EOL line — and `pr-validation.yml` tested only that one version.

So we tested neither supported release, and the floor we promise consumers was only tested by coincidence.

## The `go` directive does not change

`go 1.25.0` stays. It is already the lowest we can go:

| Direct dependency | `go` directive |
|---|---|
| `azure-sdk-for-go/sdk/azcore` v1.23.0 | **1.25.0** |
| `azure-sdk-for-go/sdk/azidentity` v1.14.0 | **1.25.0** |
| `golang.org/x/crypto`, `golang.org/x/text` | 1.24.0 |
| `AzureAD/microsoft-authentication-library-for-go` | 1.18 |
| `stretchr/testify` | 1.17 |

A module's `go` line must be at least that of every module it requires, so azcore and azidentity set a hard floor at 1.25.0. It also matches the field — pgx, spanner, modernc.org/sqlite, clickhouse-go, `x/crypto` and `x/net` are all at `1.25.0`, and nothing widely used requires more than N-2.

## Solution

**Remove the `toolchain` directive rather than bumping it.** With it omitted the implicit toolchain is the `go` line, and toolchain selection only ever switches *upward*, so contributors on any Go >= 1.25.0 are unaffected. 15 of the 16 comparable drivers and SDKs I sampled ship no `toolchain` line at all. One fewer version to keep current, and it is the version that just went stale.

**Test the floor and both supported releases, against every SQL image.** Using `1.2N.x` rather than exact patches so security fixes are picked up automatically — exact pins are how we ended up 7 patches behind on an EOL line.

```yaml
go: ['1.25.x', '1.26.x', '1.27.x']
sqlImage: ['2017-latest','2019-latest','2022-latest','2025-latest']
```

The full cross product is close to free here, and I measured rather than assumed. Matrix legs run fully parallel — six legs on an earlier revision of this PR started within 12 seconds of each other and each took about two minutes. Runners are free on a public repo, and the workflow's critical path is the `benchmarks` job at ~50 minutes. Twelve legs instead of six costs roughly twelve runner-minutes and no wall clock.

Restricting the older Go versions to a single SQL image would also leave a real gap. Every build constraint in the driver is `go1.9` through `go1.18`, all satisfied identically by 1.25/1.26/1.27, so all three compile the same code and the only version-dependent behaviour is stdlib runtime — principally `crypto/tls`. That is exactly where the SQL dimension is not orthogonal: 2017 negotiates TLS 1.2 with older cipher suites, 2025 does TLS 1.3. **Go 1.25 × SQL 2017** is a plausible enterprise combination and the one our `go` directive promises works.

**`GOTOOLCHAIN: local`** is set on the job so the floor leg actually tests the floor. This is not theoretical — the toolchain docs state that *"any command that updates the `go` line also updates the `toolchain` line"*, so a future `go get` will reintroduce one, and without this the 1.25 legs would silently start running 1.27.

**Fix the devcontainer check.** It required the image to *equal* the `go` directive, which tied the consumer floor to the development environment. Those are deliberately different things, per [go.dev/doc/toolchain](https://go.dev/doc/toolchain):

> The `go` line declares the minimum required Go version for using the module. […] Modules that are dependencies of other modules may need to set a minimum Go version requirement **lower than the preferred toolchain** to use when working in that module directly.

It now asserts the image *satisfies* the floor, so the devcontainer can move to 1.26 without raising the floor for every consumer.

## Changes

| File | Change |
|---|---|
| `go.mod` | Remove `toolchain go1.25.7`. `go 1.25.0` unchanged. |
| `pr-validation.yml` | Matrix to 1.25.x/1.26.x/1.27.x × all four SQL images; `GOTOOLCHAIN: local`; `fail-fast: false`; benchmarks job to `1.27.x` |
| `.devcontainer/Dockerfile` | `go:1.25-bookworm` to `go:1.26-bookworm` |
| `devcontainer.yml` | Equality check to `sort -V` satisfies check |
| `.github/copilot-instructions.md` | Rewrite the Go upgrade section, which documented the old model |

`fail-fast: false` is new — with legs that differ by Go version you want to see which versions fail, not just the first.

## Testing

Built and vetted against all three matrix versions, forcing each toolchain exactly as `setup-go` + `GOTOOLCHAIN=local` will in CI:

```
GOTOOLCHAIN=go1.25.14  go build ./...   exit=0
GOTOOLCHAIN=go1.26.7   go build ./...   exit=0
GOTOOLCHAIN=go1.27.0   go build ./...   exit=0
GOTOOLCHAIN=go1.27.0   go vet .         exit=0
```

Confirmed `go mod tidy` under Go 1.27 does not re-add a `toolchain` line or raise the floor — `go 1.25.0` survives, `go.sum` unchanged.

Unit-tested the new version comparison, including the double-digit case that a plain string compare gets wrong:

| `go.mod` | image | result | expected |
|---|---|---|---|
| 1.25 | 1.26 | PASS | PASS |
| 1.25 | 1.25 | PASS | PASS |
| 1.25 | 1.27 | PASS | PASS |
| 1.26 | 1.25 | FAIL | FAIL |
| 1.9 | 1.10 | PASS | PASS |
| 1.10 | 1.9 | FAIL | FAIL |

An earlier revision of this PR ran the 1.25.x, 1.26.x and 1.27.x legs green in CI, so all three versions pass the suite; this revision only widens which SQL images they run against.

Availability was checked against both registries directly: `mcr.microsoft.com/devcontainers/go` publishes `1.26` and `1.26-bookworm` but no `1.27`, which is why the devcontainer goes to 1.26 while 1.27 is exercised in Actions only.

## Related

- `appveyor.yml` `GOVERSION` is untouched — #436 owns that file and `125` still satisfies the floor. Worth revisiting once #436 lands and AppVeyor ships a 1.27 image; their Visual Studio 2026 image currently carries `C:\go126` at newest.
- #437 pins benchstat and hardens the regression gate. The pin's justification there is that the next step parses benchstat's stdout, not the Go version, so it stays valid once this PR moves the benchmarks job to 1.27.

## Related Issues

Fixes #438
