### PR TITLE
test: cover builtin command casing and near misses

### DIFF
--- a/mssql_test.go
+++ b/mssql_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/go-mssqldb/msdsn"
@@ -62,6 +63,31 @@ func TestIsProc(t *testing.T) {
 			t.Errorf("for %q, got %t want %t", item.s, got, item.is)
 		}
 	}
+
+	t.Run("builtin commands", func(t *testing.T) {
+		for _, command := range builtinCommands {
+			t.Run(command, func(t *testing.T) {
+				for _, input := range []string{
+					strings.ToUpper(command),
+					strings.ToLower(command),
+					strings.ToUpper(command[:1]) + strings.ToLower(command[1:]),
+				} {
+					t.Run(input, func(t *testing.T) {
+						if isProc(input) {
+							t.Errorf("isProc(%q) = true, want false for builtin command", input)
+						}
+					})
+				}
+				for _, input := range []string{command + "X", "X" + command} {
+					t.Run(input, func(t *testing.T) {
+						if !isProc(input) {
+							t.Errorf("isProc(%q) = false, want true for non-builtin name", input)
+						}
+					})
+				}
+			})
+		}
+	})
 }
 
 func TestConvertIsolationLevel(t *testing.T) {

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -67,6 +67,9 @@ func TestIsProc(t *testing.T) {
 	t.Run("builtin commands", func(t *testing.T) {
 		for _, command := range builtinCommands {
 			t.Run(command, func(t *testing.T) {
+				if command == "" {
+					t.Fatal("builtinCommands must not contain an empty command")
+				}
 				for _, input := range []string{
 					strings.ToUpper(command),
 					strings.ToLower(command),


### PR DESCRIPTION
Closes #395.

Extend `TestIsProc` to check every builtin command in uppercase, lowercase, and mixed case, plus prefixed and suffixed near misses. This guards against routing SQL commands as stored procedures and against rejecting procedure names that only contain a builtin keyword. Existing explicit cases remain intact; production behavior is unchanged.

Validation: `go test -race -run '^TestIsProc$' -count=1 .` passes. Temporarily removing case normalization, switching to prefix matching, and switching to substring matching each made the new subtests fail; all mutations were reverted. `git diff --check` passes.
