### PR TITLE
fix: report unsupported T-SQL declaration types

### DIFF
--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -111,7 +111,11 @@ func (b *Bulk) sendBulkCommand(ctx context.Context) (err error) {
 		if i != 0 {
 			col_defs.WriteString(", ")
 		}
-		col_defs.WriteString(q.ID(col.ColName) + " " + makeDecl(col.ti))
+		decl, err := makeDecl(col.ti)
+		if err != nil {
+			return fmt.Errorf("cannot create declaration for column %s: %w", col.ColName, err)
+		}
+		col_defs.WriteString(q.ID(col.ColName) + " " + decl)
 	}
 
 	//options

--- a/mssql.go
+++ b/mssql.go
@@ -444,7 +444,6 @@ func (d *Driver) open(ctx context.Context, dsn string) (*Conn, error) {
 	return d.connect(ctx, c, params)
 }
 
-
 func failoverPartnerParams(params msdsn.Config) *msdsn.Config {
 	if params.FailOverPartner == "" {
 		return nil
@@ -733,7 +732,11 @@ func (s *Stmt) makeRPCParams(args []namedValue, isProc bool) ([]param, []string,
 			params[i+offset].ti.Size = 0
 		}
 
-		decls[i] = fmt.Sprintf("%s %s%s", name, makeDecl(tiDecl), output)
+		decl, err := makeDecl(tiDecl)
+		if err != nil {
+			return nil, nil, fmt.Errorf("cannot create declaration for parameter %s: %w", name, err)
+		}
+		decls[i] = fmt.Sprintf("%s %s%s", name, decl, output)
 
 	}
 	return params, decls, nil

--- a/mssql.go
+++ b/mssql.go
@@ -734,7 +734,11 @@ func (s *Stmt) makeRPCParams(args []namedValue, isProc bool) ([]param, []string,
 
 		decl, err := makeDecl(tiDecl)
 		if err != nil {
-			return nil, nil, fmt.Errorf("cannot create declaration for parameter %s: %w", name, err)
+			parameter := name
+			if parameter == "" {
+				parameter = fmt.Sprintf("ordinal %d", val.Ordinal)
+			}
+			return nil, nil, fmt.Errorf("cannot create declaration for parameter %s: %w", parameter, err)
 		}
 		decls[i] = fmt.Sprintf("%s %s%s", name, decl, output)
 

--- a/types.go
+++ b/types.go
@@ -1294,6 +1294,9 @@ func makeDecl(ti typeInfo) (string, error) {
 			return fmt.Sprintf("varbinary(%d)", ti.Size), nil
 		}
 	case typeNChar:
+		if ti.Size <= 0 || ti.Size%2 != 0 || ti.Size > 8000 {
+			return "", fmt.Errorf("invalid size of NCHARTYPE: %d", ti.Size)
+		}
 		return fmt.Sprintf("nchar(%d)", ti.Size/2), nil
 	case typeBigChar, typeChar:
 		return fmt.Sprintf("char(%d)", ti.Size), nil

--- a/types.go
+++ b/types.go
@@ -1228,130 +1228,130 @@ func makeGoLangScanType(ti typeInfo) reflect.Type {
 	}
 }
 
-func makeDecl(ti typeInfo) string {
+func makeDecl(ti typeInfo) (string, error) {
 	switch ti.TypeId {
 	case typeNull:
 		// maybe we should use something else here
 		// this is tested in TestNull
-		return "nvarchar(1)"
+		return "nvarchar(1)", nil
 	case typeInt1:
-		return "tinyint"
+		return "tinyint", nil
 	case typeBigBinary:
-		return fmt.Sprintf("binary(%d)", ti.Size)
+		return fmt.Sprintf("binary(%d)", ti.Size), nil
 	case typeInt2:
-		return "smallint"
+		return "smallint", nil
 	case typeInt4:
-		return "int"
+		return "int", nil
 	case typeInt8:
-		return "bigint"
+		return "bigint", nil
 	case typeFlt4:
-		return "real"
+		return "real", nil
 	case typeIntN:
 		switch ti.Size {
 		case 1:
-			return "tinyint"
+			return "tinyint", nil
 		case 2:
-			return "smallint"
+			return "smallint", nil
 		case 4:
-			return "int"
+			return "int", nil
 		case 8:
-			return "bigint"
+			return "bigint", nil
 		default:
-			panic("invalid size of INTNTYPE")
+			return "", fmt.Errorf("invalid size of INTNTYPE: %d", ti.Size)
 		}
 	case typeFlt8:
-		return "float"
+		return "float", nil
 	case typeFltN:
 		switch ti.Size {
 		case 4:
-			return "real"
+			return "real", nil
 		case 8:
-			return "float"
+			return "float", nil
 		default:
-			panic("invalid size of FLNNTYPE")
+			return "", fmt.Errorf("invalid size of FLNNTYPE: %d", ti.Size)
 		}
 	case typeDecimal, typeDecimalN:
-		return fmt.Sprintf("decimal(%d, %d)", ti.Prec, ti.Scale)
+		return fmt.Sprintf("decimal(%d, %d)", ti.Prec, ti.Scale), nil
 	case typeNumeric, typeNumericN:
-		return fmt.Sprintf("numeric(%d, %d)", ti.Prec, ti.Scale)
+		return fmt.Sprintf("numeric(%d, %d)", ti.Prec, ti.Scale), nil
 	case typeMoney4:
-		return "smallmoney"
+		return "smallmoney", nil
 	case typeMoney:
-		return "money"
+		return "money", nil
 	case typeMoneyN:
 		switch ti.Size {
 		case 4:
-			return "smallmoney"
+			return "smallmoney", nil
 		case 8:
-			return "money"
+			return "money", nil
 		default:
-			panic("invalid size of MONEYNTYPE")
+			return "", fmt.Errorf("invalid size of MONEYNTYPE: %d", ti.Size)
 		}
 	case typeBigVarBin:
 		if ti.Size > 8000 || ti.Size == 0 {
-			return "varbinary(max)"
+			return "varbinary(max)", nil
 		} else {
-			return fmt.Sprintf("varbinary(%d)", ti.Size)
+			return fmt.Sprintf("varbinary(%d)", ti.Size), nil
 		}
 	case typeNChar:
-		return fmt.Sprintf("nchar(%d)", ti.Size/2)
+		return fmt.Sprintf("nchar(%d)", ti.Size/2), nil
 	case typeBigChar, typeChar:
-		return fmt.Sprintf("char(%d)", ti.Size)
+		return fmt.Sprintf("char(%d)", ti.Size), nil
 	case typeBigVarChar, typeVarChar:
 		if ti.Size > 8000 || ti.Size == 0 {
-			return "varchar(max)"
+			return "varchar(max)", nil
 		} else {
-			return fmt.Sprintf("varchar(%d)", ti.Size)
+			return fmt.Sprintf("varchar(%d)", ti.Size), nil
 		}
 	case typeNVarChar:
 		if ti.Size > 8000 || ti.Size == 0 {
-			return "nvarchar(max)"
+			return "nvarchar(max)", nil
 		} else {
-			return fmt.Sprintf("nvarchar(%d)", ti.Size/2)
+			return fmt.Sprintf("nvarchar(%d)", ti.Size/2), nil
 		}
 	case typeBit, typeBitN:
-		return "bit"
+		return "bit", nil
 	case typeDateN:
-		return "date"
+		return "date", nil
 	case typeDateTim4:
-		return "smalldatetime"
+		return "smalldatetime", nil
 	case typeDateTime:
-		return "datetime"
+		return "datetime", nil
 	case typeDateTimeN:
 		switch ti.Size {
 		case 4:
-			return "smalldatetime"
+			return "smalldatetime", nil
 		case 8:
-			return "datetime"
+			return "datetime", nil
 		default:
-			panic("invalid size of DATETIMNTYPE")
+			return "", fmt.Errorf("invalid size of DATETIMNTYPE: %d", ti.Size)
 		}
 	case typeTimeN:
 		if ti.Scale == 7 {
-			return "time"
+			return "time", nil
 		}
-		return fmt.Sprintf("time(%d)", ti.Scale)
+		return fmt.Sprintf("time(%d)", ti.Scale), nil
 	case typeDateTime2N:
-		return fmt.Sprintf("datetime2(%d)", ti.Scale)
+		return fmt.Sprintf("datetime2(%d)", ti.Scale), nil
 	case typeDateTimeOffsetN:
-		return fmt.Sprintf("datetimeoffset(%d)", ti.Scale)
+		return fmt.Sprintf("datetimeoffset(%d)", ti.Scale), nil
 	case typeText:
-		return "text"
+		return "text", nil
 	case typeNText:
-		return "ntext"
+		return "ntext", nil
 	case typeUdt:
-		return ti.UdtInfo.TypeName
+		return ti.UdtInfo.TypeName, nil
 	case typeImage:
-		return "image"
+		return "image", nil
 	case typeGuid:
-		return "uniqueidentifier"
+		return "uniqueidentifier", nil
 	case typeTvp:
 		if ti.UdtInfo.SchemaName != "" {
-			return fmt.Sprintf("%s.%s READONLY", ti.UdtInfo.SchemaName, ti.UdtInfo.TypeName)
+			return fmt.Sprintf("%s.%s READONLY", ti.UdtInfo.SchemaName, ti.UdtInfo.TypeName), nil
 		}
-		return fmt.Sprintf("%s READONLY", ti.UdtInfo.TypeName)
+		return fmt.Sprintf("%s READONLY", ti.UdtInfo.TypeName), nil
 	default:
-		panic(fmt.Sprintf("not implemented makeDecl for type %#x", ti.TypeId))
+		return "", fmt.Errorf("not implemented makeDecl for type %#x", ti.TypeId)
 	}
 }
 

--- a/types_test.go
+++ b/types_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/microsoft/go-mssqldb/msdsn"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMakeGoLangScanType(t *testing.T) {
@@ -275,11 +276,17 @@ func TestMakeDecl(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer handlePanic(t)
-			got := makeDecl(tt.typeInfo)
+			got, err := makeDecl(tt.typeInfo)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, got, "makeDecl()")
 		})
 	}
