### PR TITLE
fix: preserve strict encryption in DSN URLs

### DIFF
--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -722,6 +722,8 @@ func (p Config) URL() *url.URL {
 		q.Add(Encrypt, "DISABLE")
 	case EncryptionRequired:
 		q.Add(Encrypt, "true")
+	case EncryptionStrict:
+		q.Add(Encrypt, "strict")
 	}
 	// Only include TrustServerCertificate if it was explicitly set in the original connection string
 	if _, ok := p.Parameters[TrustServerCertificate]; ok {

--- a/msdsn/conn_str_test.go
+++ b/msdsn/conn_str_test.go
@@ -716,6 +716,21 @@ func TestTrustServerCertificateRoundTrip(t *testing.T) {
 	}
 }
 
+func TestEncryptionStrictRoundTrip(t *testing.T) {
+	config, err := Parse("sqlserver://user:pass@host?encrypt=strict")
+	require.NoError(t, err, "Failed to parse connection string")
+
+	urlStr := config.URL().String()
+	assert.Contains(t, urlStr, "encrypt=strict")
+
+	config2, err := Parse(urlStr)
+	require.NoError(t, err, "Failed to parse round-tripped URL")
+	assert.Equal(t, Encryption(EncryptionStrict), config2.Encryption,
+		"Encryption changed after round-trip (URL: %s)", urlStr)
+	assert.False(t, config2.TrustServerCertificate,
+		"strict encryption must not trust the server certificate (URL: %s)", urlStr)
+}
+
 func TestTrustServerCertificateURLOverride(t *testing.T) {
 	// Verify that URL() emits a lowercase key that can be cleanly overridden
 	// via url.Values without creating duplicate keys.


### PR DESCRIPTION
Fixes #442

## Summary

`msdsn.Config.URL()` omitted the `encrypt` parameter for `EncryptionStrict`. Parsing the resulting URL therefore changed strict encryption to the insecure default (`EncryptionOff`) and enabled `TrustServerCertificate`.

Emit `encrypt=strict` so strict encryption and certificate verification survive a parse → URL → parse round trip.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- Added `TestEncryptionStrictRoundTrip` regression coverage

No live SQL Server integration tests were run.