### PR TITLE
docs: close review criteria gaps found in calibration runs

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -112,8 +112,7 @@ Evaluate each area. Skip areas that don't apply rather than padding the review.
 
 These are handled by tooling or by other people, and reporting them is pure noise:
 
-- Style, naming, formatting, comment wording, import ordering — `gofmt` and
-  `golangci-lint` own these and run on every PR.
+- Style, naming, formatting, comment wording, import ordering — don’t report these; they are subjective and/or handled outside this review skill.
 - Anything `go vet`, `revive`, or `reviewdog` already reports.
 - Test structure or table-test formatting preferences.
 - "Consider adding a nil check", "consider validating this input", "consider handling

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -58,6 +58,12 @@ failure message? If yes, drop it.
 credential exposure, hung connection? "Cleaner", "safer", and "more idiomatic" are not
 consequences. Drop it.
 
+Three checklist items are exempt from the consequence gate, because their harm is to the
+review and release process rather than to running code: a **weakened, skipped, or deleted
+test**; a **PR description that does not match the diff**; and **unrelated changes** that
+inflate the diff. Report these when you find them. Everything else must clear all three
+gates.
+
 ## What to check
 
 Evaluate each area. Skip areas that don't apply rather than padding the review.
@@ -102,6 +108,24 @@ Evaluate each area. Skip areas that don't apply rather than padding the review.
 - **No AI slop**: comments that restate what the code does, filler phrases, redundant
   validation, duplicated logic.
 
+## What never to report
+
+These are handled by tooling or by other people, and reporting them is pure noise:
+
+- Style, naming, formatting, comment wording, import ordering — `gofmt` and
+  `golangci-lint` own these and run on every PR.
+- Anything `go vet`, `revive`, or `reviewdog` already reports.
+- Test structure or table-test formatting preferences.
+- "Consider adding a nil check", "consider validating this input", "consider handling
+  this error" — unless you can name a reachable path where it matters.
+- Defensive checks for conditions the type system already excludes.
+- Refactoring suggestions, extracting helpers, reducing nesting.
+- Anything already stated in a Copilot review comment or a CI failure message.
+- Praise, summaries, or restatements of what the PR does.
+
+This list outranks the severity tiers. A finding that lands here is dropped even if you
+believe it is correct.
+
 ## Output format
 
 1. **Summary** — one to three sentences: what the PR does and your overall assessment.
@@ -109,7 +133,8 @@ Evaluate each area. Skip areas that don't apply rather than padding the review.
    - **Blocking** — must fix before merge: bugs, security issues, breaking changes
      without handling, a weakened test.
    - **Suggestion** — should consider; improves quality but does not block merge.
-   - **Nit** — minor or optional.
+   - **Nit** — a correctness or clarity issue too small to block. Never style, naming,
+     formatting, comment wording, or import ordering.
 3. Each finding gives the exact `file:line`, the concrete failure path, the consequence,
    and a suggested fix — or an explicit "I am not certain of the right fix here".
 
@@ -140,5 +165,7 @@ Before reviewing, check the PR's comments for a marker matching the current head
 skip the PR entirely if one exists. With no findings, post only a brief "No findings"
 line plus the marker — that is a normal, successful outcome, not a failure.
 
-Never raise a finding on a line that was modified in direct response to one of your own
-earlier comments. That is a review loop and it does not converge.
+Never raise a finding on a line that was modified in direct response to an earlier review
+comment — whether yours, GitHub Copilot's, or a human's — unless the change introduced a
+new defect you can demonstrate. Second-guessing a fix someone already asked for is a
+review loop and it does not converge.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -112,7 +112,7 @@ Evaluate each area. Skip areas that don't apply rather than padding the review.
 
 These are handled by tooling or by other people, and reporting them is pure noise:
 
-- Style, naming, formatting, comment wording, import ordering — don’t report these; they are subjective and/or handled outside this review skill.
+- Style, naming preferences, formatting, comment wording, import ordering — don’t report these; they are subjective and/or handled outside this review skill.
 - Anything `go vet`, `revive`, or `reviewdog` already reports.
 - Test structure or table-test formatting preferences.
 - "Consider adding a nil check", "consider validating this input", "consider handling

--- a/.github/skills/security-review/SKILL.md
+++ b/.github/skills/security-review/SKILL.md
@@ -83,6 +83,10 @@ Conversely, when input genuinely reaches the code path, the bar for consequence 
 than elsewhere — a panic/DoS (for example an out-of-bounds slice) or credential exposure
 is severe even when the triggering conditions are narrow.
 
+"Lower" is not "absent". You must still name a concrete consequence from the list this
+skill covers: memory unsafety, credential or token exposure, authentication bypass, TLS
+downgrade, or denial of service. Reachable-but-harmless is still not a finding.
+
 ## Output
 
 Follow the `code-review` output format, with severity meaning:


### PR DESCRIPTION
Follow-up to #444. Adjusts the review skills based on dry-running them against six merged PRs.

## What changed

**`.github/skills/code-review/SKILL.md`**

- `Nit` was defined as "minor or optional" with no style exclusion. Redefined as a correctness or clarity issue too small to block, explicitly excluding style, naming, formatting, comment wording, and import ordering.
- Added a `What never to report` section: style/formatting, anything `go vet`/`revive`/`reviewdog` already reports, test-structure preferences, unreachable defensive checks, refactoring suggestions, anything Copilot or CI already said, and praise. The section is marked as outranking the severity tiers.
- Named three exemptions to the consequence gate — weakened tests, a PR description that does not match the diff, and unrelated changes — because the checklist requires flagging them but they have no runtime consequence.
- Widened the anti-loop rule from "one of your own earlier comments" to any reviewer's comment, including Copilot's and a human's.

**`.github/skills/security-review/SKILL.md`**

- Added a floor to the "bar for consequence is lower than elsewhere" guidance: a named consequence from the skill's own list is still required.

## Why

The exclusion list existed in `.github/instructions/pr-review.instructions.md` before #444 consolidated the instruction files into skills, and was not carried across. Runs against #411, #414, #415, #421, #425 and #428 each assembled style-level findings and dropped them only by reference to the removed file. Working from the skills alone, they would have been reported.

The consequence-gate contradiction and the anti-loop gap were each hit in the same runs.

Docs only. No code, test, or CI changes.