+}
+
+func TestMakeDeclUnknownTypeReturnsError(t *testing.T) {
+	decl, err := makeDecl(typeInfo{TypeId: 0xff})
+	assert.Error(t, err)
+	assert.Empty(t, decl)
 }
 
 func handlePanic(t *testing.T) {

--- a/types_test.go
+++ b/types_test.go
@@ -289,6 +289,36 @@ func TestMakeDeclUnknownTypeReturnsError(t *testing.T) {
 	assert.Empty(t, decl)
 }
 
+func TestMakeDeclInvalidSizeReturnsError(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeInfo typeInfo
+	}{
+		{"typeIntN", typeInfo{TypeId: typeIntN, Size: 3}},
+		{"typeFltN", typeInfo{TypeId: typeFltN, Size: 3}},
+		{"typeMoneyN", typeInfo{TypeId: typeMoneyN, Size: 3}},
+		{"typeDateTimeN", typeInfo{TypeId: typeDateTimeN, Size: 3}},
+		{"typeNChar zero", typeInfo{TypeId: typeNChar, Size: 0}},
+		{"typeNChar odd", typeInfo{TypeId: typeNChar, Size: 3}},
+		{"typeNChar too large", typeInfo{TypeId: typeNChar, Size: 8002}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decl, err := makeDecl(tt.typeInfo)
+			assert.Error(t, err)
+			assert.Empty(t, decl)
+		})
+	}
+}
+
+func TestMakeRPCParamsReportsUnnamedParameterOrdinal(t *testing.T) {
+	_, _, err := (&Stmt{}).makeRPCParams(
+		[]namedValue{{Ordinal: 1, Value: NChar("")}}, true)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "parameter ordinal 1")
+}
+
 func handlePanic(t *testing.T) {
 	if r := recover(); r != nil {
 		assert.Fail(t, "recovered panic", "%v", r)


### PR DESCRIPTION
Fixes #447

## Summary
- make `makeDecl` return an error for unsupported type IDs and invalid type sizes
- propagate declaration errors from RPC parameter and bulk-copy column generation
- add regression coverage for an unknown type ID

## Behavior change
Previously, unsupported type metadata could panic while constructing a declaration, or produce an invalid declaration if the failure was not surfaced. Callers now receive a wrapped error and can abort the operation before sending malformed T-SQL.

## Validation
- `go test ./... -run 'TestMakeDecl|Test.*RPC|Test.*Bulk' -count=1`\n- `go test ./... -count=1`\n- `go vet ./...`\n\nThe regression test was first run before the fix and reproduced the panic for type ID `0xff`; it passes after the error-returning contract and both call sites were added.